### PR TITLE
feat: add mindmap generation to EAP in response to /mindmap command

### DIFF
--- a/src/agents/eventAssistant/eventAssistantPlus.ts
+++ b/src/agents/eventAssistant/eventAssistantPlus.ts
@@ -1,8 +1,11 @@
+/* eslint-disable no-useless-escape */
 import verify from '../helpers/verify.js'
 import { AgentMessageActions, AgentResponse, ConversationHistory } from '../../types/index.types.js'
 
 import Message from '../../models/message.model.js'
 import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
+import { getChatPromptResponse } from '../helpers/llmChain.js'
+import transcript from '../helpers/transcript.js'
 import {
   eventAssistantLLMTemplates,
   eventAssistantLlmTemplateVars,
@@ -19,6 +22,52 @@ const submitToModeratorQuestion = 'Would you like to submit this question anonym
 const submitToModeratorReply = 'Your message has been submitted to the moderator.'
 const declineModeratorReply = "OK, I won't submit it. Feel free to ask me anything else!"
 const submitToModeratorCommand = '/mod'
+const mindMapCommand = '/mindmap'
+
+const mindMapSystem = `You are a mind map generator for a live event. Create a concise mind map from the provided transcript that visually organizes the key points.
+
+CONSTRAINTS:
+- Identify 3-5 main topics maximum
+- Use only 3 levels of hierarchy (main topics, subtopics, and key details)
+- Keep each item to one short sentence or phrase
+- Focus on the most important points, not comprehensive coverage
+
+Use Markmap.js code (example below) in a code block to represent the mind map, with branches for each of the main topics and subtopics, without mentioning the cites. The mind map should be easy to navigate and visually clear.
+
+<MarkmapExample>
+---
+markmap:
+---
+
+# Event Topic
+
+## Main Concept 1
+- **Key point A** with *emphasis*
+- **Key point B**
+- [Reference link](https://example.com)
+
+## Main Concept 2
+- \`technical term\` definition
+- [x] Completed milestone
+- [ ] Pending action
+
+## Main Concept 3
+
+| Comparison | Value |
+|-|-|
+| Option A | High |
+| Option B | Low |
+
+## Main Concept 4
+- First takeaway
+- Second takeaway
+- Third takeaway
+</MarkmapExample>`
+const mindMapUser = `## Event topic:
+{topic}
+
+## Recent Transcript:
+{transcript}`
 
 function isAffirmative(text) {
   const normalized = text.trim().toLowerCase()
@@ -155,6 +204,29 @@ export default verify({
         .trim()
       const agentResponse = await answerQuestion.call(this, modifiedMessage, conversationHistory)
       return [agentResponse]
+    }
+
+    // Mind map command
+    if (userMessage.body.trim().toString().toLowerCase().startsWith(mindMapCommand)) {
+      // all the transcript so far
+      const liveTranscript = transcript.getTranscript(this.conversation, this.conversationHistorySettings?.endTime)
+
+      const topic = this.conversation.name
+      const llm = await this.getLLM()
+      const llmResponse = await getChatPromptResponse(llm, mindMapSystem, mindMapUser, {
+        transcript: liveTranscript,
+        topic
+      })
+
+      return [
+        {
+          visible: true,
+          message: llmResponse,
+          channels: this.conversation.channels.filter((channel) => userMessage.channels.includes(channel.name)),
+          context: liveTranscript,
+          topic
+        }
+      ]
     }
 
     // Check if the previous message was asking about submitting to moderator

--- a/tests/agents/eventAssistant/eventAssistantPlus.agent.test.ts
+++ b/tests/agents/eventAssistant/eventAssistantPlus.agent.test.ts
@@ -555,6 +555,103 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
     })
   })
 
+  describe('mind map command', () => {
+    it(
+      'generates a mind map from the transcript',
+      async () => {
+        const msg = await createQuestion('/mindmap create a mind map of the talk')
+
+        const evaluation = await defaultAgentTypes.eventAssistantPlus.evaluate.call(agent, msg)
+
+        agent.conversationHistorySettings = {
+          endTime: new Date(startTime.getTime() + 954 * 1000),
+          count: 100,
+          directMessages: true,
+          channels: ['chat']
+        }
+
+        const responses = await defaultAgentTypes.eventAssistantPlus.respond.call(
+          agent,
+          { messages: [] },
+          evaluation.userMessage
+        )
+
+        await validateResponse(responses)
+        expect(responses).toHaveLength(1)
+        expect(responses[0].message).toBeDefined()
+        expect(typeof responses[0].message).toBe('string')
+
+        // Should contain markmap markdown in code block
+        expect(responses[0].message).toMatch(/```/)
+
+        // Should contain hierarchical markdown structure (## or ###)
+        expect(responses[0].message).toMatch(/##/)
+
+        // Should NOT contain Katex (since we removed it from the prompt)
+        expect(responses[0].message).not.toMatch(/\$.*\$/)
+
+        // Should NOT contain JavaScript code blocks (since we removed the example)
+        expect(responses[0].message).not.toMatch(/```js/)
+        expect(responses[0].message).not.toMatch(/console\.log/)
+
+        // Should have context and topic metadata
+        expect(responses[0].context).toBeDefined()
+        expect(responses[0].topic).toBe('Test Event')
+
+        console.log('Mind map response:', responses[0].message)
+      },
+      testTimeout
+    )
+
+    it(
+      'includes relevant content from the transcript in the mind map',
+      async () => {
+        const msg = await createQuestion('/mindmap')
+
+        agent.conversationHistorySettings = {
+          endTime: new Date(startTime.getTime() + 954 * 1000),
+          count: 100,
+          directMessages: true,
+          channels: ['chat']
+        }
+
+        const responses = await defaultAgentTypes.eventAssistantPlus.respond.call(agent, { messages: [] }, msg)
+
+        await validateResponse(responses)
+
+        // The mind map should reference key topics from the part-time work transcript
+        const responseText = responses[0].message.toLowerCase()
+        expect(responseText).toMatch(/part.?time|work|employee|business|hour/i)
+      },
+      testTimeout
+    )
+
+    it(
+      'handles /mindmap command with various casings',
+      async () => {
+        const variants = ['/mindmap', '/MINDMAP', '/MindMap', '/mindMAP']
+
+        for (const variant of variants) {
+          const msg = await createQuestion(`${variant} please`)
+
+          agent.conversationHistorySettings = {
+            endTime: new Date(startTime.getTime() + 954 * 1000),
+            count: 100,
+            directMessages: true,
+            channels: ['chat']
+          }
+
+          const responses = await defaultAgentTypes.eventAssistantPlus.respond.call(agent, { messages: [] }, msg)
+
+          await validateResponse(responses)
+          expect(responses).toHaveLength(1)
+          expect(responses[0].message).toMatch(/```/)
+        }
+      },
+      testTimeout
+    )
+  })
+
   it(
     'introduces itself on new DM channels',
     async () => {


### PR DESCRIPTION
add prompt to generate mindmap in markmap format

## What is in this PR?

Adds a prompt and processing of messages that start with /mindmap to EAP for generating a mindmap of the event so far (using the entire transcript as context). Mindmap is generated in [markmap](https://markmap.js.org) format for rendering by FE. 

## Changes in the codebase

See above - changes localized to EAP

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Test in conjunction with FE PR https://github.com/berkmancenter/nextspace/pull/51
- [ ] Create an EAP conversation
- [ ] After some transcript has been generated, send a /mindmap command in Nextspace
- [ ] Verify mind map comes back readable and can be zoomed in/out, panned, and fit to screen. 
- [ ] Reload the page and ensure mindmaps still rendered


## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
