### PR TITLE
refactor: extract structured output parsing logic into helper function

### DIFF
--- a/src/agents/helpers/responseFormatSchemas.ts
+++ b/src/agents/helpers/responseFormatSchemas.ts
@@ -27,8 +27,6 @@ const insight = z.object({
 
 const insights = z.object({ results: z.array(insight) })
 
-const commentInsights = z.array(insight)
-
 // This schema uses JSONSchema so we can inject a user's outputSchema as the result property
 export function generateGenericAgentAnswerSchema(outputSchema) {
   return {
@@ -74,7 +72,6 @@ export function generateGenericAgentAnswerSchema(outputSchema) {
 export default {
   citedAnswer,
   votingAnswer,
-  commentInsights,
   insights,
   generateGenericAgentAnswerSchema
 }


### PR DESCRIPTION
## What is in this PR?

Create new helper function to handle LLM structured output through tool calling or native support, dependent on model. I originally made this change to support Event Assistant also using structured output for classification. I decided not to go that route, but the helper function is still useful for future agent development. Models that can work with langchain's structured output often do not allow arrays as the top-level schema object (e.g. OpenAI), hence the method's massaging of the schema when arrays are involved. As of now, Claude models are the only ones we support that have to use the tool binding rather than standard structured output support.

## Changes in the codebase

See above

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [ ] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [ ] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

- Automated backChannel tests still passing shows the refactoring is OK, but could create a Back Channel event and test it out for extra assurance.
- Claude models are currently the only ones we support that have to use a bound tool call rather than the standard langchainjs structured output support. See [here](https://github.com/berkmancenter/llm_engine/actions/runs/20375664794) for a test run from this branch against Claude Haiku.

## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
