### PR TITLE
Add interception of feedback messages and routing to a feedback channel

### DIFF
--- a/src/services/message.service.ts
+++ b/src/services/message.service.ts
@@ -235,11 +235,11 @@ const handleFeedbackMessage = async (message, user, conversation) => {
 
     // Validate that all required parts are present
     if (!parts[1] || !parts[2] || !parts[3]) {
-      logger.warn('Feedback message missing required parts. Expected format: /ShareFeedback|type|messageId|value')
+      logger.warn('Feedback message missing required parts. Expected format: /feedback|type|messageId|value')
       return []
     }
 
-    // Remove "/ShareFeedback" from first element and create JSON body
+    // Remove "/feedback" from first element and create JSON body
     feedbackMessageBody = {
       type: parts[1].toLowerCase(),
       messageId: parts[2],
@@ -273,7 +273,7 @@ const handleFeedbackMessage = async (message, user, conversation) => {
 const newMessageHandler = async (message, user, request = null) => {
   // Check if this is a feedback message
   const isFeedback =
-    (message.bodyType === 'text' && message.body?.toLowerCase().startsWith('/sharefeedback')) ||
+    (message.bodyType === 'text' && message.body?.toLowerCase().startsWith('/feedback')) ||
     (message.bodyType === 'json' && message.body?.feedback === true)
 
   if (isFeedback) {

--- a/tests/services/message.service.test.ts
+++ b/tests/services/message.service.test.ts
@@ -687,10 +687,10 @@ describe('Message service methods', () => {
       jest.clearAllMocks()
     })
 
-    test('should route text feedback message starting with /ShareFeedback to feedback channel', async () => {
+    test('should route text feedback message starting with /feedback to feedback channel', async () => {
       const feedbackMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback|rating|msg123|5',
+        body: '/feedback|rating|msg123|5',
         bodyType: 'text',
         channels: []
       }
@@ -750,7 +750,7 @@ describe('Message service methods', () => {
 
       const feedbackMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback|type1|msg456|testvalue',
+        body: '/feedback|type1|msg456|testvalue',
         bodyType: 'text',
         channels: []
       }
@@ -780,7 +780,7 @@ describe('Message service methods', () => {
 
       const feedbackMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback|type2|msg789|anothervalue',
+        body: '/feedback|type2|msg789|anothervalue',
         bodyType: 'text',
         channels: []
       }
@@ -799,7 +799,7 @@ describe('Message service methods', () => {
     test('should parse pipe-delimited text feedback correctly with whitespace', async () => {
       const feedbackMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback | sentiment | msg999 | positive ',
+        body: '/feedback | sentiment | msg999 | positive ',
         bodyType: 'text',
         channels: []
       }
@@ -816,7 +816,7 @@ describe('Message service methods', () => {
     test('should replace existing channels with feedback channel', async () => {
       const feedbackMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback|category|msg111|important',
+        body: '/feedback|category|msg111|important',
         bodyType: 'text',
         channels: [testZoomChannel, testSlackChannel]
       }
@@ -882,7 +882,7 @@ describe('Message service methods', () => {
 
       const feedbackMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback|quality|msg222|excellent',
+        body: '/feedback|quality|msg222|excellent',
         bodyType: 'text',
         channels: []
       }
@@ -907,7 +907,7 @@ describe('Message service methods', () => {
     test('should store feedback message in database', async () => {
       const feedbackMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback|helpfulness|msg333|very helpful',
+        body: '/feedback|helpfulness|msg333|very helpful',
         bodyType: 'text',
         channels: []
       }
@@ -931,7 +931,7 @@ describe('Message service methods', () => {
     test('should lowercase the type property when converting text to JSON', async () => {
       const feedbackMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback|RATING|msg444|UPPERCASE_VALUE',
+        body: '/feedback|RATING|msg444|UPPERCASE_VALUE',
         bodyType: 'text',
         channels: []
       }
@@ -953,7 +953,7 @@ describe('Message service methods', () => {
 
       const malformedMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback||msg555|value',
+        body: '/feedback||msg555|value',
         bodyType: 'text',
         channels: []
       }
@@ -963,7 +963,7 @@ describe('Message service methods', () => {
       expect(result).toBeDefined()
       expect(result).toHaveLength(0)
       expect(loggerWarnSpy).toHaveBeenCalledWith(
-        'Feedback message missing required parts. Expected format: /ShareFeedback|type|messageId|value'
+        'Feedback message missing required parts. Expected format: /feedback|type|messageId|value'
       )
 
       loggerWarnSpy.mockRestore()
@@ -974,7 +974,7 @@ describe('Message service methods', () => {
 
       const malformedMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback|rating||value',
+        body: '/feedback|rating||value',
         bodyType: 'text',
         channels: []
       }
@@ -984,7 +984,7 @@ describe('Message service methods', () => {
       expect(result).toBeDefined()
       expect(result).toHaveLength(0)
       expect(loggerWarnSpy).toHaveBeenCalledWith(
-        'Feedback message missing required parts. Expected format: /ShareFeedback|type|messageId|value'
+        'Feedback message missing required parts. Expected format: /feedback|type|messageId|value'
       )
 
       loggerWarnSpy.mockRestore()
@@ -995,7 +995,7 @@ describe('Message service methods', () => {
 
       const malformedMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback|rating|msg666|',
+        body: '/feedback|rating|msg666|',
         bodyType: 'text',
         channels: []
       }
@@ -1005,7 +1005,7 @@ describe('Message service methods', () => {
       expect(result).toBeDefined()
       expect(result).toHaveLength(0)
       expect(loggerWarnSpy).toHaveBeenCalledWith(
-        'Feedback message missing required parts. Expected format: /ShareFeedback|type|messageId|value'
+        'Feedback message missing required parts. Expected format: /feedback|type|messageId|value'
       )
 
       loggerWarnSpy.mockRestore()
@@ -1016,7 +1016,7 @@ describe('Message service methods', () => {
 
       const malformedMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback|rating',
+        body: '/feedback|rating',
         bodyType: 'text',
         channels: []
       }
@@ -1026,7 +1026,7 @@ describe('Message service methods', () => {
       expect(result).toBeDefined()
       expect(result).toHaveLength(0)
       expect(loggerWarnSpy).toHaveBeenCalledWith(
-        'Feedback message missing required parts. Expected format: /ShareFeedback|type|messageId|value'
+        'Feedback message missing required parts. Expected format: /feedback|type|messageId|value'
       )
 
       loggerWarnSpy.mockRestore()
@@ -1037,7 +1037,7 @@ describe('Message service methods', () => {
 
       const malformedMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedback|rating',
+        body: '/feedback|rating',
         bodyType: 'text',
         channels: []
       }
@@ -1062,10 +1062,10 @@ describe('Message service methods', () => {
       loggerWarnSpy.mockRestore()
     })
 
-    test('should route feedback message with lowercase /sharefeedback to feedback channel', async () => {
+    test('should route feedback message with lowercase /feedback to feedback channel', async () => {
       const feedbackMessage = {
         conversation: testConversation._id,
-        body: '/sharefeedback|rating|msg777|4',
+        body: '/feedback|rating|msg777|4',
         bodyType: 'text',
         channels: []
       }
@@ -1088,10 +1088,10 @@ describe('Message service methods', () => {
       expect(websocketGateway.broadcastNewMessage).not.toHaveBeenCalled()
     })
 
-    test('should route feedback message with uppercase /SHAREFEEDBACK to feedback channel', async () => {
+    test('should route feedback message with uppercase /feedback to feedback channel', async () => {
       const feedbackMessage = {
         conversation: testConversation._id,
-        body: '/SHAREFEEDBACK|sentiment|msg888|negative',
+        body: '/feedback|sentiment|msg888|negative',
         bodyType: 'text',
         channels: []
       }
@@ -1114,10 +1114,10 @@ describe('Message service methods', () => {
       expect(websocketGateway.broadcastNewMessage).not.toHaveBeenCalled()
     })
 
-    test('should route feedback message with mixed case /ShareFeedBack to feedback channel', async () => {
+    test('should route feedback message with mixed case /feedback to feedback channel', async () => {
       const feedbackMessage = {
         conversation: testConversation._id,
-        body: '/ShareFeedBack|quality|msg999|excellent',
+        body: '/feedback|quality|msg999|excellent',
         bodyType: 'text',
         channels: []
       }
@@ -1140,10 +1140,10 @@ describe('Message service methods', () => {
       expect(websocketGateway.broadcastNewMessage).not.toHaveBeenCalled()
     })
 
-    test('should route feedback message with /sHaReFEEDBACK (random case) to feedback channel', async () => {
+    test('should route feedback message with /feedback (random case) to feedback channel', async () => {
       const feedbackMessage = {
         conversation: testConversation._id,
-        body: '/sHaReFEEDBACK|helpfulness|msg1010|very useful',
+        body: '/feedback|helpfulness|msg1010|very useful',
         bodyType: 'text',
         channels: []
       }


### PR DESCRIPTION
## What is in this PR?

Interception and handling of feedback messages to route them to the designated "feedback" channel from the Event Assistant.

## Changes in the codebase

- Changes to message.service to add detection and handling of feedback messages (with initial text "/ShareFeedback" or structured json
- Text messages are converted to json for easier query/retrieval from the DB later to support reporting before saving
- Feedback messages are not routed through agents

## Documentation and automated testing

Did you:
- [X] document any breaking changes in your commit messages?
- [X] document your changes as comments in the code? Use TSDoc format where appropriate.
- [X] update the README and docs to be clear and easy to use for end users and developers?
- [X] add and/or update automated tests?
- [X] update team documentation of any new or changed environment variables?

## Testing this PR

- [ ] Test with the FE on branch `bam/user-feedback`
- [ ] Confirm rating (button) messages and also free form text feedback messages are received, intercepted and routed to the feedback channel
- [ ] Confirm the feedback channel is created (with a passcode) if it does not exist
- [ ] Confirm text feedback is converted to json before saving (using Postman or Studio 3T)
- [ ] Confirm the messages are formatted correctly and end up on the feedback channel only
- [ ] Confirm the test suite extensions look appropriate and are passing, and all other tests pass

## Additional information

N/A
