### PR TITLE
feat: jargon filter seen terms memory and remove summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,8 @@
     "fast-xml-parser": ">=5.3.5",
     "basic-ftp": ">=5.2.0",
     "convict": ">=6.2.5",
-    "handlebars": ">=4.7.9"
+    "handlebars": ">=4.7.9",
+    "axios": "1.11.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "config": {

--- a/src/agents/jargonFilter/jargonFilter.ts
+++ b/src/agents/jargonFilter/jargonFilter.ts
@@ -35,8 +35,7 @@ export const JARGON_FILTER_SYSTEM_PROMPT = `You are an assistant monitoring a li
 
 **How to write the clarification:**
 - Cover all jargon found in the window in a single, consolidated response
-- Begin with a plain-language summary of what was just discussed in the transcript. Label it "**Summary:**" on its own line. Write it in first person as if you are the speaker (e.g. "This is an explanation of how our system handles issues") — never start with "The speaker said" or refer to the speaker in third person. Maximum two sentences — do not exceed this limit.
-- After the summary, write each jargon term as its own bullet point on a new line
+- Write each jargon term as its own bullet point on a new line
 - Bold the jargon term or phrase at the start of each bullet (e.g. **SLO** — ...)
 - Explain each term as if to a high school student with no background in the field — use everyday analogies and avoid assuming any prior knowledge
 - Be concise: one or two sentences per term is enough
@@ -50,7 +49,7 @@ Return a JSON object with the following fields:
 
 {{
   "jargonFound": boolean,
-  "text": "A plain-language summary followed by a bullet-point list clarifying each jargon term found (null if jargonFound is false). The summary must be labeled '**Summary:**' and separated from the bullets by \\n\\n. Each bullet must be on its own line separated by \\n. Example: **Summary:**\\n\\nThis is a discussion of how we set reliability targets and recover from outages.\\n\\n- **SLO** — A target for how reliable a system should be.\\n- **MTTR** — How long it takes to fix something after it breaks.",
+  "text": "A bullet-point list clarifying each jargon term found (null if jargonFound is false). Each bullet must be on its own line separated by \\n. Example: - **SLO** — A target for how reliable a system should be.\\n- **MTTR** — How long it takes to fix something after it breaks.",
   "sourceText": "Verbatim quote from the transcript that contains the jargon (null if jargonFound is false)",
   "terms": "Flat array of jargon term names explained in this response, matching exactly the bolded terms in the text field (null if jargonFound is false). Example: [\\"SLO\\", \\"MTTR\\"]"
 }}
@@ -72,7 +71,7 @@ const USER_TEMPLATE = `## Event Topic:
 ## Transcript:
 {transcript}
 
-Analyze the transcript above for technical jargon and return JSON only. The "text" field must begin with a "**Summary:**" section before the bullet points.`
+Analyze the transcript above for technical jargon and return JSON only.`
 
 // Interactive mode: Combined classification and answer
 export const JARGON_FOLLOW_UP_SYSTEM_PROMPT = `You are a helpful assistant that answers follow-up questions about technical jargon and terminology from an event.

--- a/src/agents/jargonFilter/jargonFilter.ts
+++ b/src/agents/jargonFilter/jargonFilter.ts
@@ -11,6 +11,7 @@ export type JargonFilterResponse = {
   type: 'jargon_clarification'
   text: string // the clarified text
   sourceText: string // original transcript excerpt
+  terms: string[] // flat list of jargon term names explained in this response
   transcriptWindow: {
     // Unix start and end times for the transcript window
     start: number
@@ -50,7 +51,8 @@ Return a JSON object with the following fields:
 {{
   "jargonFound": boolean,
   "text": "A plain-language summary followed by a bullet-point list clarifying each jargon term found (null if jargonFound is false). The summary must be labeled '**Summary:**' and separated from the bullets by \\n\\n. Each bullet must be on its own line separated by \\n. Example: **Summary:**\\n\\nThis is a discussion of how we set reliability targets and recover from outages.\\n\\n- **SLO** — A target for how reliable a system should be.\\n- **MTTR** — How long it takes to fix something after it breaks.",
-  "sourceText": "Verbatim quote from the transcript that contains the jargon (null if jargonFound is false)"
+  "sourceText": "Verbatim quote from the transcript that contains the jargon (null if jargonFound is false)",
+  "terms": "Flat array of jargon term names explained in this response, matching exactly the bolded terms in the text field (null if jargonFound is false). Example: [\\"SLO\\", \\"MTTR\\"]"
 }}
 
 Return ONLY raw JSON. No markdown, no backticks, no explanation.`
