### PR TITLE
fix: proactive agents should not contribute at the same time

### DIFF
--- a/src/agents/helpers/interventionHandler.ts
+++ b/src/agents/helpers/interventionHandler.ts
@@ -6,6 +6,7 @@ import { getChatPromptResponse } from './llmChain.js'
 
 import config from '../../config/config.js'
 import logger from '../../config/logger.js'
+import Message from '../../models/message.model.js'
 import { InterventionAnalysis, InterventionType } from './interventionTypes.js'
 import { buildSystemPromptWithPersonality, getInterventionExamples } from './agentPersonality.js'
 import validateProfessionalism from './professionalismValidator.js'
@@ -146,7 +147,8 @@ export async function detectInterventionOpportunity(
   baseSystemPrompt: string,
   schema: z.ZodSchema,
   privateConversationHistory?: ConversationHistory | null,
-  moderatorConversationHistory?: ConversationHistory
+  moderatorConversationHistory?: ConversationHistory,
+  sharedChatChannel: string = 'chat'
 ): Promise<InterventionAnalysis | null> {
   // Use conversationHistory.end as "now" to maintain consistent time simulation
   // This allows tests and the system to reason about specific moments in time
@@ -246,6 +248,21 @@ export async function detectInterventionOpportunity(
       )
       return null
     }
+  }
+
+  // Re-check with fresh DB state to handle concurrent agents in a cluster.
+  // Shrinks the race window from LLM latency (seconds) to milliseconds.
+  const freshRecentIntervention = await Message.findOne({
+    conversation: this.conversation._id,
+    fromAgent: true,
+    visible: true,
+    channels: sharedChatChannel,
+    createdAt: { $gte: new Date(now - minInterval) }
+  })
+
+  if (freshRecentIntervention) {
+    logger.info(`Agent ${this.name} dropping intervention: another agent posted during LLM call`)
+    return null
   }
 
   return analysis as InterventionAnalysis


### PR DESCRIPTION

## What is in this PR?

The two proactive agents are supposed to take into account whether *any* agent has posted in the group chat when rate limiting. In practice, this did not always work, because the agents often evaluated concurrently, and the initial database check would not show the other's intervention because it was in progress. This fix rechecks after the LLM call and discards the LLM response if another agent has intervened during the time since the precheck.

## Changes in the codebase

See above

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [ ] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Create an EAP Proactive conversation with default 3-5 minute contribution interval (I tested with 5 and saw one intervention being discarded on the third interval, right at the end of a 15 minute transcript)
- [ ] Test it against at least 15 minutes of transcript and verify agent messages to group chat are spaced out as expected (i.e. no two in the same minute). Can also check the log to see if an intervention was discarded b/c of this concurrency issue

## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
