### PR TITLE
feat: add support for /visual command in EA and EAP and /mindmap in EA

### DIFF
--- a/src/agents/eventAssistant/eventAssistant.ts
+++ b/src/agents/eventAssistant/eventAssistant.ts
@@ -11,6 +11,14 @@ import renderAgentTemplate from '../helpers/renderAgentTemplate.js'
 import config from '../../config/config.js'
 import logger from '../../config/logger.js'
 import generateImageResponse from './imageGenerator.js'
+import { parseSlashCommands, hasCommand, extractMessageText, SlashCommand } from './slashCommandParser.js'
+import generateMindMap from './mindMapGenerator.js'
+
+// Supported slash commands for Event Assistant
+const supportedCommands: SlashCommand[] = [
+  { command: 'visual', prefix: '/visual ' },
+  { command: 'mindmap', prefix: '/mindmap' }
+]
 
 export default verify({
   name: 'Event Assistant',
@@ -67,8 +75,12 @@ export default verify({
         suggestion: undefined
       }
     }
+
+    // Parse slash commands using shared parser
+    const modifiedMessage = parseSlashCommands(userMessage, supportedCommands)
+
     return {
-      userMessage,
+      userMessage: modifiedMessage,
       action: AgentMessageActions.CONTRIBUTE,
       userContributionVisible: true,
       suggestion: undefined
@@ -81,12 +93,24 @@ export default verify({
       return imageResponse ? [imageResponse] : []
     }
 
+    // Handle mind map command
+    if (hasCommand(userMessage, 'mindmap')) {
+      return await generateMindMap(this, userMessage)
+    }
+
     const modifiedMessage = { ...userMessage }
+
+    // Check for visual command (set in evaluate)
+    const forceVisual = hasCommand(userMessage, 'visual')
+
+    // Extract text from JSON body if present
+    modifiedMessage.body = extractMessageText(userMessage)
+
     if (userMessage?.channels?.includes('chat')) {
       // trim the '@${this.agentConfig.botName}' from the message body so it's just a regular question
       modifiedMessage.body = modifiedMessage.body.trim().replaceAll(`@${this.agentConfig.botName}`, '').trim()
     }
-    const agentResponse = await answerQuestion.call(this, modifiedMessage, conversationHistory, options)
+    const agentResponse = await answerQuestion.call(this, modifiedMessage, conversationHistory, { ...options, forceVisual })
     return [agentResponse]
   },
   async start() {

--- a/src/agents/eventAssistant/eventAssistantPlus.ts
+++ b/src/agents/eventAssistant/eventAssistantPlus.ts
@@ -1,12 +1,9 @@
-/* eslint-disable no-useless-escape */
 import verify from '../helpers/verify.js'
 import { AgentMessageActions, AgentResponse, ConversationHistory } from '../../types/index.types.js'
 import renderAgentTemplate from '../helpers/renderAgentTemplate.js'
 
 import Message from '../../models/message.model.js'
 import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
-import { getChatPromptResponse } from '../helpers/llmChain.js'
-import transcript from '../helpers/transcript.js'
 import {
   eventAssistantLLMTemplates,
   eventAssistantLlmTemplateVars,
@@ -18,6 +15,8 @@ import {
 import logger from '../../config/logger.js'
 import config from '../../config/config.js'
 import generateImageResponse from './imageGenerator.js'
+import { parseSlashCommands, hasCommand, extractMessageText, SlashCommand } from './slashCommandParser.js'
+import generateMindMap from './mindMapGenerator.js'
 
 const submitToModeratorQuestion = 'Would you like to submit this question anonymously to the moderator for Q&A?'
 const submitToModeratorReply = 'Your message has been submitted to the moderator.'
@@ -25,50 +24,12 @@ const declineModeratorReply = "OK, I won't submit it. Feel free to ask me anythi
 const submitToModeratorCommand = '/mod'
 const mindMapCommand = '/mindmap'
 
-const mindMapSystem = `You are a mind map generator for a live event. Create a concise mind map from the provided transcript that visually organizes the key points.
-
-CONSTRAINTS:
-- Identify 3-5 main topics maximum
-- Use only 3 levels of hierarchy (main topics, subtopics, and key details)
-- Keep each item to one short sentence or phrase
-- Focus on the most important points, not comprehensive coverage
-
-Use Markmap.js code (example below) in a code block to represent the mind map, with branches for each of the main topics and subtopics, without mentioning the cites. The mind map should be easy to navigate and visually clear.
-
-<MarkmapExample>
----
-markmap:
----
-
-# Event Topic
-
-## Main Concept 1
-- **Key point A** with *emphasis*
-- **Key point B**
-- [Reference link](https://example.com)
-
-## Main Concept 2
-- \`technical term\` definition
-- [x] Completed milestone
-- [ ] Pending action
-
-## Main Concept 3
-
-| Comparison | Value |
-|-|-|
-| Option A | High |
-| Option B | Low |
-
-## Main Concept 4
-- First takeaway
-- Second takeaway
-- Third takeaway
-</MarkmapExample>`
-const mindMapUser = `## Event topic:
-{topic}
-
-## Recent Transcript:
-{transcript}`
+// Supported slash commands for Event Assistant Plus
+const supportedCommands: SlashCommand[] = [
+  { command: 'mod', prefix: submitToModeratorCommand, addToChannels: ['participant'] },
+  { command: 'visual', prefix: '/visual ' },
+  { command: 'mindmap', prefix: mindMapCommand }
+]
 
 function isAffirmative(text) {
   const normalized = text.trim().toLowerCase()
@@ -174,13 +135,10 @@ export default verify({
         suggestion: undefined
       }
     }
-    const modifiedMessage = { ...userMessage }
-    if (modifiedMessage.body.trim().toString().toLowerCase().startsWith(submitToModeratorCommand)) {
-      modifiedMessage!.channels = modifiedMessage!.channels ?? []
-      modifiedMessage!.channels.push('participant')
-      // Remove the '/mod ' command from the message body
-      modifiedMessage.body = modifiedMessage.body.trim().substring(submitToModeratorCommand.length).trim()
-    }
+
+    // Parse slash commands using shared parser
+    const modifiedMessage = parseSlashCommands(userMessage, supportedCommands)
+
     return {
       userMessage: modifiedMessage,
       action: AgentMessageActions.CONTRIBUTE,
@@ -195,6 +153,11 @@ export default verify({
       return imageResponse ? [imageResponse] : []
     }
 
+    // Handle mind map command
+    if (hasCommand(userMessage, 'mindmap')) {
+      return await generateMindMap(this, userMessage)
+    }
+
     // Message on chat channel?
     if (userMessage?.channels?.includes('chat')) {
       const modifiedMessage = { ...userMessage }
@@ -202,29 +165,6 @@ export default verify({
       modifiedMessage.body = modifiedMessage.body.trim().replaceAll(`@${this.agentConfig.botName}`, '').trim()
       const agentResponse = await answerQuestion.call(this, modifiedMessage, conversationHistory)
       return [agentResponse]
-    }
-
-    // Mind map command
-    if (userMessage.body.trim().toString().toLowerCase().startsWith(mindMapCommand)) {
-      // all the transcript so far
-      const liveTranscript = transcript.getTranscript(this.conversation, this.conversationHistorySettings?.endTime)
-
-      const topic = this.conversation.name
-      const llm = await this.getLLM()
-      const llmResponse = await getChatPromptResponse(llm, mindMapSystem, mindMapUser, {
-        transcript: liveTranscript,
-        topic
-      })
-
-      return [
-        {
-          visible: true,
-          message: llmResponse,
-          channels: this.conversation.channels.filter((channel) => userMessage.channels.includes(channel.name)),
-          context: liveTranscript,
-          topic
-        }
-      ]
     }
 
     // Check if the previous message was asking about submitting to moderator
@@ -237,7 +177,9 @@ export default verify({
     ) {
       const originalMessageId = (lastMessage.body as Record<string, unknown>).message
       const message = await Message.findById(originalMessageId)
-      if (isAffirmative(userMessage.body)) {
+      // Get the text from body (handle both string and JSON body types)
+      const responseText = extractMessageText(userMessage)
+      if (isAffirmative(responseText)) {
         if (!message) {
           logger.error(`Could not find original message with ID ${originalMessageId} to submit to moderator`)
           return []
@@ -248,7 +190,7 @@ export default verify({
         return submitToModeratorResponse.call(this, userMessage, message)
       }
 
-      if (isNegative(userMessage.body)) {
+      if (isNegative(responseText)) {
         return declineModeratorResponse.call(this, userMessage, message)
       }
       // If neither affirmative nor negative, fall through to process as a new question
@@ -258,7 +200,14 @@ export default verify({
       return submitToModeratorResponse.call(this, userMessage, userMessage)
     }
 
-    const agentResponse = await answerQuestion.call(this, userMessage, conversationHistory)
+    // Check for visual command (set in evaluate)
+    const forceVisual = hasCommand(userMessage, 'visual')
+
+    // Extract text from JSON body if present for processing
+    const modifiedMessage = { ...userMessage }
+    modifiedMessage.body = extractMessageText(userMessage)
+
+    const agentResponse = await answerQuestion.call(this, modifiedMessage, conversationHistory, { forceVisual })
     const agentResponses: AgentResponse<string | Record<string, unknown>>[] = [agentResponse]
     const { classification } = agentResponse
     if (

--- a/src/agents/eventAssistant/eventQuestionHandler.ts
+++ b/src/agents/eventAssistant/eventQuestionHandler.ts
@@ -317,16 +317,26 @@ ${chunks}`
   let parentMessageId
   let responseMessage = llmResponse
 
-  // Check user's visual response preference and add image-gen channel if appropriate
+  // Check if visual generation should happen (either forced via /visual or user preference)
   const user = await User.findById(userMessage.owner)
-  if (user?.preferences?.visualResponse) {
-    logger.debug(`User ${user!._id} has visual response preference enabled`)
+  const forceVisual = options?.forceVisual === true
 
-    // Classify if this question/answer would benefit from a visual
-    const shouldGenerate = await shouldGenerateVisual.call(this, question, classification, llmResponse, templates)
+  if (forceVisual || user?.preferences?.visualResponse) {
+    let shouldGenerate = false
+
+    if (forceVisual) {
+      logger.debug('Visual generation forced via /visual command')
+      // For /visual command, always generate unless it's an error response
+      // User explicitly requested visual, so respect their intent
+      shouldGenerate = llmResponse !== cannotRespond
+    } else {
+      logger.debug(`User ${user!._id} has visual response preference enabled`)
+      // Classify if this question/answer would benefit from a visual
+      shouldGenerate = await shouldGenerateVisual.call(this, question, classification, llmResponse, templates)
+    }
 
     if (shouldGenerate) {
-      logger.debug(`Adding image-gen channel to response for user ${user!._id}`)
+      logger.debug(`Adding image-gen channel to response${forceVisual ? ' (forced)' : ''}`)
       // Add image-gen channel to the response
       const imageGenChannel = this.conversation.channels.find((channel: IChannel) => channel.name === 'image-gen')
       if (imageGenChannel) {

--- a/src/agents/eventAssistant/mindMapGenerator.ts
+++ b/src/agents/eventAssistant/mindMapGenerator.ts
@@ -1,0 +1,76 @@
+import { getChatPromptResponse } from '../helpers/llmChain.js'
+import transcript from '../helpers/transcript.js'
+
+const mindMapSystem = `You are a mind map generator for a live event. Create a concise mind map from the provided transcript that visually organizes the key points.
+
+CONSTRAINTS:
+- Identify 3-5 main topics maximum
+- Use only 3 levels of hierarchy (main topics, subtopics, and key details)
+- Keep each item to one short sentence or phrase
+- Focus on the most important points, not comprehensive coverage
+
+Use Markmap.js code (example below) in a code block to represent the mind map, with branches for each of the main topics and subtopics, without mentioning the cites. The mind map should be easy to navigate and visually clear.
+
+<MarkmapExample>
+---
+markmap:
+---
+
+# Event Topic
+
+## Main Concept 1
+- **Key point A** with *emphasis*
+- **Key point B**
+- [Reference link](https://example.com)
+
+## Main Concept 2
+- \`technical term\` definition
+- [x] Completed milestone
+- [ ] Pending action
+
+## Main Concept 3
+
+| Comparison | Value |
+|-|-|
+| Option A | High |
+| Option B | Low |
+
+## Main Concept 4
+- First takeaway
+- Second takeaway
+- Third takeaway
+</MarkmapExample>`
+
+const mindMapUser = `## Event topic:
+{topic}
+
+## Recent Transcript:
+{transcript}`
+
+/**
+ * Generate a mind map from the conversation transcript
+ * @param agent - The agent instance (with conversation, getLLM, conversationHistorySettings)
+ * @param userMessage - The user message that triggered the mind map generation
+ * @returns Agent response with the mind map
+ */
+export default async function generateMindMap(agent, userMessage) {
+  // Get the transcript so far
+  const liveTranscript = transcript.getTranscript(agent.conversation, agent.conversationHistorySettings?.endTime)
+
+  const topic = agent.conversation.name
+  const llm = await agent.getLLM()
+  const llmResponse = await getChatPromptResponse(llm, mindMapSystem, mindMapUser, {
+    transcript: liveTranscript,
+    topic
+  })
+
+  return [
+    {
+      visible: true,
+      message: llmResponse,
+      channels: agent.conversation.channels.filter((channel) => userMessage.channels.includes(channel.name)),
+      context: liveTranscript,
+      topic
+    }
+  ]
+}

--- a/src/agents/eventAssistant/slashCommandParser.ts
+++ b/src/agents/eventAssistant/slashCommandParser.ts
@@ -1,0 +1,70 @@
+/**
+ * Slash command configuration
+ */
+export interface SlashCommand {
+  command: string // The command name (e.g., 'visual', 'mindmap')
+  prefix: string // The slash prefix to match (e.g., '/visual ', '/mindmap')
+  addToChannels?: string[] // Optional: channels to add when this command is detected
+}
+
+/**
+ * Parse slash commands from user message and return modified message with JSON body
+ * @param userMessage - The original user message
+ * @param supportedCommands - Array of slash command configurations
+ * @returns Modified message with bodyType: 'json' and body: { command, text } if a command was found
+ */
+export function parseSlashCommands(userMessage, supportedCommands: SlashCommand[]) {
+  const modifiedMessage = { ...userMessage }
+  const bodyStr = (userMessage.body || '').trim().toLowerCase()
+
+  // Check each supported command
+  for (const cmdConfig of supportedCommands) {
+    if (bodyStr.startsWith(cmdConfig.prefix.toLowerCase())) {
+      // Set bodyType to json
+      modifiedMessage.bodyType = 'json'
+
+      // Extract the text after the command prefix
+      const text = userMessage.body.trim().substring(cmdConfig.prefix.length).trim()
+
+      // Set body to JSON structure
+      modifiedMessage.body = {
+        command: cmdConfig.command,
+        text
+      }
+
+      // Add to channels if specified
+      if (cmdConfig.addToChannels && cmdConfig.addToChannels.length > 0) {
+        modifiedMessage.channels = modifiedMessage.channels ?? []
+        modifiedMessage.channels.push(...cmdConfig.addToChannels)
+      }
+
+      // Return on first match (commands are mutually exclusive)
+      return modifiedMessage
+    }
+  }
+
+  // No command found, return unmodified
+  return modifiedMessage
+}
+
+/**
+ * Extract text from a message body (handles both string and JSON body types)
+ * @param userMessage - The user message
+ * @returns The text content of the message
+ */
+export function extractMessageText(userMessage) {
+  if (userMessage?.bodyType === 'json' && userMessage?.body?.text) {
+    return userMessage.body.text
+  }
+  return userMessage?.body || ''
+}
+
+/**
+ * Check if a message has a specific command
+ * @param userMessage - The user message
+ * @param command - The command name to check for
+ * @returns True if the message has the specified command
+ */
+export function hasCommand(userMessage, command) {
+  return userMessage?.bodyType === 'json' && userMessage?.body?.command === command
+}

--- a/tests/agents/eventAssistant/eventAssistant.agent.test.ts
+++ b/tests/agents/eventAssistant/eventAssistant.agent.test.ts
@@ -714,6 +714,184 @@ describe(`event assistant CI tests`, () => {
     // Some tests may call the real image generator if classification determines
     // a visual is appropriate, which is the actual behavior we want to test.
 
+    // /visual command tests
+    describe('/visual command', () => {
+      it(
+        'triggers visual generation even without user preference when using /visual command',
+        async () => {
+          // user1 by default has no visualResponse preference set
+          const msg = await createQuestion('/visual How does part-time work benefit companies?')
+          msg._id = new mongoose.Types.ObjectId()
+          agent.conversationHistorySettings = {
+            endTime: new Date(startTime.getTime() + 147 * 1000),
+            count: 100,
+            directMessages: true
+          }
+
+          // Call evaluate first to parse the slash command
+          const evaluation = await defaultAgentTypes.eventAssistant.evaluate.call(agent, msg)
+          const responses = await defaultAgentTypes.eventAssistant.respond.call(
+            agent,
+            { messages: [] },
+            evaluation.userMessage
+          )
+
+          // Should initiate visual generation even without user preference
+          await validateVisualGenerationInitiation(responses)
+          expect(responses[0].parent).toBe(msg._id)
+        },
+        testTimeout
+      )
+
+      it(
+        'strips /visual prefix from message before processing',
+        async () => {
+          const msg = await createQuestion('/visual What did she say about part-time work?')
+          msg._id = new mongoose.Types.ObjectId()
+          agent.conversationHistorySettings = {
+            endTime: new Date(startTime.getTime() + 147 * 1000),
+            count: 100,
+            directMessages: true
+          }
+
+          // Call evaluate first to parse the slash command
+          const evaluation = await defaultAgentTypes.eventAssistant.evaluate.call(agent, msg)
+          const responses = await defaultAgentTypes.eventAssistant.respond.call(
+            agent,
+            { messages: [] },
+            evaluation.userMessage
+          )
+
+          // Response should answer the question without mentioning "/visual"
+          expect(responses[0].message).toBeDefined()
+          expect(typeof responses[0].message).toBe('string')
+          expect(responses[0].message.toLowerCase()).not.toContain('/visual')
+          // Should still initiate visual generation
+          await validateVisualGenerationInitiation(responses)
+        },
+        testTimeout
+      )
+
+      it(
+        'does not generate visuals for off-topic questions even with /visual command',
+        async () => {
+          const msg = await createQuestion('/visual What is the weather like in Paris?')
+          agent.conversationHistorySettings = {
+            endTime: new Date(startTime.getTime() + 147 * 1000),
+            count: 100,
+            directMessages: true
+          }
+
+          // Call evaluate first to parse the slash command
+          const evaluation = await defaultAgentTypes.eventAssistant.evaluate.call(agent, msg)
+          const responses = await defaultAgentTypes.eventAssistant.respond.call(
+            agent,
+            { messages: [] },
+            evaluation.userMessage
+          )
+
+          // OFF_TOPIC responses should never have visuals, even with /visual
+          await validateResponse(responses)
+          expect(responses[0].classification).toBe(QuestionClassification.OFF_TOPIC)
+          expect(responses[0].message).toBe(cannotRespond)
+          expect(responses[0].message).not.toContain('🎨 Generating visual...')
+        },
+        testTimeout
+      )
+
+      it(
+        'case insensitive /visual command detection',
+        async () => {
+          const msg = await createQuestion('/VISUAL How does part-time work benefit companies?')
+          msg._id = new mongoose.Types.ObjectId()
+          agent.conversationHistorySettings = {
+            endTime: new Date(startTime.getTime() + 147 * 1000),
+            count: 100,
+            directMessages: true
+          }
+
+          // Call evaluate first to parse the slash command
+          const evaluation = await defaultAgentTypes.eventAssistant.evaluate.call(agent, msg)
+          const responses = await defaultAgentTypes.eventAssistant.respond.call(
+            agent,
+            { messages: [] },
+            evaluation.userMessage
+          )
+
+          // Should work with uppercase /VISUAL
+          await validateVisualGenerationInitiation(responses)
+        },
+        testTimeout
+      )
+
+      it(
+        'completes two-step visual generation process with /visual command',
+        async () => {
+          // Question with /visual command
+          const msg = await createQuestion('/visual What are the key steps in creating a smallest viable job?')
+          msg._id = new mongoose.Types.ObjectId()
+          agent.conversationHistorySettings = {
+            endTime: new Date(startTime.getTime() + 829 * 1000),
+            count: 100,
+            directMessages: true
+          }
+
+          // Call evaluate first to parse the slash command
+          const evaluation = await defaultAgentTypes.eventAssistant.evaluate.call(agent, msg)
+
+          // Step 1: Get the initial text response
+          const initialResponses = await defaultAgentTypes.eventAssistant.respond.call(
+            agent,
+            { messages: [] },
+            evaluation.userMessage
+          )
+          expect(initialResponses).toHaveLength(1)
+          expect(typeof initialResponses[0].message).toBe('string')
+
+          // Should trigger visual generation
+          await validateVisualGenerationInitiation(initialResponses)
+          expect(initialResponses[0].parent).toBe(msg._id)
+
+          // Step 2: Simulate the agent receiving its own message on image-gen channel
+          const imageGenMessage = await createMessage(
+            initialResponses[0].message,
+            { _id: agent._id, pseudonym: agent.name, pseudonyms: [{ pseudonym: agent.name }] },
+            conversation,
+            ['image-gen', `direct-agents-${user1._id}`]
+          )
+          imageGenMessage.parentMessage = msg._id
+
+          // Agent sees its own message on image-gen and generates the image
+          const imageResponses = await defaultAgentTypes.eventAssistant.respond.call(
+            agent,
+            { messages: [] },
+            imageGenMessage
+          )
+
+          // Should return image response
+          expect(imageResponses).toHaveLength(1)
+          expect(imageResponses[0].messageType).toBe('multimodal')
+          expect(imageResponses[0].message).toBeDefined()
+          expect(imageResponses[0].message.media).toBeDefined()
+          expect(imageResponses[0].message.media).toHaveLength(1)
+          expect(imageResponses[0].message.media[0].type).toBe('image')
+          expect(imageResponses[0].message.media[0].data).toBeDefined()
+          expect(imageResponses[0].message.media[0].data.length).toBeGreaterThan(100)
+          expect(imageResponses[0].message.media[0].mimeType).toMatch(/^image\//)
+
+          // Should NOT include image-gen channel (to avoid infinite loop)
+          const imageChannelNames = imageResponses[0].channels.map((ch: IChannel) => ch.name)
+          expect(imageChannelNames).not.toContain('image-gen')
+          // Should include the user's direct channel
+          expect(imageChannelNames).toContain(`direct-agents-${user1._id}`)
+
+          // Should have same parent as initial response (the user's question)
+          expect(imageResponses[0].parent).toBe(msg._id)
+        },
+        testTimeout
+      )
+    })
+
     it(
       'does not generate visuals when user preference is not set',
       async () => {

--- a/tests/agents/eventAssistant/eventAssistantPlus.agent.test.ts
+++ b/tests/agents/eventAssistant/eventAssistantPlus.agent.test.ts
@@ -433,7 +433,8 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
 
       const evaluation = await defaultAgentTypes.eventAssistantPlus.evaluate.call(agent, modMsg)
 
-      expect(evaluation.userMessage.body).toBe('This is urgent')
+      expect(evaluation.userMessage.body).toEqual({ command: 'mod', text: 'This is urgent' })
+      expect(evaluation.userMessage.bodyType).toBe('json')
       expect(evaluation.userMessage.channels).toContain('participant')
       expect(evaluation.action).toBe(AgentMessageActions.CONTRIBUTE)
     })
@@ -614,8 +615,13 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
           directMessages: true,
           channels: ['chat']
         }
+        const evaluation = await defaultAgentTypes.eventAssistantPlus.evaluate.call(agent, msg)
 
-        const responses = await defaultAgentTypes.eventAssistantPlus.respond.call(agent, { messages: [] }, msg)
+        const responses = await defaultAgentTypes.eventAssistantPlus.respond.call(
+          agent,
+          { messages: [] },
+          evaluation.userMessage
+        )
 
         await validateResponse(responses)
 
@@ -640,8 +646,12 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
             directMessages: true,
             channels: ['chat']
           }
-
-          const responses = await defaultAgentTypes.eventAssistantPlus.respond.call(agent, { messages: [] }, msg)
+          const evaluation = await defaultAgentTypes.eventAssistantPlus.evaluate.call(agent, msg)
+          const responses = await defaultAgentTypes.eventAssistantPlus.respond.call(
+            agent,
+            { messages: [] },
+            evaluation.userMessage
+          )
 
           await validateResponse(responses)
           expect(responses).toHaveLength(1)


### PR DESCRIPTION
## What is in this PR?

add support for /visual command in EA and EAP and /mindmap in EA

## Changes in the codebase
- add /visual command to generate a visual response to a question on demand to EA and EAP
- add /mindmap support to EA as well as EAP and extract to helper function
- add framework for agent types to specify the commands they support and helper for parsing

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Test in conjunction with https://github.com/berkmancenter/nextspace/pull/54
- [ ] Create EAP conversation
- [ ] Do not set visual preference
- [ ] Send a /visual command as a DM to Berkie
- [ ] Verify the '/visual' prefix is stripped from your message as visualized
- [ ] Verify you get back the usual text response with a Generating visual... and visual response arrives later
- [ ] Send a /mod command and verify the usual 'Your message was submitted' message is displayed
- [ ] Send a message designed to trigger the 'Would you like to submit to moderator?' question and ensure that all works as expected



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