@@ -58,11 +60,14 @@ Return ONLY raw JSON. No markdown, no backticks, no explanation.`
 const jargonFilterSchema = z.object({
   jargonFound: z.boolean(),
   text: z.string().nullable(),
-  sourceText: z.string().nullable()
+  sourceText: z.string().nullable(),
+  terms: z.array(z.string()).nullable()
 })
 
 const USER_TEMPLATE = `## Event Topic:
 {topic}
+
+{seenTerms}
 
 ## Transcript:
 {transcript}
@@ -131,6 +136,7 @@ export default verify({
     system: [],
     user: [
       { name: 'topic', description: 'The event topic' },
+      { name: 'seenTerms', description: 'Already-explained terms to skip, or empty string if none' },
       { name: 'transcript', description: 'Transcript window to analyze for jargon' }
     ]
   },
@@ -237,18 +243,35 @@ export default verify({
     // Path A: Periodic trigger - existing proactive jargon detection
     const transcript = formatTranscript(conversationHistory.messages)
 
+    // Collect terms already explained in prior invocations from saved jargon messages
+    const priorMessages = (this.conversation.messages ?? []) as Array<{ fromAgent: boolean; body: unknown }>
+    const alreadyExplained: string[] = priorMessages
+      .filter((m) => m.fromAgent && (m.body as JargonFilterResponse)?.type === 'jargon_clarification')
+      .flatMap((m) => (m.body as JargonFilterResponse).terms ?? [])
+
+    const seenTermsCheck =
+      alreadyExplained.length > 0
+        ? `## Already Explained Terms:\nThe following terms have already been clarified earlier in this event. Do not explain them again:\n${alreadyExplained.map((t) => `- ${t}`).join('\n')}`
+        : ''
+
     const response = await getChatPromptResponse(
       llm,
       this.llmTemplates.system,
       this.llmTemplates.user,
       {
         topic: this.conversation.name,
+        seenTerms: seenTermsCheck,
         transcript
       },
       [], // no chat history needed, only the transcript
       jargonFilterSchema
     )
     if (!response.jargonFound) return []
+
+    if (!Array.isArray(response.terms) || response.terms.length === 0) {
+      logger.warn(`${this.name}: jargon found but LLM returned invalid or empty terms array — skipping response`)
+      return []
+    }
 
     // Find direct channels where this agent is a participant and the user has opted in.
     const directChannels = this.conversation.channels.filter(
@@ -274,6 +297,7 @@ export default verify({
       type: 'jargon_clarification',
       text: response.text!,
       sourceText: response.sourceText!,
+      terms: response.terms!,
       transcriptWindow: {
         start: conversationHistory.start.getTime(),
         end: conversationHistory.end.getTime()

--- a/tests/agents/jargonFilter/jargonFilter.agent.test.ts
+++ b/tests/agents/jargonFilter/jargonFilter.agent.test.ts
@@ -93,8 +93,8 @@ describe('jargon filter agent tests', () => {
         expect(response.messageType).toBe('json')
         expect(response.message.text).toBeTruthy()
 
-        // text must begin with a summary section followed by bullet points
-        expect(response.message.text).toMatch(/\*\*Summary:\*\*/)
+        // text contains bullet points but no summary section
+        expect(response.message.text).not.toMatch(/\*\*Summary:\*\*/)
         expect(response.message.text).toMatch(/- \*\*.+\*\*/)
 
         // sourceText is a verbatim quote from the transcript — assert it contains a known jargon term

--- a/tests/agents/jargonFilter/jargonFilter.agent.test.ts
+++ b/tests/agents/jargonFilter/jargonFilter.agent.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../utils/agentTestHelpers.js'
 import getConversationHistory from '../../../src/agents/helpers/getConversationHistory.js'
 import User from '../../../src/models/user.model/user.model.js'
-import { AgentMessageActions } from '../../../src/types/index.types.js'
+import { AgentMessageActions, IMessage } from '../../../src/types/index.types.js'
 
 jest.setTimeout(180000)
 
@@ -206,6 +206,62 @@ describe('jargon filter agent tests', () => {
             expect(participantIds).toContain(jargonFilterAgent._id.toString())
           }
         }
+      },
+      testTimeout
+    )
+  })
+
+  describe('seen terms memory', () => {
+    it(
+      'includes a terms array in the response listing each jargon term explained',
+      async () => {
+        await loadTestTranscript(conversation, jargonTranscript)
+
+        const conversationHistory = getConversationHistory(conversation.messages, {
+          channels: ['transcript'],
+          endTime: new Date(startTime.getTime() + 5 * 60 * 1000)
+        })
+
+        const responses = await defaultAgentTypes.jargonFilterAgent.respond.call(jargonFilterAgent, conversationHistory)
+        expect(responses.length).toBeGreaterThan(0)
+
+        const { terms } = responses[0].message
+        expect(Array.isArray(terms)).toBe(true)
+        expect(terms.length).toBeGreaterThan(0)
+        terms.forEach((term) => expect(typeof term).toBe('string'))
+      },
+      testTimeout
+    )
+
+    it(
+      'skips terms already explained in a previous window',
+      async () => {
+        await loadTestTranscript(conversation, jargonTranscript)
+
+        const conversationHistory = getConversationHistory(conversation.messages, {
+          channels: ['transcript'],
+          endTime: new Date(startTime.getTime() + 5 * 60 * 1000)
+        })
+
+        // First invocation — agent sees jargon and clarifies it
+        const firstResponses = await defaultAgentTypes.jargonFilterAgent.respond.call(jargonFilterAgent, conversationHistory)
+        expect(firstResponses.length).toBeGreaterThan(0)
+
+        // Simulate the agent's response being saved to the conversation so the next invocation can see it
+        const firstMessage = firstResponses[0].message
+        conversation.messages.push({
+          body: firstMessage,
+          bodyType: 'json',
+          fromAgent: true,
+          channels: firstResponses[0].channels.map((c) => c.name),
+          pseudonym: jargonFilterAgent.pseudonyms[0].pseudonym,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        } as unknown as IMessage)
+
+        // Second invocation with the same transcript window — all terms already seen
+        const secondResponses = await defaultAgentTypes.jargonFilterAgent.respond.call(jargonFilterAgent, conversationHistory)
+        expect(secondResponses).toHaveLength(0)
       },
       testTimeout
     )


### PR DESCRIPTION
## What is in this PR?

Two fixes for the jargon filter agent:

1. The agent was re-explaining the same jargon terms when a speaker repeated them throughout an event. It now tracks previously explained terms and skips them on subsequent invocations.
2. Removes the Summary section from jargon clarification messages (it was adding noise without much value).

Also pins axios to 1.11.0 via yarn resolutions. Versions 1.14.1 and 0.30.4 were found to be compromised (axios/axios#10604 — maintainer accounts were breached and malicious versions were published that drop a remote access trojan). Axios is a transitive dependency here, so this pins it across all dependents.

## Changes in the codebase

- Agent now returns a `terms` array in each response listing the explained term names
- Previously explained terms are passed to the LLM as context to skip on subsequent invocations
- Added validation that the LLM returns a well-formed `terms` array before posting a response
- Removed the Summary section from jargon clarification messages
- Pinned `axios` to `1.11.0` in `resolutions`

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

Set up an event with a jargon-heavy transcript — the test transcript in `tests/utils/agentTestHelpers.ts` works well. Load it and let the jargon filter run across multiple time windows.

Then verify:
- [ ] Jargon terms explained in an earlier time window are not re-explained when the same term appears again later in the transcript
- [ ] New terms not yet explained are still caught and clarified
- [ ] Clarification messages have no Summary section — just the bullet list of terms

## Additional information

The axios pin is a precaution — we're currently on 1.11.0 which is safe. The resolutions entry prevents any future `yarn upgrade` from pulling in a compromised version.