### PR TITLE
feat: support tool calling and structured output with Claude

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
     "validator": "^13.12.0",
     "winston": "^3.17.0",
     "xss-clean": "^0.1.4",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/src/agents/helpers/claudeHandler.ts
+++ b/src/agents/helpers/claudeHandler.ts
@@ -27,20 +27,28 @@ export function buildBedrockClaudePayload({
   systemPrompt,
   userMessages,
   maxTokens = 1024,
-  temperature = 0
+  temperature = 0,
+  tools
 }: {
   systemPrompt: string
   userMessages: Record<string, unknown>[]
   maxTokens?: number
   temperature?: number
+  tools?: unknown[]
 }) {
-  return {
+  const payload: Record<string, unknown> = {
     system: systemPrompt,
     anthropic_version: 'bedrock-2023-05-31',
     max_tokens: maxTokens,
     temperature,
     messages: userMessages
   }
+
+  if (tools && tools.length > 0) {
+    payload.tools = tools
+  }
+
+  return payload
 }
 
 // Transform standard LLM payload to Bedrock Claude format if needed
@@ -73,35 +81,52 @@ export function transformPayloadForClaude(bodyContent: unknown, defaultLLMModel:
     throw new Error('User message content is empty. Bedrock Claude requires a non-empty user message.')
   }
 
-  // For Claude models, remove any structured output instructions from the system prompt
-  // This prevents tool calling attempts that might cause issues
-  let cleanedSystemPrompt = systemPrompt
-  if (useClaudeFormat) {
-    // Remove common structured output patterns
-    cleanedSystemPrompt = systemPrompt
-      .replace(/You must respond with a JSON object that matches the following schema:/gi, '')
-      .replace(/The response must be a valid JSON object with the following structure:/gi, '')
-      .replace(/Return your response as a JSON object with the following format:/gi, '')
-      .replace(/Use the following JSON schema for your response:/gi, '')
-      .replace(/```json\n[\s\S]*?\n```/g, '') // Remove JSON schema blocks
-      .replace(/```\n[\s\S]*?\n```/g, '') // Remove any other code blocks
-      .trim()
+  // Extract maxTokens - check both snake_case (Bedrock API format) and camelCase (LangChain format)
+  let maxTokens = 1024 // Default
+  if (isObj) {
+    const body = bodyContent as Record<string, unknown>
+    if (typeof body.max_tokens === 'number') {
+      maxTokens = body.max_tokens
+    } else if (typeof body.maxTokens === 'number') {
+      maxTokens = body.maxTokens
+    }
   }
-
-  const maxTokens =
-    isObj && typeof (bodyContent as Record<string, unknown>).max_tokens === 'number'
-      ? ((bodyContent as Record<string, unknown>).max_tokens as number)
-      : 1024
   const temperature =
     isObj && typeof (bodyContent as Record<string, unknown>).temperature === 'number'
       ? ((bodyContent as Record<string, unknown>).temperature as number)
       : 0
 
+  // Extract tools if present
+  const tools =
+    isObj && Array.isArray((bodyContent as Record<string, unknown>).tools)
+      ? ((bodyContent as Record<string, unknown>).tools as unknown[])
+      : undefined
+
+  // Deduplicate tool_use blocks in messages to work around LangGraph bug
+  // where tool_use blocks can be duplicated in message history
+  const deduplicatedMessages = messagesArr.map((msg) => {
+    if (Array.isArray(msg.content)) {
+      const toolUseIds = new Set<string>()
+      const deduplicatedContent = msg.content.filter((block) => {
+        if (block.type === 'tool_use') {
+          if (toolUseIds.has(block.id)) {
+            return false
+          }
+          toolUseIds.add(block.id)
+        }
+        return true
+      })
+      return { ...msg, content: deduplicatedContent }
+    }
+    return msg
+  })
+
   return buildBedrockClaudePayload({
-    systemPrompt: cleanedSystemPrompt,
-    userMessages: messagesArr,
+    systemPrompt,
+    userMessages: deduplicatedMessages,
     maxTokens,
-    temperature
+    temperature,
+    tools
   })
 }
 

--- a/src/agents/helpers/llmChain.ts
+++ b/src/agents/helpers/llmChain.ts
@@ -1,8 +1,9 @@
 import { ChatPromptTemplate, PromptTemplate } from '@langchain/core/prompts'
 // import { ConsoleCallbackHandler } from 'langchain/callbacks'
-import { StringOutputParser, StructuredOutputParser } from '@langchain/core/output_parsers'
+import { StringOutputParser } from '@langchain/core/output_parsers'
 import { RunnableSequence } from '@langchain/core/runnables'
 import { z } from 'zod'
+import { zodToJsonSchema } from 'zod-to-json-schema'
 import logger from '../../config/logger.js'
 import rag from './rag.js'
 
@@ -133,15 +134,18 @@ function getStructuredResponseChain(llm, prompt, responseFormatSchema) {
   // Otherwise, use the structured schema as-is
   const { shape } = responseFormatSchema
   const keys = Object.keys(shape)
-
-  let responseFormatSchemaNonStructured
   let arrayKey
-
   if (keys.length === 1 && shape[keys[0]] instanceof z.ZodArray) {
     ;[arrayKey] = keys
-    responseFormatSchemaNonStructured = shape[keys[0]]
-  } else {
-    responseFormatSchemaNonStructured = responseFormatSchema
+  }
+
+  // Convert Zod schema to JSON Schema and ensure it has type: 'object' for Bedrock compatibility
+  // Always use the original responseFormatSchema (not unwrapped) for tool definition
+  // because Claude requires the tool's input_schema to be type: 'object'
+  const jsonSchema = zodToJsonSchema(responseFormatSchema)
+  const parametersSchema = {
+    ...(typeof jsonSchema === 'object' && jsonSchema !== null ? jsonSchema : {}),
+    type: 'object'
   }
 
   const toolSchema = {
@@ -149,34 +153,39 @@ function getStructuredResponseChain(llm, prompt, responseFormatSchema) {
     function: {
       name: 'structured_response',
       description: 'Respond with structured data',
-      parameters: responseFormatSchemaNonStructured
+      parameters: parametersSchema
     }
   }
-
-  const parser = StructuredOutputParser.fromZodSchema(responseFormatSchemaNonStructured)
 
   // BedrockChat (@langchain/community) has a broken withStructuredOutput implementation in LangChain 1.0.
   // The base class checks for AIMessageChunk, but invoke() returns AIMessage, causing "Input is not an AIMessageChunk" error.
   // The modern replacement, ChatBedrockConverse (@langchain/aws), properly implements structured output.
   // For now, we use bindTools + manual parsing for BedrockChat/Anthropic models.
-  return shouldUseStructuredOutput(llm)
-    ? prompt.pipe(llm.withStructuredOutput(responseFormatSchema))
-    : prompt
-        .pipe(llm.bindTools([toolSchema]))
-        .pipe(new StringOutputParser())
-        .pipe(async (text: string) =>
-          text
-            .replace(/^```(?:json)?\s*/i, '')
-            .replace(/\s*```\s*$/, '')
-            .trim()
-        )
-        .pipe(parser)
-        .pipe(async (parsed) => {
-          if (Array.isArray(parsed) && arrayKey) {
-            return { [arrayKey]: parsed }
-          }
-          return parsed
-        })
+  if (shouldUseStructuredOutput(llm)) {
+    return prompt.pipe(llm.withStructuredOutput(responseFormatSchema))
+  }
+
+  // For Bedrock/Anthropic: use bindTools and extract tool call arguments
+  // This matches LangChain's withStructuredOutput behavior
+  return prompt.pipe(llm.bindTools([toolSchema])).pipe(async (message) => {
+    // Extract tool call from AIMessage
+    const aiMsg = message as { tool_calls?: Array<{ name: string; args: unknown; id?: string }> }
+
+    if (!aiMsg.tool_calls || aiMsg.tool_calls.length === 0) {
+      throw new Error('No tool calls found in the response.')
+    }
+
+    const structuredResponseCall = aiMsg.tool_calls.find((tc) => tc.name === 'structured_response')
+    if (!structuredResponseCall) {
+      throw new Error('No structured_response tool call found.')
+    }
+
+    // If we have an arrayKey, wrap the result
+    if (Array.isArray(structuredResponseCall.args) && arrayKey) {
+      return { [arrayKey]: structuredResponseCall.args }
+    }
+    return structuredResponseCall.args
+  })
 }
 
 /**

--- a/src/agents/jargonFilter/jargonFilter.ts
+++ b/src/agents/jargonFilter/jargonFilter.ts
@@ -240,6 +240,11 @@ export default verify({
     }
 
     // Path A: Periodic trigger - existing proactive jargon detection
+    // Return early if no messages in the conversation history window
+    if (!conversationHistory.messages || conversationHistory.messages.length === 0) {
+      return []
+    }
+
     const transcript = formatTranscript(conversationHistory.messages)
 
     // Collect terms already explained in prior invocations from saved jargon messages

--- a/src/agents/jargonFilter/jargonFilter.ts
+++ b/src/agents/jargonFilter/jargonFilter.ts
@@ -60,7 +60,7 @@ const jargonFilterSchema = z.object({
   jargonFound: z.boolean(),
   text: z.string().nullable(),
   sourceText: z.string().nullable(),
-  terms: z.array(z.string()).nullable().optional()
+  terms: z.array(z.string()).nullable()
 })
 
 const USER_TEMPLATE = `## Event Topic:
@@ -118,7 +118,7 @@ Determine if this is about jargon/terminology and answer if so. Return JSON only
 
 const jargonFollowUpSchema = z.object({
   isJargonRelated: z.boolean(),
-  text: z.string().optional()
+  text: z.string().nullable()
 })
 
 export default verify({

--- a/tests/agents/helpers/claudeHandler.test.ts
+++ b/tests/agents/helpers/claudeHandler.test.ts
@@ -70,6 +70,48 @@ describe('claudeHandler', () => {
       expect(result.max_tokens).toBe(1024)
       expect(result.temperature).toBe(0)
     })
+
+    it('should include tools when provided', () => {
+      const tools = [
+        {
+          name: 'get_weather',
+          description: 'Get weather information',
+          input_schema: {
+            type: 'object',
+            properties: {
+              location: { type: 'string' }
+            }
+          }
+        }
+      ]
+
+      const result = buildBedrockClaudePayload({
+        systemPrompt: 'You are a helpful assistant',
+        userMessages: [{ role: 'user', content: 'Hello world' }],
+        tools
+      })
+
+      expect(result.tools).toEqual(tools)
+    })
+
+    it('should not include tools field when tools array is empty', () => {
+      const result = buildBedrockClaudePayload({
+        systemPrompt: 'You are a helpful assistant',
+        userMessages: [{ role: 'user', content: 'Hello world' }],
+        tools: []
+      })
+
+      expect(result.tools).toBeUndefined()
+    })
+
+    it('should not include tools field when tools is not provided', () => {
+      const result = buildBedrockClaudePayload({
+        systemPrompt: 'You are a helpful assistant',
+        userMessages: [{ role: 'user', content: 'Hello world' }]
+      })
+
+      expect(result.tools).toBeUndefined()
+    })
   })
 
   describe('transformPayloadForClaude', () => {
@@ -137,6 +179,204 @@ describe('claudeHandler', () => {
       expect(() => {
         transformPayloadForClaude(inputPayload, 'anthropic.claude-3-5-sonnet-20240620-v1:0', 'bedrock')
       }).toThrow('User message content is empty. Bedrock Claude requires a non-empty user message.')
+    })
+
+    it('should extract maxTokens from camelCase format', () => {
+      const inputPayload = {
+        system: 'You are a helpful assistant',
+        messages: [{ role: 'user', content: 'Hello world' }],
+        maxTokens: 3000
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = transformPayloadForClaude(inputPayload, 'anthropic.claude-3-5-sonnet-20240620-v1:0', 'bedrock') as any
+
+      expect(result.max_tokens).toBe(3000)
+    })
+
+    it('should extract maxTokens from snake_case format', () => {
+      const inputPayload = {
+        system: 'You are a helpful assistant',
+        messages: [{ role: 'user', content: 'Hello world' }],
+        max_tokens: 4000
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = transformPayloadForClaude(inputPayload, 'anthropic.claude-3-5-sonnet-20240620-v1:0', 'bedrock') as any
+
+      expect(result.max_tokens).toBe(4000)
+    })
+
+    it('should prioritize snake_case max_tokens over camelCase maxTokens', () => {
+      const inputPayload = {
+        system: 'You are a helpful assistant',
+        messages: [{ role: 'user', content: 'Hello world' }],
+        max_tokens: 5000,
+        maxTokens: 3000
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = transformPayloadForClaude(inputPayload, 'anthropic.claude-3-5-sonnet-20240620-v1:0', 'bedrock') as any
+
+      expect(result.max_tokens).toBe(5000)
+    })
+
+    it('should use default maxTokens when not provided', () => {
+      const inputPayload = {
+        system: 'You are a helpful assistant',
+        messages: [{ role: 'user', content: 'Hello world' }]
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = transformPayloadForClaude(inputPayload, 'anthropic.claude-3-5-sonnet-20240620-v1:0', 'bedrock') as any
+
+      expect(result.max_tokens).toBe(1024)
+    })
+
+    it('should include tools when provided', () => {
+      const tools = [
+        {
+          name: 'get_weather',
+          description: 'Get weather information',
+          input_schema: {
+            type: 'object',
+            properties: {
+              location: { type: 'string' }
+            }
+          }
+        }
+      ]
+
+      const inputPayload = {
+        system: 'You are a helpful assistant',
+        messages: [{ role: 'user', content: 'Hello world' }],
+        tools
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = transformPayloadForClaude(inputPayload, 'anthropic.claude-3-5-sonnet-20240620-v1:0', 'bedrock') as any
+
+      expect(result.tools).toEqual(tools)
+    })
+
+    it('should not include tools when not provided', () => {
+      const inputPayload = {
+        system: 'You are a helpful assistant',
+        messages: [{ role: 'user', content: 'Hello world' }]
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = transformPayloadForClaude(inputPayload, 'anthropic.claude-3-5-sonnet-20240620-v1:0', 'bedrock') as any
+
+      expect(result.tools).toBeUndefined()
+    })
+
+    it('should deduplicate tool_use blocks with same IDs', () => {
+      const inputPayload = {
+        system: 'You are a helpful assistant',
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'text', text: 'Let me help with that' },
+              { type: 'tool_use', id: 'tool_123', name: 'get_weather', input: { location: 'NYC' } },
+              { type: 'tool_use', id: 'tool_123', name: 'get_weather', input: { location: 'NYC' } }, // duplicate
+              { type: 'tool_use', id: 'tool_456', name: 'get_time', input: {} }
+            ]
+          }
+        ]
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = transformPayloadForClaude(inputPayload, 'anthropic.claude-3-5-sonnet-20240620-v1:0', 'bedrock') as any
+
+      expect(result.messages[0].content).toHaveLength(3)
+      expect(result.messages[0].content[0]).toEqual({ type: 'text', text: 'Let me help with that' })
+      expect(result.messages[0].content[1]).toEqual({
+        type: 'tool_use',
+        id: 'tool_123',
+        name: 'get_weather',
+        input: { location: 'NYC' }
+      })
+      expect(result.messages[0].content[2]).toEqual({ type: 'tool_use', id: 'tool_456', name: 'get_time', input: {} })
+    })
+
+    it('should preserve non-tool_use content blocks', () => {
+      const inputPayload = {
+        system: 'You are a helpful assistant',
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'text', text: 'First text' },
+              { type: 'image', source: { type: 'base64', data: 'abc123' } },
+              { type: 'tool_use', id: 'tool_123', name: 'test', input: {} },
+              { type: 'text', text: 'Second text' }
+            ]
+          }
+        ]
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = transformPayloadForClaude(inputPayload, 'anthropic.claude-3-5-sonnet-20240620-v1:0', 'bedrock') as any
+
+      expect(result.messages[0].content).toHaveLength(4)
+      expect(result.messages[0].content[0].type).toBe('text')
+      expect(result.messages[0].content[1].type).toBe('image')
+      expect(result.messages[0].content[2].type).toBe('tool_use')
+      expect(result.messages[0].content[3].type).toBe('text')
+    })
+
+    it('should handle messages with string content (no deduplication needed)', () => {
+      const inputPayload = {
+        system: 'You are a helpful assistant',
+        messages: [{ role: 'user', content: 'Simple string message' }]
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = transformPayloadForClaude(inputPayload, 'anthropic.claude-3-5-sonnet-20240620-v1:0', 'bedrock') as any
+
+      expect(result.messages[0].content).toBe('Simple string message')
+    })
+
+    it('should handle multiple messages with duplicates in different messages', () => {
+      const inputPayload = {
+        system: 'You are a helpful assistant',
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'tool_123', name: 'test1', input: {} },
+              { type: 'tool_use', id: 'tool_123', name: 'test1', input: {} }
+            ]
+          },
+          {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'tool_123', content: 'result' }]
+          },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'tool_456', name: 'test2', input: {} },
+              { type: 'tool_use', id: 'tool_456', name: 'test2', input: {} }
+            ]
+          }
+        ]
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = transformPayloadForClaude(inputPayload, 'anthropic.claude-3-5-sonnet-20240620-v1:0', 'bedrock') as any
+
+      // First message should have only one tool_use (duplicate removed)
+      expect(result.messages[0].content).toHaveLength(1)
+      expect(result.messages[0].content[0].id).toBe('tool_123')
+
+      // Second message is unchanged
+      expect(result.messages[1].content).toHaveLength(1)
+
+      // Third message should have only one tool_use (duplicate removed)
+      expect(result.messages[2].content).toHaveLength(1)
+      expect(result.messages[2].content[0].id).toBe('tool_456')
     })
   })
 })

--- a/tests/agents/helpers/professionalismValidator.test.ts
+++ b/tests/agents/helpers/professionalismValidator.test.ts
@@ -180,7 +180,7 @@ describe('professionalismValidator', () => {
 
     it('should allow references to team dynamics', async () => {
       const message =
-        "The relationship between your sales and engineering teams seems... tense. Anyone want to surface what's really going on?"
+        "I'm noticing your sales and engineering teams have different priorities for the roadmap. Let's get both perspectives on the table - what's the disconnect?"
       const result = await validateProfessionalism(
         llm,
         message,

--- a/tests/agents/jargonFilter/jargonFilter.agent.test.ts
+++ b/tests/agents/jargonFilter/jargonFilter.agent.test.ts
@@ -134,7 +134,7 @@ describe('jargon filter agent tests', () => {
         // messages in conversation.messages and produce a response. It should not.
         const emptyHistory = getConversationHistory(conversation.messages, {
           channels: ['transcript'],
-          timeWindow: 0,
+          timeWindow: 120,
           endTime: startTime // before any messages were loaded
         })
 
@@ -213,16 +213,19 @@ describe('jargon filter agent tests', () => {
 
   describe('malformed LLM output handling', () => {
     it.each([
-      ['missing', '{"jargonFound":true,"text":"- **SLO** — A target for reliability.","sourceText":"We need to hit our SLO."}'],
-      ['empty array', '{"jargonFound":true,"text":"- **SLO** — A target for reliability.","sourceText":"We need to hit our SLO.","terms":[]}']
-    ])(
-      'jargon schema accepts a response where terms is %s',
-      (_label, jsonStr) => {
-        const parsed = JSON.parse(jsonStr)
-        expect(parsed.jargonFound).toBe(true)
-        expect(parsed.terms == null || Array.isArray(parsed.terms)).toBe(true)
-      }
-    )
+      [
+        'missing',
+        '{"jargonFound":true,"text":"- **SLO** — A target for reliability.","sourceText":"We need to hit our SLO."}'
+      ],
+      [
+        'empty array',
+        '{"jargonFound":true,"text":"- **SLO** — A target for reliability.","sourceText":"We need to hit our SLO.","terms":[]}'
+      ]
+    ])('jargon schema accepts a response where terms is %s', (_label, jsonStr) => {
+      const parsed = JSON.parse(jsonStr)
+      expect(parsed.jargonFound).toBe(true)
+      expect(parsed.terms == null || Array.isArray(parsed.terms)).toBe(true)
+    })
   })
 
   describe('seen terms memory', () => {
@@ -274,7 +277,10 @@ describe('jargon filter agent tests', () => {
         } as unknown as IMessage)
 
         // Second invocation with the same transcript window — all terms already seen
-        const secondResponses = await defaultAgentTypes.jargonFilterAgent.respond.call(jargonFilterAgent, conversationHistory)
+        const secondResponses = await defaultAgentTypes.jargonFilterAgent.respond.call(
+          jargonFilterAgent,
+          conversationHistory
+        )
         expect(secondResponses).toHaveLength(0)
       },
       testTimeout

--- a/yarn.lock
+++ b/yarn.lock
@@ -3506,7 +3506,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
   integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
-axios@^1.11.0, axios@^1.8.2:
+axios@1.11.0, axios@^1.11.0, axios@^1.8.2:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.11.0.tgz#c2ec219e35e414c025b2095e8b8280278478fdb6"
   integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==
@@ -11579,6 +11579,11 @@ zod-to-json-schema@^3.24.1:
   version "3.24.6"
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz#5920f020c4d2647edfbb954fa036082b92c9e12d"
   integrity sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==
+
+zod-to-json-schema@^3.25.2:
+  version "3.25.2"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz#3fa799a7badd554541472fb65843fdc460b2e5aa"
+  integrity sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==
 
 zod-validation-error@^3.5.3:
   version "3.5.3"


### PR DESCRIPTION


## What is in this PR?

While enabling support for ReAct agents for an upcoming PR, I discovered that we were not passing tools to Claude in the request payloads. Fixing this allowed us to use tool calling for output parsing and remove the custom code to strip code fences

## Changes in the codebase
-  Remove prompt format cleaning and pass structured_output tool to Claude for JSON responses
- Deduplicate tool_use ids in Claude responses (workaround Langchain BedrockChat issue)
- Pass maxTokens property of agents in Claude payload
- Fix jargon filter output parsing not working with OpenAI (does not allow use of both nullable and optional in response format schema)
- Fix unrelated intermittent test failures
   - jargon filter return early if no new conversation history
   - make professionalism validator team dynamics test more robust

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x] Mostly just CI verification (I ran this against ChatGPT as well, see [CI run](https://github.com/berkmancenter/llm_engine/actions/runs/24109990319))
- [x] Could create an EAP Proactive conversation with jargon filtering preference set and make sure responses are still formatted and displayed properly

## Additional information

We should still upgrade to `ChatBedrockConverse`, but this should hopefully give us more stable output parsing until we do...
