### PR TITLE
feat: allow jargon agent to respond to follow-up requests for clarification

### DIFF
--- a/src/agents/jargonFilter/jargonFilter.ts
+++ b/src/agents/jargonFilter/jargonFilter.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod'
 import verify from '../helpers/verify.js'
-import { AgentMessageActions, ConversationHistory, IChannel } from '../../types/index.types.js'
+import { AgentMessageActions, ConversationHistory, IChannel, IMessage } from '../../types/index.types.js'
 import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
 import logger from '../../config/logger.js'
 import { getChatPromptResponse } from '../helpers/llmChain.js'
-import { formatTranscript } from '../helpers/llmInputFormatters.js'
+import { formatTranscript, formatSingleUserConversationHistory } from '../helpers/llmInputFormatters.js'
 import User from '../../models/user.model/user.model.js'
 
 export type JargonFilterResponse = {
@@ -69,6 +69,54 @@ const USER_TEMPLATE = `## Event Topic:
 
 Analyze the transcript above for technical jargon and return JSON only. The "text" field must begin with a "**Summary:**" section before the bullet points.`
 
+// Interactive mode: Combined classification and answer
+export const JARGON_FOLLOW_UP_SYSTEM_PROMPT = `You are a helpful assistant that answers follow-up questions about technical jargon and terminology from an event.
+
+## Your Task
+
+1. First, determine if the question is about jargon/terminology clarification
+2. If YES: Answer the question about the jargon (include the "text" field in your response)
+3. If NO: Do not include the "text" field in your response
+
+## Questions that ARE about jargon:
+- Technical terms, acronyms, or jargon from the event
+- Definitions or explanations of concepts mentioned
+- Further clarification about previously explained terms
+
+## Questions that are NOT about jargon:
+- General conversation or greetings
+- Event logistics (time, location, etc.)
+- Off-topic personal questions
+- Questions unrelated to terminology or jargon
+
+## Guidelines for answering (when isJargonRelated is true):
+- Use plain language as if explaining to a high school student with no background in the field
+- Be conversational and natural - this is a back-and-forth dialogue
+- Keep responses concise (2-3 sentences unless more detail is needed)
+- Use everyday analogies when helpful
+- If the user asks for more detail about a term, expand on your previous explanation
+- Never imply terms are obvious or that the reader should already know them
+- Avoid phrases like "simply", "just", "basically", "obviously", or "of course"
+
+Return JSON with:
+- isJargonRelated: boolean (true if about jargon, false otherwise)
+- text: string (your answer - ONLY include this field if isJargonRelated is true)
+
+Return ONLY raw JSON. No markdown, no backticks, no explanation.`
+
+const JARGON_FOLLOW_UP_USER_TEMPLATE = `## Event Topic:
+{topic}
+
+## User Question:
+{userQuestion}
+
+Determine if this is about jargon/terminology and answer if so. Return JSON only.`
+
+const jargonFollowUpSchema = z.object({
+  isJargonRelated: z.boolean(),
+  text: z.string().optional()
+})
+
 export default verify({
   name: 'Jargon Filter Agent',
   description:
@@ -76,7 +124,8 @@ export default verify({
   priority: 50,
   maxTokens: 2000,
   defaultTriggers: {
-    periodic: { timerPeriod: 120, conversationHistorySettings: { channels: ['transcript'], timeWindow: 120 } }
+    periodic: { timerPeriod: 120, conversationHistorySettings: { channels: ['transcript'], timeWindow: 120 } },
+    perMessage: { directMessages: true }
   },
   llmTemplateVars: {
     system: [],
@@ -98,19 +147,94 @@ export default verify({
     return true
   },
 
-  async evaluate(userMessage) {
+  async evaluate(userMessage?: IMessage) {
+    // Path A: Periodic trigger (no userMessage)
+    if (!userMessage) {
+      return {
+        action: AgentMessageActions.CONTRIBUTE,
+        userMessage,
+        userContributionVisible: true,
+        suggestion: undefined
+      }
+    }
+
+    // Path B: Per-message trigger (direct channel message)
+    // Only respond to threaded replies (not standalone DMs)
+    if (!userMessage.parentMessage) {
+      logger.info(`${this.name}: Ignoring non-threaded direct message`)
+      return {
+        userMessage,
+        action: AgentMessageActions.OK,
+        userContributionVisible: true,
+        suggestion: undefined
+      }
+    }
+
+    // Threaded reply detected - always contribute
+    // (Off-topic detection happens in respond() to provide helpful decline message)
     return {
-      action: AgentMessageActions.CONTRIBUTE,
       userMessage,
+      action: AgentMessageActions.CONTRIBUTE,
       userContributionVisible: true,
       suggestion: undefined
     }
   },
 
-  async respond(conversationHistory: ConversationHistory) {
+  async respond(conversationHistory: ConversationHistory, userMessage?: IMessage) {
     const llm = await this.getLLM()
     if (!this.conversation) return []
 
+    // Path B: Per-message trigger - interactive clarification
+    if (userMessage) {
+      const chatHistory = formatSingleUserConversationHistory(conversationHistory)
+
+      const response = await getChatPromptResponse(
+        llm,
+        JARGON_FOLLOW_UP_SYSTEM_PROMPT,
+        JARGON_FOLLOW_UP_USER_TEMPLATE,
+        {
+          topic: this.conversation.name,
+          userQuestion: userMessage.body
+        },
+        chatHistory,
+        jargonFollowUpSchema
+      )
+
+      const responseChannels = this.conversation.channels.filter((channel: IChannel) =>
+        userMessage.channels?.includes(channel.name)
+      )
+
+      const parentMessageId = userMessage.parentMessage || userMessage._id
+
+      // If off-topic, send polite decline
+      if (!response.isJargonRelated || !response.text) {
+        return [
+          {
+            visible: true,
+            message: {
+              text: 'I can only help clarify jargon from the event. Please ask event-related questions in the main chat.',
+              type: 'jargon_follow_up'
+            },
+            messageType: 'json',
+            channels: responseChannels,
+            parent: parentMessageId
+          }
+        ]
+      }
+
+      // Send LLM-generated answer
+      return [
+        {
+          visible: true,
+          message: { text: response.text, type: 'jargon_follow_up' },
+          messageType: 'json',
+          channels: responseChannels,
+          parent: parentMessageId
+        }
+      ]
+    }
+
+    // Path A: Periodic trigger - existing proactive jargon detection
     const transcript = formatTranscript(conversationHistory.messages)
 
     const response = await getChatPromptResponse(

--- a/tests/agents/jargonFilter/jargonFilter.agent.test.ts
+++ b/tests/agents/jargonFilter/jargonFilter.agent.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../utils/agentTestHelpers.js'
 import getConversationHistory from '../../../src/agents/helpers/getConversationHistory.js'
 import User from '../../../src/models/user.model/user.model.js'
+import { AgentMessageActions } from '../../../src/types/index.types.js'
 
 jest.setTimeout(180000)
 
@@ -64,6 +65,11 @@ describe('jargon filter agent tests', () => {
       expect(jargonFilterAgent.triggers.periodic.conversationHistorySettings.channels).toContain('transcript')
       expect(jargonFilterAgent.triggers.periodic.conversationHistorySettings.timeWindow).toBe(120)
     })
+
+    it('uses perMessage trigger for direct messages', () => {
+      expect(jargonFilterAgent.triggers.perMessage).toBeDefined()
+      expect(jargonFilterAgent.triggers.perMessage.directMessages).toBe(true)
+    })
   })
 
   describe('jargon detection', () => {
@@ -92,7 +98,16 @@ describe('jargon filter agent tests', () => {
         expect(response.message.text).toMatch(/- \*\*.+\*\*/)
 
         // sourceText is a verbatim quote from the transcript — assert it contains a known jargon term
-        const knownJargonTerms = ['SLO', 'mTLS', 'MTTR', 'write-ahead logging', 'consistent hashing', 'error budget', 'thundering herd', 'exponential backoff']
+        const knownJargonTerms = [
+          'SLO',
+          'mTLS',
+          'MTTR',
+          'write-ahead logging',
+          'consistent hashing',
+          'error budget',
+          'thundering herd',
+          'exponential backoff'
+        ]
         expect(knownJargonTerms.some((term) => response.message.sourceText.includes(term))).toBe(true)
 
         // transcriptWindow reflects the conversationHistory boundaries passed to respond()
@@ -202,6 +217,176 @@ describe('jargon filter agent tests', () => {
       const agentType = defaultAgentTypes.jargonFilterAgent
       const msgs = await agentType.introduce.call(jargonFilterAgent, chatChannel)
       expect(msgs).toEqual([])
+    })
+  })
+
+  describe('interactive mode - direct message handling', () => {
+    describe('evaluate()', () => {
+      it('returns CONTRIBUTE for periodic trigger (no userMessage)', async () => {
+        const evaluation = await defaultAgentTypes.jargonFilterAgent.evaluate.call(jargonFilterAgent, undefined)
+        expect(evaluation.action).toBe(AgentMessageActions.CONTRIBUTE)
+      })
+
+      it('returns CONTRIBUTE when userMessage has parentMessage (threaded reply)', async () => {
+        const userMessage = {
+          _id: 'message123',
+          body: 'Can you explain more about SLO?',
+          parentMessage: 'parent456',
+          channels: [`direct-agents-${userOptedIn._id}`],
+          owner: userOptedIn._id
+        }
+
+        const evaluation = await defaultAgentTypes.jargonFilterAgent.evaluate.call(jargonFilterAgent, userMessage)
+        expect(evaluation.action).toBe(AgentMessageActions.CONTRIBUTE)
+      })
+
+      it('returns OK when userMessage has no parentMessage (non-threaded DM)', async () => {
+        const userMessage = {
+          _id: 'message123',
+          body: 'Hello, what is an API?',
+          channels: [`direct-agents-${userOptedIn._id}`],
+          owner: userOptedIn._id
+        }
+
+        const evaluation = await defaultAgentTypes.jargonFilterAgent.evaluate.call(jargonFilterAgent, userMessage)
+        expect(evaluation.action).toBe(AgentMessageActions.OK)
+      })
+    })
+
+    describe('respond() with userMessage', () => {
+      it(
+        'responds to on-topic jargon question with conversational answer',
+        async () => {
+          // Create a mock direct channel
+          const directChannel = conversation.channels.find((c) => c.name === `direct-agents-${userOptedIn._id}`)
+
+          const userMessage = {
+            _id: 'message123',
+            body: 'Can you explain more about SLO?',
+            parentMessage: 'parent456',
+            channels: [directChannel.name],
+            owner: userOptedIn._id
+          }
+
+          // Create minimal conversation history
+          const conversationHistory = {
+            messages: [],
+            start: new Date(),
+            end: new Date()
+          }
+
+          const responses = await defaultAgentTypes.jargonFilterAgent.respond.call(
+            jargonFilterAgent,
+            conversationHistory,
+            userMessage
+          )
+
+          expect(responses).toHaveLength(1)
+          const response = responses[0]
+
+          expect(response.visible).toBe(true)
+          expect(response.messageType).toBe('json')
+          expect(response.message.type).toBe('jargon_follow_up')
+          expect(response.message.text).toBeTruthy()
+
+          // Should be conversational, not the structured Summary + bullets format
+          expect(response.message.text).not.toMatch(/\*\*Summary:\*\*/)
+
+          // Should thread the response
+          expect(response.parent).toBe(userMessage.parentMessage)
+
+          // Should target the correct channel
+          expect(response.channels.map((c) => c.name)).toContain(directChannel.name)
+        },
+        testTimeout
+      )
+
+      it(
+        'responds to off-topic question with polite decline',
+        async () => {
+          const directChannel = conversation.channels.find((c) => c.name === `direct-agents-${userOptedIn._id}`)
+
+          const userMessage = {
+            _id: 'message123',
+            body: 'What time does the event end?',
+            parentMessage: 'parent456',
+            channels: [directChannel.name],
+            owner: userOptedIn._id
+          }
+
+          const conversationHistory = {
+            messages: [],
+            start: new Date(),
+            end: new Date()
+          }
+
+          const responses = await defaultAgentTypes.jargonFilterAgent.respond.call(
+            jargonFilterAgent,
+            conversationHistory,
+            userMessage
+          )
+
+          expect(responses).toHaveLength(1)
+          const response = responses[0]
+
+          expect(response.visible).toBe(true)
+          expect(response.messageType).toBe('json')
+          expect(response.message.type).toBe('jargon_follow_up')
+          expect(response.message.text).toContain('I can only help clarify jargon')
+
+          // Should thread the response
+          expect(response.parent).toBe(userMessage.parentMessage)
+
+          // Should target the correct channel
+          expect(response.channels.map((c) => c.name)).toContain(directChannel.name)
+        },
+        testTimeout
+      )
+
+      it(
+        'uses conversation history for context when answering',
+        async () => {
+          const directChannel = conversation.channels.find((c) => c.name === `direct-agents-${userOptedIn._id}`)
+
+          // Simulate previous clarification in history
+          const previousMessage = {
+            _id: 'parent456',
+            body: 'Previous clarification about SLO meaning Service Level Objective',
+            pseudonym: 'Jargon Filter Agent',
+            fromAgent: true,
+            channels: [directChannel.name],
+            createdAt: new Date(Date.now() - 2 * 60 * 1000)
+          }
+
+          const userMessage = {
+            _id: 'message123',
+            body: 'Can you give an example?',
+            parentMessage: 'parent456',
+            channels: [directChannel.name],
+            owner: userOptedIn._id
+          }
+
+          const conversationHistory = {
+            messages: [previousMessage],
+            start: new Date(Date.now() - 5 * 60 * 1000),
+            end: new Date()
+          }
+
+          const responses = await defaultAgentTypes.jargonFilterAgent.respond.call(
+            jargonFilterAgent,
+            conversationHistory,
+            userMessage
+          )
+
+          expect(responses).toHaveLength(1)
+          const response = responses[0]
+
+          expect(response.visible).toBe(true)
+          expect(response.message.text).toBeTruthy()
+          // The LLM should provide a contextual answer based on conversation history
+        },
+        testTimeout
+      )
     })
   })
 })


### PR DESCRIPTION
## What is in this PR?

Modifies the jargon filter agent to listen for incoming messages, and if they are replies to a jargon clarification, attempt to respond.

## Changes in the codebase

See above

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x] Test in conjunction with FE changes https://github.com/berkmancenter/nextspace/pull/76. See test steps there.



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
