### PR TITLE
Add pseudonym fun fact to EA intro and make 'cannot respond' message more fun

### DIFF
--- a/src/agents/eventAssistant/eventAssistant.ts
+++ b/src/agents/eventAssistant/eventAssistant.ts
@@ -1,6 +1,11 @@
 import verify from '../helpers/verify.js'
 import { AgentMessageActions, ConversationHistory } from '../../types/index.types.js'
-import { eventAssistantLLMTemplates, eventAssistantLlmTemplateVars, answerQuestion } from './eventQuestionHandler.js'
+import {
+  eventAssistantLLMTemplates,
+  eventAssistantLlmTemplateVars,
+  answerQuestion,
+  generatePseudonymFunFact
+} from './eventQuestionHandler.js'
 import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
 
 export default verify({
@@ -13,7 +18,7 @@ export default verify({
   },
   agentConfig: {
     introMessage:
-      "Hi! I'm the LLM Event Assistant. You can ask me questions about the event content like “what did I just miss,” or, “what was that acronym?” None of your messages to me will be surfaced to the moderator or the rest of the audience, but please note that a pseudonymized message transcript will be visible to our eng team. Please share your feedback on the tool at brk.mn/feedback!",
+      "Hey! I'm your event assistant-ask me about what's happening, or use /mod to fast-track a message to the mod.",
     chatIntroMessage:
       'Welcome to the chat! This is a space to chat with other event participants. You can also ask me questions with an @Event Assistant mention. Just remember that everyone can see what you ask me here. Use the Event Assistant tab if you want to talk privately. Have fun!'
   },
@@ -65,9 +70,17 @@ export default verify({
   },
   async introduce(channel) {
     if (channel.direct) {
+      const { introMessage: defaultIntroMessage } = this.agentConfig
+      let introMessage = defaultIntroMessage
+
+      const funFact = await generatePseudonymFunFact.call(this, channel)
+      if (funFact) {
+        introMessage = `${introMessage} Fun fact about your pseudonym: ${funFact}`
+      }
+
       return [
         {
-          message: this.agentConfig.introMessage,
+          message: introMessage,
           channels: [channel],
           visible: true
         }

--- a/src/agents/eventAssistant/eventAssistantPlus.ts
+++ b/src/agents/eventAssistant/eventAssistantPlus.ts
@@ -7,7 +7,8 @@ import {
   eventAssistantLLMTemplates,
   eventAssistantLlmTemplateVars,
   answerQuestion,
-  QuestionClassification
+  QuestionClassification,
+  generatePseudonymFunFact
 } from './eventQuestionHandler.js'
 
 import logger from '../../config/logger.js'
@@ -66,9 +67,8 @@ export default verify({
     perMessage: { directMessages: true, channels: ['chat'] }
   },
   agentConfig: {
-    introMessage: `Hi! I'm the LLM Event Assistant. I'm listening to the event, so feel free to ask me questions like “what did I just miss,” or, “what was that acronym?” If you ask a (relevant!) question I can't answer, I'll ask if you want to send it through to the moderator. Use /mod to fast-track a message to the mod. The mod will get a digestible summary of questions.
-
-A pseudonymized message transcript will be visible to our eng team. Thanks for trying the tool, please share your feedback at brk.mn/feedback!`,
+    introMessage:
+      "Hey! I'm your event assistant-ask me about what's happening, or use /mod to fast-track a message to the mod.",
     chatIntroMessage:
       'Welcome to the chat! This is a space to chat with other event participants. You can also ask me questions with an @Event Assistant mention. Just remember that everyone can see what you ask me here. Use the Event Assistant tab if you want to talk privately. Have fun!'
   },
@@ -195,9 +195,17 @@ A pseudonymized message transcript will be visible to our eng team. Thanks for t
   },
   async introduce(channel) {
     if (channel.direct) {
+      const { introMessage: defaultIntroMessage } = this.agentConfig
+      let introMessage = defaultIntroMessage
+
+      const funFact = await generatePseudonymFunFact.call(this, channel)
+      if (funFact) {
+        introMessage = `${introMessage} Fun fact about your pseudonym: ${funFact}`
+      }
+
       return [
         {
-          message: this.agentConfig.introMessage,
+          message: introMessage,
           channels: [channel],
           visible: true
         }

--- a/src/agents/eventAssistant/eventQuestionHandler.ts
+++ b/src/agents/eventAssistant/eventQuestionHandler.ts
@@ -1,6 +1,8 @@
 import { getChatPromptResponse } from '../helpers/llmChain.js'
 import { formatMultiUserConversationHistory, formatSingleUserConversationHistory } from '../helpers/llmInputFormatters.js'
 import transcript from '../helpers/transcript.js'
+import User from '../../models/user.model/user.model.js'
+import logger from '../../config/logger.js'
 import { IChannel } from '../../types/index.types.js'
 
 export enum QuestionClassification {
@@ -11,7 +13,7 @@ export enum QuestionClassification {
   CATCHUP = 'CATCHUP'
 }
 
-const cannotRespond =
+export const cannotRespond =
   "Hmm, I don't have a great answer to that one. Can you try rephrasing it? I'm best at event-related questions. And if you think this was on me, a bug report at http://brk.mn/feedback would be much appreciated!"
 
 export const eventAssistantLLMTemplates = {
@@ -120,6 +122,10 @@ export const eventAssistantLlmTemplateVars = {
   ]
 }
 
+const funFactSystemTemplate =
+  'You create short, fun facts about pseudonyms. The pseudonym is in the form "adjective noun". Create a 1 sentence fun fact that is factual about the noun, but can be playful about the adjective part. Makes sure your answers are safe for work.'
+const funFactUserTemplate = 'Create a fun fact about the pseudonym: {pseudonym}'
+
 async function getResponse(question, context, chatHistory, systemTemplate) {
   const llm = await this.getLLM()
   const topic = this.conversation.name
@@ -135,6 +141,28 @@ async function getResponse(question, context, chatHistory, systemTemplate) {
     chatHistory
   )
   return llmResponse
+}
+
+export async function generatePseudonymFunFact(channel) {
+  // Find the user participant (not the agent)
+  const userParticipantId = channel.participants.find(
+    (participantId: string) => participantId.toString() !== this._id.toString()
+  )
+  const user = await User.findById(userParticipantId)
+  const activePseudonym = user?.pseudonyms?.find((p) => p.active)
+
+  if (!activePseudonym?.pseudonym) {
+    logger.debug(`No active pseudonym found for user ${user?._id} on channel ${channel.name}, cannot generate fun fact.`)
+    return null
+  }
+
+  const llm = await this.getLLM()
+
+  const funFact = await getChatPromptResponse(llm, funFactSystemTemplate, funFactUserTemplate, {
+    pseudonym: activePseudonym.pseudonym
+  })
+
+  return funFact
 }
 
 export async function answerQuestion(userMessage, conversationHistory, options?) {

--- a/tests/agents/eventAssistant/eventAssistant.agent.test.ts
+++ b/tests/agents/eventAssistant/eventAssistant.agent.test.ts
@@ -10,15 +10,12 @@ import {
   createMessage
 } from '../../utils/agentTestHelpers.js'
 import Channel from '../../../src/models/channel.model.js'
-import { QuestionClassification } from '../../../src/agents/eventAssistant/eventQuestionHandler.js'
+import { cannotRespond, QuestionClassification } from '../../../src/agents/eventAssistant/eventQuestionHandler.js'
 import { AgentMessageActions } from '../../../src/types/index.types.js'
 
 jest.setTimeout(180000)
 
 const testConfig = setupAgentTest('eventAssistant')
-
-const cannotAnswerResponse =
-  "Based on the content of this conversation, I wasn't able to find a good answer - can you try rephrasing your question? I'm supposed to answer event-related questions; if you think I should've answered this, you can file a bug report at http://brk.mn/feedback."
 
 const offTopicQuestions = [
   'What should I make for lunch?',
@@ -114,7 +111,7 @@ describe(`event assistant CI tests`, () => {
     const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, { messages: [] }, msg)
     await validateResponse(responses)
     expect(responses[0].classification).toBe(QuestionClassification.OFF_TOPIC)
-    expect(responses[0].message).toEqual(cannotAnswerResponse)
+    expect(responses[0].message).toEqual(cannotRespond)
   })
 
   it(
@@ -299,7 +296,7 @@ describe(`event assistant CI tests`, () => {
       const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, { messages: [] }, msg)
       await validateResponse(responses)
       expect(responses[0].classification).toBe(QuestionClassification.OFF_TOPIC)
-      expect(responses[0].message).toEqual(cannotAnswerResponse)
+      expect(responses[0].message).toEqual(cannotRespond)
     },
     testTimeout
   )
@@ -362,7 +359,7 @@ describe(`event assistant CI tests`, () => {
     const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, { messages: [] }, msg)
     await validateResponse(responses)
     expect(responses[0].classification).toBe(QuestionClassification.CATCHUP)
-    expect(responses[0].message).not.toEqual(cannotAnswerResponse)
+    expect(responses[0].message).not.toEqual(cannotRespond)
   })
 
   it('responds to an @Event Assistant message on the chat channel', async () => {
@@ -380,7 +377,7 @@ describe(`event assistant CI tests`, () => {
     const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, { messages: [msg1] }, msg)
     await validateResponse(responses, 'chat')
     expect(responses[0].classification).toBe(QuestionClassification.CATCHUP)
-    expect(responses[0].message).not.toEqual(cannotAnswerResponse)
+    expect(responses[0].message).not.toEqual(cannotRespond)
   })
 
   it('does not respond to a regular message on the chat channel', async () => {
@@ -401,7 +398,12 @@ describe(`event assistant CI tests`, () => {
     ])
     const msgs = await agent.introduce(directChannel)
     expect(msgs).toHaveLength(1)
-    expect(msgs[0].body).toEqual(agent.agentConfig.introMessage)
+    // Should start with the intro message
+    expect(msgs[0].body).toContain(agent.agentConfig.introMessage)
+    // Should contain a fun fact about the pseudonym
+    expect(msgs[0].body).toContain('Fun fact about your pseudonym:')
+    // Should mention the pseudonym or at least "badger" (the noun part)
+    expect(msgs[0].body.toLowerCase()).toMatch(/badger/)
     expect(msgs[0].channels).toHaveLength(1)
     expect(msgs[0].channels[0]).toEqual(directChannel)
   })
@@ -420,5 +422,31 @@ describe(`event assistant CI tests`, () => {
     const [channel] = await Channel.create([{ name: 'testchannel' }])
     const msgs = await agent.introduce(channel)
     expect(msgs).toHaveLength(0)
+  })
+
+  it('includes a fun fact about the user pseudonym in DM intro', async () => {
+    // Create a user with a clear "adjective noun" pseudonym
+    const testUser = await createUser('Curious Elephant')
+    const [directChannel] = await Channel.create([
+      { name: 'direct-test-pseudonym', direct: true, participants: [testUser._id, agent._id] }
+    ])
+    const msgs = await agent.introduce(directChannel)
+
+    expect(msgs).toHaveLength(1)
+    const introMessage = msgs[0].body
+
+    // Should contain the intro message
+    expect(introMessage).toContain(agent.agentConfig.introMessage)
+
+    // Should have the fun fact header
+    expect(introMessage).toContain('Fun fact about your pseudonym:')
+
+    // Should mention "elephant" (the noun part) in the fun fact
+    expect(introMessage.toLowerCase()).toContain('elephant')
+
+    // The fun fact should be factual about elephants
+    // We can't predict exact LLM output, but it should be substantive (more than just the header)
+    const funFactPart = introMessage.split('Fun fact about your pseudonym:')[1]
+    expect(funFactPart.length).toBeGreaterThan(20) // Should be at least 1-2 sentences
   })
 })

--- a/tests/agents/eventAssistant/eventAssistantPlus.agent.test.ts
+++ b/tests/agents/eventAssistant/eventAssistantPlus.agent.test.ts
@@ -41,7 +41,7 @@ describe(`event assistant plus tests`, () => {
   }
 
   beforeEach(async () => {
-    user1 = await createUser('John Hancock')
+    user1 = await createUser('Cautious Cat')
 
     topic = await createPublicTopic()
     conversation = await createEventAssistantPlusConversation(
@@ -563,7 +563,12 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
       ])
       const msgs = await agent.introduce(directChannel)
       expect(msgs).toHaveLength(1)
-      expect(msgs[0].body).toEqual(agent.agentConfig.introMessage)
+      // Should start with the intro message
+      expect(msgs[0].body).toContain(agent.agentConfig.introMessage)
+      // Should contain a fun fact about the pseudonym
+      expect(msgs[0].body).toContain('Fun fact about your pseudonym:')
+      // Should mention the pseudonym
+      expect(msgs[0].body.toLowerCase()).toMatch(/cat/)
       expect(msgs[0].channels).toHaveLength(1)
       expect(msgs[0].channels[0]).toEqual(directChannel)
       expect(msgs[0].visible).toBe(true)
@@ -589,4 +594,34 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
     expect(msgs[0].channels).toHaveLength(1)
     expect(msgs[0].channels[0]).toEqual(chatChannel)
   })
+
+  it(
+    'includes a fun fact about the user pseudonym in DM intro',
+    async () => {
+      // Create a user with a clear "adjective noun" pseudonym
+      const testUser = await createUser('Curious Elephant')
+      const [directChannel] = await Channel.create([
+        { name: 'direct-test-pseudonym', direct: true, participants: [testUser._id, agent._id] }
+      ])
+      const msgs = await agent.introduce(directChannel)
+
+      expect(msgs).toHaveLength(1)
+      const introMessage = msgs[0].body
+
+      // Should contain the intro message
+      expect(introMessage).toContain(agent.agentConfig.introMessage)
+
+      // Should have the fun fact header
+      expect(introMessage).toContain('Fun fact about your pseudonym:')
+
+      // Should mention "elephant" (the noun part) in the fun fact
+      expect(introMessage.toLowerCase()).toContain('elephant')
+
+      // The fun fact should be factual about elephants
+      // We can't predict exact LLM output, but it should be substantive (more than just the header)
+      const funFactPart = introMessage.split('Fun fact about your pseudonym:')[1]
+      expect(funFactPart.length).toBeGreaterThan(20) // Should be at least 1-2 sentences
+    },
+    testTimeout
+  )
 })


### PR DESCRIPTION
## What is in this PR?

Adds a short LLM-generated 'fun fact' about the user's pseudonym to the Event Assistant intro message. Replaces static 'cannotRespond' text with something a bit friendlier.

## Changes in the codebase

See above and commits

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Create an Event Assistant Plus Nextspace conversation and verify intro message contains a fun fact about your pseudonym.
- [ ] Ask an off-topic question and verify the response is friendlier but still contains clickable link to feedback form.
- [ ] (noting the above also works with just Event Assistant and in Zoom as well. Not as critical of a test path)


## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
