### PR TITLE
remove filter for questions sent to moderator

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "express-rate-limit": "^7.5.0",
     "fuzzball": "^2.2.2",
     "googleapis": "^144.0.0",
-    "handlebars": "^4.7.8",
+    "handlebars": "^4.7.9",
     "helmet": "^8.0.0",
     "http-status": "^1",
     "joi": "^17.13.3",
@@ -178,7 +178,8 @@
     "zod": "<=3.25.67",
     "fast-xml-parser": ">=5.3.5",
     "basic-ftp": ">=5.2.0",
-    "convict": ">=6.2.5"
+    "convict": ">=6.2.5",
+    "handlebars": ">=4.7.9"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "config": {

--- a/src/agents/backChannel/backChannelInsightsGenerator.ts
+++ b/src/agents/backChannel/backChannelInsightsGenerator.ts
@@ -133,12 +133,7 @@ export const backChannelLLMTemplateVars = {
     { name: 'reportingThreshold', description: 'The minimum number of users from which to generate an insight' },
     { name: 'maxInsights', description: 'The maximum number of insights to generate' }
   ],
-  insightsSystem: [], // TODO don't require for system prompts?,
-  standaloneQuestionUser: [
-    { name: 'topic', description: 'The topic of the conversation' },
-    { name: 'comments', description: 'The comments to process' }
-  ],
-  standaloneQuestionSystem: [] // TODO don't require for system prompts?
+  insightsSystem: [] // TODO don't require for system prompts?
 }
 
 function groupCommentsByUser(commentMsgs) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6412,7 +6412,7 @@ guid-typescript@^1.0.9:
   resolved "https://registry.yarnpkg.com/guid-typescript/-/guid-typescript-1.0.9.tgz#e35f77003535b0297ea08548f5ace6adb1480ddc"
   integrity sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==
 
-handlebars@>=4.7.9, handlebars@^4.7.8, handlebars@^4.7.9:
+handlebars@^4.7.8, handlebars@^4.7.9:
   version "4.7.9"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
   integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==


### PR DESCRIPTION
## What is in this PR?

Removes the filter that was blocking individual participant questions from reaching the moderator. Adds a test to make sure clustered comments don't also show up as standalone questions.

## Changes in the codebase

- Removed mod filter logic from the back channel insights agent
- New test verifies that comments grouped into an insight don't also appear in the standalone questions list

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

Set up an event with this test data as an example:
- **Title:** The Future of Remote Work: Collaboration Without Borders
- **Speaker:** Dr. Priya Mehta
- **Transcript:** 2-minute talk loaded into the conversation
- **Chat:** 3 users (with a mix of on-topic messages that should cluster and off-topic standalones (audiobook question, speaker booking request, hybrid model tangent)

Then verify:
- [ ] Clustered comments appear as insights and are not duplicated as standalone questions
- [ ] Off-topic messages surface individually to the moderator
- [ ] Questions previously dropped by the mod filter now come through

## Additional information
