### PR TITLE
feat: add description, presenters, moderators to retrieved conversations

### DIFF
--- a/src/services/conversation.service.ts
+++ b/src/services/conversation.service.ts
@@ -18,7 +18,8 @@ import { getConversationType } from '../conversations/index.js'
 import { supportedModels } from '../agents/helpers/getEmbeddings.js'
 import transcript from '../agents/helpers/transcript.js'
 
-const returnFields = 'name slug locked owner createdAt active conversationType platforms scheduledTime'
+const returnFields =
+  'name slug locked owner createdAt active conversationType platforms scheduledTime description moderators presenters'
 const transcriptBatchInterval = 30
 export const maxScheduledInterval = 10 * 60 * 1000 // 10 minutes in milliseconds
 /**
@@ -403,6 +404,10 @@ const findByIdFull = async (id, user) => {
   const followed = Follower.findOne({ conversation, user }).select('_id').exec() !== null
   const conversationPojo = conversation.toObject({
     transform: (doc, ret: ConversationDocument) => {
+      // Only transform the top-level conversation document
+      if (doc !== conversation) {
+        return ret
+      }
       const { _id, ...cleanRet } = ret
       // display channel passcodes only to conversation owner
       let { channels } = cleanRet

--- a/tests/integration/conversation.test.ts
+++ b/tests/integration/conversation.test.ts
@@ -1263,6 +1263,9 @@ describe('Conversation routes', () => {
       await adapter.save()
       const scheduledTime = new Date()
       agentConversation.scheduledTime = scheduledTime
+      agentConversation.description = 'A conversation about something'
+      agentConversation.presenters = [{ name: 'Ann Speaker', bio: 'An experienced speaker' }]
+      agentConversation.moderators = [{ name: 'Joe Moderator', bio: 'An experienced moderator' }]
       agentConversation.adapters.push(adapter)
       await agentConversation.save()
 
@@ -1294,7 +1297,10 @@ describe('Conversation routes', () => {
         locked: agentConversation.locked,
         id: agentConversation._id.toString(),
         owner: agentConversation.owner._id.toString(),
-        scheduledTime: scheduledTime.toISOString()
+        scheduledTime: scheduledTime.toISOString(),
+        description: agentConversation.description,
+        presenters: [{ name: 'Ann Speaker', bio: 'An experienced speaker' }],
+        moderators: [{ name: 'Joe Moderator', bio: 'An experienced moderator' }]
       }
       agentConversation.agents.push(agent)
       await agentConversation.save()


### PR DESCRIPTION
all conversation retrieval endpoints now return these properties

## What is in this PR?

small change to conversation service to include these properties

## Changes in the codebase

See above

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [ ] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- Create a conversation specifying description, presenters, and moderators
- Use a retrieval endpoint like GET conversation and verify these properties are in the response body


## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
