### PR TITLE
feat: set conversation props like description and moderators when creating by type

### DIFF
--- a/src/services/conversation.service.ts
+++ b/src/services/conversation.service.ts
@@ -241,7 +241,7 @@ const resolvePropertyReferences = (obj, properties) => {
  * @returns {Promise<Conversation>}
  */
 const createConversationFromType = async (params, user) => {
-  const { type, name, platforms, topicId, properties = {}, scheduledTime } = params
+  const { type, platforms, properties = {} } = params
 
   const conversationType = getConversationType(type)
   if (!conversationType) {
@@ -318,17 +318,13 @@ const createConversationFromType = async (params, user) => {
     ? resolvePropertyReferences(conversationType.agents, resolvedProperties)
     : []
 
-  // Build conversation body
   const conversationBody = {
-    name,
-    topicId,
+    ...params,
     conversationType: type,
-    platforms,
     agentTypes: resolvedAgents,
     adapters: adapterConfigs,
     channels: conversationType.channels || [],
-    enableDMs: conversationType.enableDMs,
-    ...(scheduledTime && { scheduledTime })
+    enableDMs: conversationType.enableDMs
   }
 
   return createConversation(conversationBody, user)

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -287,6 +287,32 @@ describe('Conversation service methods', () => {
         expect(conversation.scheduledTime).toEqual(scheduledTime)
         expect(conversation.active).toBe(false) // Should not auto-start when scheduled
       })
+      test('should create conversation with metadata', async () => {
+        const params = {
+          type: 'eventAssistant',
+          name: 'Scheduled Event',
+          platforms: ['zoom'],
+          topicId: topicOne._id.toString(),
+          properties: {
+            zoomMeetingUrl: 'https://zoom.us/j/123456789'
+          },
+          description: 'An event about something',
+          moderators: [{ name: 'Joe Moderator', bio: 'Moderates' }],
+          presenters: [
+            { name: 'Sam Speaker', bio: 'Speaks' },
+            { name: 'Jim Speaker', bio: 'Also Speaks' }
+          ]
+        }
+
+        const conversation = await conversationService.createConversationFromType(params, registeredUser)
+
+        expect(conversation.description).toEqual(params.description)
+        expect(conversation.moderators).toHaveLength(1)
+        expect(conversation.moderators![0]).toMatchObject(params.moderators[0])
+        expect(conversation.presenters).toHaveLength(2)
+        expect(conversation.presenters![0]).toMatchObject(params.presenters[0])
+        expect(conversation.presenters![1]).toMatchObject(params.presenters[1])
+      })
       test('should not set llmModel on agents when optional property is omitted', async () => {
         const params = {
           type: 'eventAssistant',


### PR DESCRIPTION
## What is in this PR?

Allow Conversation properties to be passed when creating a conversation from a type. This allows us to set description, presenters, moderators, etc.

## Changes in the codebase

- Pass all params sent to `createConversationFromType` to `createConversation` for filtering

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [ ] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

- Create a conversation using the `/conversations/from-type` endpoint, passing description, presenters, moderators as body properties. Ensure properties are set on created conversation.

## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
