### PR TITLE
add voice assistant

### DIFF
--- a/src/agents/eventAssistant/eventAssistantPlus.ts
+++ b/src/agents/eventAssistant/eventAssistantPlus.ts
@@ -130,9 +130,10 @@ export default verify({
       }
     }
 
+    const messageText = userMessage?.bodyType === 'json' ? userMessage?.body?.text : userMessage?.body
     if (
       userMessage?.channels?.includes('chat') &&
-      !userMessage?.body.toLowerCase().includes(`@${this.agentConfig.botName}`.toLowerCase())
+      !messageText?.toLowerCase().includes(`@${this.agentConfig.botName}`.toLowerCase())
     ) {
       // regular chat message, no need to process
       return {

--- a/src/agents/eventAssistant/eventQuestionHandler.ts
+++ b/src/agents/eventAssistant/eventQuestionHandler.ts
@@ -345,13 +345,12 @@ ${chunks}`
   }
 
   // Check if visual generation should happen (either forced via /visual or user preference)
-  const user = await User.findById(userMessage.owner)
   const forceVisual = options?.forceVisual === true
 
-  // Only use visual preference is this is on a user's private channel, not e.g. group chat
+  // Only use visual preference on a user's private channel, not e.g. group chat
   const isDirectChannel = responseChannels.some((channel: IChannel) => channel.direct)
 
-  if (forceVisual || (user?.preferences?.visualResponse && isDirectChannel)) {
+  if (forceVisual || isDirectChannel) {
     let shouldGenerate = false
 
     if (forceVisual) {
@@ -360,9 +359,13 @@ ${chunks}`
       // User explicitly requested visual, so respect their intent
       shouldGenerate = llmResponse !== cannotRespond
     } else {
-      logger.debug(`User ${user!._id} has visual response preference enabled`)
-      // Classify if this question/answer would benefit from a visual
-      shouldGenerate = await shouldGenerateVisual.call(this, question, classification, llmResponse, templates)
+      // isDirectChannel — only now do we need the user's preferences
+      const user = await User.findById(userMessage.owner)
+      if (user?.preferences?.visualResponse) {
+        logger.debug(`User ${user._id} has visual response preference enabled`)
+        // Classify if this question/answer would benefit from a visual
+        shouldGenerate = await shouldGenerateVisual.call(this, question, classification, llmResponse, templates)
+      }
     }
 
     if (shouldGenerate) {

--- a/src/agents/eventAssistant/voiceAssistant.ts
+++ b/src/agents/eventAssistant/voiceAssistant.ts
@@ -50,6 +50,17 @@ export default verify({
   ragCollectionName: undefined,
   useTranscriptRAGCollection: true,
   defaultConversationHistorySettings: { count: 10, channels: ['transcript'] },
+  parseOutput: (msg) => {
+    if (msg.bodyType !== 'json' || msg.body?.source !== 'voice') {
+      return msg
+    }
+    const translatedMsg = msg.toObject()
+    const sourceMessage = msg.body.sourceMessage as string
+    const truncated = sourceMessage.length > 25 ? `${sourceMessage.slice(0, 25)}...` : sourceMessage
+    translatedMsg.bodyType = 'text'
+    translatedMsg.body = `🔊 "${truncated}"\n${msg.body.text}`
+    return translatedMsg
+  },
 
   async initialize() {
     return true

--- a/src/agents/eventAssistant/voiceAssistant.ts
+++ b/src/agents/eventAssistant/voiceAssistant.ts
@@ -1,0 +1,144 @@
+import * as fuzzball from 'fuzzball'
+import verify from '../helpers/verify.js'
+import { AgentMessageActions, ConversationHistory } from '../../types/index.types.js'
+import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
+import { eventAssistantLLMTemplates, eventAssistantLlmTemplateVars, answerQuestion } from './eventQuestionHandler.js'
+import { extractMessageText } from '../helpers/slashCommandParser.js'
+import logger from '../../config/logger.js'
+
+const heyMatchThreshold = 85
+const nameMatchThreshold = 70
+
+function matchHeyDirective(text: string, botName: string): { matched: boolean; question: string } {
+  // Split and scan all consecutive word pairs for "hey <botName>" anywhere in the message
+  const words = text.trim().split(/\s+/)
+  if (words.length < 2) return { matched: false, question: '' }
+
+  for (let i = 0; i < words.length - 1; i++) {
+    const heyToken = words[i].replace(/[,!.]+$/, '')
+    const nameToken = words[i + 1].replace(/[,!.]+$/, '').toLowerCase()
+
+    const heyScore = fuzzball.ratio(heyToken.toLowerCase(), 'hey')
+    const nameScore = fuzzball.ratio(nameToken, botName.toLowerCase())
+
+    if (heyScore >= heyMatchThreshold && nameScore >= nameMatchThreshold) {
+      const extracted = words
+        .slice(i + 2)
+        .join(' ')
+        .trim()
+      const question = extracted.charAt(0).toUpperCase() + extracted.slice(1)
+      return { matched: true, question }
+    }
+  }
+
+  return { matched: false, question: '' }
+}
+
+export default verify({
+  name: 'Voice Assistant',
+  description:
+    'Listens for voice activations on the transcript channel and answers questions about the event in the group chat',
+  priority: 100,
+  maxTokens: 2000,
+  defaultTriggers: {
+    perMessage: { channels: ['transcript'] }
+  },
+  llmTemplateVars: eventAssistantLlmTemplateVars,
+  defaultLLMTemplates: eventAssistantLLMTemplates,
+  defaultLLMPlatform,
+  defaultLLMModel,
+  ragCollectionName: undefined,
+  useTranscriptRAGCollection: true,
+  defaultConversationHistorySettings: { count: 10, channels: ['transcript'] },
+
+  async initialize() {
+    return true
+  },
+
+  async evaluate(userMessage) {
+    return { userMessage, action: AgentMessageActions.CONTRIBUTE, userContributionVisible: true, suggestion: undefined }
+  },
+
+  async respond(conversationHistory: ConversationHistory, userMessage) {
+    const chatChannel = this.conversation.channels.find((channel) => channel.name === 'chat')
+    if (!chatChannel) return []
+
+    const messageText = extractMessageText(userMessage)
+    const botName = this.agentConfig.botName as string
+
+    const { matched, question } = matchHeyDirective(messageText, botName)
+
+    let questionText
+
+    if (matched && question) {
+      // "hey botName <question>" - answer immediately
+      logger.debug(`Voice trigger matched with inline question: "${question}"`)
+      questionText = question
+    } else if (matched && !question) {
+      // bare "hey botName" - wait for next message
+      logger.debug(`Voice trigger matched (bare), waiting for next message`)
+    } else if (!matched) {
+      // No trigger in current message - check if the previous transcript message was a bare "hey [botName]"
+      const { messages } = conversationHistory
+      if (messages.length > 0) {
+        const prevMessage = messages[messages.length - 1]
+        const prevText = extractMessageText(prevMessage)
+        const prev = matchHeyDirective(prevText, botName)
+        if (prev.matched && !prev.question) {
+          // Previous transcript message was a bare "hey botName" - treat current as the question
+          logger.debug(`Voice trigger processing deferred question: "${messageText}"`)
+          questionText = messageText
+        }
+      }
+    }
+
+    if (!questionText) return []
+
+    // Pass to answerQuestion with modified body and empty history - conversationHistory here contains
+    // transcript messages, but answerQuestion expects chat/DM history; transcript is handled internally via RAG
+    logger.debug(`Voice assistant answering question: "${questionText}"`)
+    const questionMessage = { ...userMessage, body: questionText }
+    const responses = await answerQuestion.call(this, questionMessage, { messages: [] })
+
+    return responses.map((r) => ({
+      ...r,
+      channels: [chatChannel],
+      parent: undefined,
+      message: {
+        ...r.message,
+        source: 'voice',
+        sourceMessage: questionText,
+        sourcePseudonym: userMessage.pseudonym
+      }
+    }))
+  },
+
+  async start() {
+    return true
+  },
+
+  async stop() {
+    return true
+  },
+
+  async introduce() {
+    return []
+  },
+  formatTraceInput(conversationHistory, userMessage) {
+    return userMessage?.body
+  },
+
+  formatTraceOutput(responses) {
+    return responses[0]?.message
+  },
+
+  getTraceMetadata(conversationHistory, userMessage, responses) {
+    return {
+      context: responses[0]?.context,
+      conversationHistory,
+      channels: userMessage?.channels,
+      promptType: responses[0]?.promptType,
+      topic: responses[0]?.topic
+    }
+  }
+})

--- a/src/agents/eventAssistant/voiceAssistant.ts
+++ b/src/agents/eventAssistant/voiceAssistant.ts
@@ -56,7 +56,7 @@ export default verify({
     }
     const translatedMsg = msg.toObject()
     const sourceMessage = msg.body.sourceMessage as string
-    const truncated = sourceMessage.length > 25 ? `${sourceMessage.slice(0, 25)}...` : sourceMessage
+    const truncated = sourceMessage.length > 40 ? `${sourceMessage.slice(0, 40)}...` : sourceMessage
     translatedMsg.bodyType = 'text'
     translatedMsg.body = `🔊 "${truncated}"\n${msg.body.text}`
     return translatedMsg

--- a/src/agents/helpers/llmInputFormatters.ts
+++ b/src/agents/helpers/llmInputFormatters.ts
@@ -92,7 +92,7 @@ function formatSingleUserConversationHistory(conversationHistory: ConversationHi
 }
 
 function formatMultiUserConversationHistory(conversationHistory: ConversationHistory) {
-  return conversationHistory.messages?.map((message) => {
+  return conversationHistory.messages?.flatMap((message) => {
     let messageText = message.body
     // conversation history messsages must be strings. If json or multimodal, assume it has a 'text' property
     if (message.bodyType === 'json' || message.bodyType === 'multimodal') {
@@ -104,6 +104,16 @@ function formatMultiUserConversationHistory(conversationHistory: ConversationHis
       }
     }
     if (message.fromAgent) {
+      // For voice assistant responses, prepend the original question so other agents
+      // see the full exchange rather than an unexplained answer
+      const body = message.body as Record<string, unknown>
+      if (body?.source === 'voice' && body?.sourceMessage) {
+        const asker = (body.sourcePseudonym as string) || 'User'
+        return [
+          { role: 'user', content: `${asker}: ${body.sourceMessage}` },
+          { role: 'assistant', content: messageText }
+        ]
+      }
       return { role: 'assistant', content: messageText }
     }
     // For multi-user environments, include the pseudonym in the content

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -20,6 +20,7 @@ import eventMediator from './eventMediator/eventMediator.js'
 import eventMediatorPlus from './eventMediator/eventMediatorPlus.js'
 import engagementAgent from './engagement/engagementAgent.js'
 import jargonFilterAgent from './jargonFilter/jargonFilter.js'
+import voiceAssistant from './eventAssistant/voiceAssistant.js'
 
 const development = {
   civilityPerMessage,
@@ -42,5 +43,6 @@ export default {
   eventMediator,
   eventMediatorPlus,
   engagementAgent,
-  jargonFilterAgent
+  jargonFilterAgent,
+  voiceAssistant
 }

--- a/src/conversations/eventAssistantPlus.ts
+++ b/src/conversations/eventAssistantPlus.ts
@@ -113,6 +113,10 @@ const eventAssistantPlus: ConversationType = {
     {
       name: 'jargonFilterAgent',
       properties: [{ $ref: 'llmModel.llmModel' }, { $ref: 'llmModel.llmPlatform' }]
+    },
+    {
+      name: 'voiceAssistant',
+      properties: [{ $ref: 'llmModel.llmModel' }, { $ref: 'llmModel.llmPlatform' }]
     }
   ],
   enableDMs: ['agents'],

--- a/tests/agents/eventAssistant/voiceAssistant.agent.test.ts
+++ b/tests/agents/eventAssistant/voiceAssistant.agent.test.ts
@@ -8,7 +8,7 @@ import {
   createMessage,
   createConversation
 } from '../../utils/agentTestHelpers.js'
-import { Agent, Channel } from '../../../src/models/index.js'
+import { Agent, Channel, Message } from '../../../src/models/index.js'
 
 import { AgentMessageActions } from '../../../src/types/index.types.js'
 import { QuestionClassification } from '../../../src/agents/eventAssistant/eventQuestionHandler.js'
@@ -331,4 +331,48 @@ describe('voice assistant CI tests', () => {
     },
     testTimeout
   )
+})
+
+describe('voiceAssistant parseOutput', () => {
+  function makeVoiceMessage(text: string, sourceMessage: string, sourcePseudonym?: string) {
+    return new Message({
+      body: { text, source: 'voice', sourceMessage, ...(sourcePseudonym ? { sourcePseudonym } : {}) },
+      bodyType: 'json',
+      fromAgent: true,
+      pseudonym: 'Voice Assistant'
+    })
+  }
+
+  it('prefixes response with 🔊 and the question in quotes', () => {
+    const msg = makeVoiceMessage('Part-time work is fewer hours.', 'What is part-time work?')
+    const result = defaultAgentTypes.voiceAssistant.parseOutput(msg)
+    expect(result.bodyType).toBe('text')
+    expect(result.body).toBe('🔊 "What is part-time work?"\nPart-time work is fewer hours.')
+  })
+
+  it('truncates questions longer than 25 chars with ellipsis', () => {
+    const longQuestion = 'What exactly does the speaker mean when they talk about flexible working arrangements?'
+    const msg = makeVoiceMessage('They mean employees can choose their hours.', longQuestion)
+    const result = defaultAgentTypes.voiceAssistant.parseOutput(msg)
+    expect(result.body).toBe('🔊 "What exactly does the spe..."\nThey mean employees can choose their hours.')
+  })
+
+  it('does not add ellipsis when question is exactly 25 chars', () => {
+    const twentyFiveChars = 'A'.repeat(25)
+    const msg = makeVoiceMessage('Answer.', twentyFiveChars)
+    const result = defaultAgentTypes.voiceAssistant.parseOutput(msg)
+    expect(result.body).toBe(`🔊 "${twentyFiveChars}"\nAnswer.`)
+  })
+
+  it('returns non-voice json messages unchanged', () => {
+    const msg = new Message({ body: { text: 'Some response', type: 'on_topic_answer' }, bodyType: 'json', fromAgent: true })
+    const result = defaultAgentTypes.voiceAssistant.parseOutput(msg)
+    expect(result).toBe(msg)
+  })
+
+  it('returns text messages unchanged', () => {
+    const msg = new Message({ body: 'Plain text response', bodyType: 'text', fromAgent: true })
+    const result = defaultAgentTypes.voiceAssistant.parseOutput(msg)
+    expect(result).toBe(msg)
+  })
 })

--- a/tests/agents/eventAssistant/voiceAssistant.agent.test.ts
+++ b/tests/agents/eventAssistant/voiceAssistant.agent.test.ts
@@ -1,0 +1,334 @@
+/* eslint-disable no-console */
+import setupAgentTest from '../../utils/setupAgentTest.js'
+import defaultAgentTypes from '../../../src/agents/index.js'
+import {
+  createPublicTopic,
+  createUser,
+  loadPartTimeWorkTranscript,
+  createMessage,
+  createConversation
+} from '../../utils/agentTestHelpers.js'
+import { Agent, Channel } from '../../../src/models/index.js'
+
+import { AgentMessageActions } from '../../../src/types/index.types.js'
+import { QuestionClassification } from '../../../src/agents/eventAssistant/eventQuestionHandler.js'
+
+jest.setTimeout(180000)
+
+const testConfig = setupAgentTest('voiceAssistant')
+const testTimeout = 120000
+
+async function createVoiceAssistantConversation(conversationObj, owner, topic, startTime, llmPlatform?, llmModel?) {
+  const conversation = await createConversation(conversationObj, owner, topic, startTime)
+  const agent = new Agent({
+    agentType: 'voiceAssistant',
+    conversation,
+    llmPlatform,
+    llmModel
+  })
+  const channels = await Channel.create([{ name: 'transcript' }, { name: 'chat' }])
+  conversation.channels.push(...channels)
+  await agent.save()
+  conversation.agents.push(agent)
+  await conversation.save()
+  await agent.initialize()
+  await agent.start()
+  return conversation
+}
+
+describe('voice assistant CI tests', () => {
+  let agent
+  let conversation
+  let topic
+  let user1
+
+  const startTime = new Date(Date.now() - 15 * 60 * 1000)
+
+  beforeEach(async () => {
+    user1 = await createUser('Boring Badger')
+    topic = await createPublicTopic()
+    conversation = await createVoiceAssistantConversation(
+      {
+        name: 'Why your company should consider part-time work',
+        description: `"No one wants to work anymore." Entrepreneur Jessica Drain believes otherwise.`,
+        presenters: [{ name: 'Jessica Drain', bio: 'A career marketer and graphic designer.' }],
+        moderators: [{ name: 'Joe Moderator', bio: 'An experienced event moderator.' }]
+      },
+      user1,
+      topic,
+      startTime,
+      testConfig.llmPlatform,
+      testConfig.llmModel
+    )
+    const [testAgent] = conversation.agents
+    agent = testAgent
+    await loadPartTimeWorkTranscript(conversation, true)
+  })
+
+  // EVALUATE TESTS
+
+  it('contributes to transcript messages from other users', async () => {
+    const msg = await createMessage(`hey ${agent.agentConfig.botName} what is going on?`, user1, conversation, [
+      'transcript'
+    ])
+    const evaluation = await defaultAgentTypes.voiceAssistant.evaluate.call(agent, msg)
+    expect(evaluation.action).toEqual(AgentMessageActions.CONTRIBUTE)
+  })
+
+  // RESPOND TESTS - TRIGGER DETECTION
+
+  it('returns empty when no hey trigger is present', async () => {
+    const msg = await createMessage('part-time work is interesting', user1, conversation, ['transcript'])
+    agent.conversationHistorySettings = {
+      endTime: new Date(startTime.getTime() + 313 * 1000),
+      count: 10,
+      channels: ['transcript']
+    }
+    const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+    expect(responses).toHaveLength(0)
+  })
+
+  it('returns empty for a bare hey trigger with no question, waiting for next message', async () => {
+    const msg = await createMessage(`hey ${agent.agentConfig.botName}`, user1, conversation, ['transcript'])
+    agent.conversationHistorySettings = {
+      endTime: new Date(startTime.getTime() + 313 * 1000),
+      count: 10,
+      channels: ['transcript']
+    }
+    const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+    expect(responses).toHaveLength(0)
+  })
+
+  it(
+    'answers an inline question on the transcript channel',
+    async () => {
+      const msg = await createMessage(`hey ${agent.agentConfig.botName} what is this talk about?`, user1, conversation, [
+        'transcript'
+      ])
+      agent.conversationHistorySettings = {
+        endTime: new Date(startTime.getTime() + 313 * 1000),
+        count: 10,
+        channels: ['transcript']
+      }
+      const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+      expect(responses).toHaveLength(1)
+      expect(responses[0].message.text).toBeDefined()
+      console.log(`A: ${responses[0].message.text}`)
+      expect([
+        QuestionClassification.ON_TOPIC_ANSWER,
+        QuestionClassification.ON_TOPIC_ASK_SPEAKER,
+        QuestionClassification.CATCHUP
+      ]).toContain(responses[0].classification)
+    },
+    testTimeout
+  )
+
+  it(
+    'answers a deferred question when the previous transcript message was a bare hey trigger',
+    async () => {
+      const prevMsg = await createMessage(`hey ${agent.agentConfig.botName}`, user1, conversation, ['transcript'])
+      const currMsg = await createMessage('what did Jessica say about flexible work?', user1, conversation, ['transcript'])
+      agent.conversationHistorySettings = {
+        endTime: new Date(startTime.getTime() + 622 * 1000),
+        count: 10,
+        channels: ['transcript']
+      }
+      const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [prevMsg] }, currMsg)
+      expect(responses).toHaveLength(1)
+      expect(responses[0].message.text).toBeDefined()
+      console.log(`A (deferred): ${responses[0].message.text}`)
+      expect([
+        QuestionClassification.ON_TOPIC_ANSWER,
+        QuestionClassification.ON_TOPIC_ASK_SPEAKER,
+        QuestionClassification.CATCHUP
+      ]).toContain(responses[0].classification)
+    },
+    testTimeout
+  )
+
+  it('does not treat current message as deferred question when previous hey trigger had inline question text', async () => {
+    const prevMsg = await createMessage(`hey ${agent.agentConfig.botName} what is part-time work?`, user1, conversation, [
+      'transcript'
+    ])
+    const currMsg = await createMessage('tell me more', user1, conversation, ['transcript'])
+    agent.conversationHistorySettings = {
+      endTime: new Date(startTime.getTime() + 313 * 1000),
+      count: 10,
+      channels: ['transcript']
+    }
+    // prev had an inline question, so current should not be treated as deferred
+    const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [prevMsg] }, currMsg)
+    expect(responses).toHaveLength(0)
+  })
+
+  it(
+    'capitalizes the first letter of an inline question extracted after the hey trigger',
+    async () => {
+      agent.agentConfig.botName = 'Berkie'
+      const msg = await createMessage('hey Berkie what is part-time work?', user1, conversation, ['transcript'])
+      agent.conversationHistorySettings = {
+        endTime: new Date(startTime.getTime() + 313 * 1000),
+        count: 10,
+        channels: ['transcript']
+      }
+      const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+      expect(responses).toHaveLength(1)
+      expect(responses[0].message.source).toBe('voice')
+      expect(responses[0].message.sourceMessage).toBe('What is part-time work?')
+    },
+    testTimeout
+  )
+
+  // FUZZY MATCHING TESTS - HEY TRIGGER POSITION
+
+  it(
+    'matches hey trigger anywhere in the message, not just at the start',
+    async () => {
+      agent.agentConfig.botName = 'Berkie'
+      const msg = await createMessage('so hey Berkie what is this talk about?', user1, conversation, ['transcript'])
+      agent.conversationHistorySettings = {
+        endTime: new Date(startTime.getTime() + 313 * 1000),
+        count: 10,
+        channels: ['transcript']
+      }
+      const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+      expect(responses).toHaveLength(1)
+      console.log(`A (mid-message trigger): ${responses[0].message.text}`)
+    },
+    testTimeout
+  )
+
+  it('only uses words after the hey trigger as the question, not the preamble before it', async () => {
+    agent.agentConfig.botName = 'Berkie'
+    // Bare "hey Berkie" in the middle — preamble before it should be ignored, no question after = wait for next
+    const msg = await createMessage('okay so hey Berkie', user1, conversation, ['transcript'])
+    agent.conversationHistorySettings = {
+      endTime: new Date(startTime.getTime() + 313 * 1000),
+      count: 10,
+      channels: ['transcript']
+    }
+    const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+    expect(responses).toHaveLength(0)
+  })
+
+  // FUZZY MATCHING TESTS - BOT NAME VARIATIONS (fuzzball scores vs 'Berkie')
+
+  it(
+    'fuzzy matches hey with punctuation variations (hey, Berkie,)',
+    async () => {
+      agent.agentConfig.botName = 'Berkie'
+      const msg = await createMessage('hey, Berkie, what is part-time work?', user1, conversation, ['transcript'])
+      agent.conversationHistorySettings = {
+        endTime: new Date(startTime.getTime() + 313 * 1000),
+        count: 10,
+        channels: ['transcript']
+      }
+      const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+      expect(responses).toHaveLength(1)
+      console.log(`A (punctuation): ${responses[0].message.text}`)
+    },
+    testTimeout
+  )
+
+  it(
+    'fuzzy matches "Burkie" (score ~83, passes nameMatchThreshold)',
+    async () => {
+      agent.agentConfig.botName = 'Berkie'
+      const msg = await createMessage('hey Burkie what is part-time work?', user1, conversation, ['transcript'])
+      agent.conversationHistorySettings = {
+        endTime: new Date(startTime.getTime() + 313 * 1000),
+        count: 10,
+        channels: ['transcript']
+      }
+      const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+      expect(responses).toHaveLength(1)
+      console.log(`A (Burkie): ${responses[0].message.text}`)
+    },
+    testTimeout
+  )
+
+  it(
+    'fuzzy matches "Birkie" (score ~83, passes nameMatchThreshold)',
+    async () => {
+      agent.agentConfig.botName = 'Berkie'
+      const msg = await createMessage('hey Birkie what is part-time work?', user1, conversation, ['transcript'])
+      agent.conversationHistorySettings = {
+        endTime: new Date(startTime.getTime() + 313 * 1000),
+        count: 10,
+        channels: ['transcript']
+      }
+      const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+      expect(responses).toHaveLength(1)
+      console.log(`A (Birkie): ${responses[0].message.text}`)
+    },
+    testTimeout
+  )
+
+  it(
+    'fuzzy matches "Berkee" (score ~83, passes nameMatchThreshold)',
+    async () => {
+      agent.agentConfig.botName = 'Berkie'
+      const msg = await createMessage('hey Berkee what is part-time work?', user1, conversation, ['transcript'])
+      agent.conversationHistorySettings = {
+        endTime: new Date(startTime.getTime() + 313 * 1000),
+        count: 10,
+        channels: ['transcript']
+      }
+      const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+      expect(responses).toHaveLength(1)
+      console.log(`A (Berkee): ${responses[0].message.text}`)
+    },
+    testTimeout
+  )
+
+  it(
+    'fuzzy matches "Berkye" (score ~83, passes nameMatchThreshold)',
+    async () => {
+      agent.agentConfig.botName = 'Berkie'
+      const msg = await createMessage('hey Berkye what is part-time work?', user1, conversation, ['transcript'])
+      agent.conversationHistorySettings = {
+        endTime: new Date(startTime.getTime() + 313 * 1000),
+        count: 10,
+        channels: ['transcript']
+      }
+      const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+      expect(responses).toHaveLength(1)
+      console.log(`A (Berkye): ${responses[0].message.text}`)
+    },
+    testTimeout
+  )
+
+  it(
+    'fuzzy matches "Berk" (score ~80, passes nameMatchThreshold)',
+    async () => {
+      agent.agentConfig.botName = 'Berkie'
+      const msg = await createMessage('hey Berk what is part-time work?', user1, conversation, ['transcript'])
+      agent.conversationHistorySettings = {
+        endTime: new Date(startTime.getTime() + 313 * 1000),
+        count: 10,
+        channels: ['transcript']
+      }
+      const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+      expect(responses).toHaveLength(1)
+      console.log(`A (Berk): ${responses[0].message.text}`)
+    },
+    testTimeout
+  )
+
+  it(
+    'fuzzy matches "Berky" (score ~73, passes nameMatchThreshold of 70)',
+    async () => {
+      agent.agentConfig.botName = 'Berkie'
+      const msg = await createMessage('hey Berky what is part-time work?', user1, conversation, ['transcript'])
+      agent.conversationHistorySettings = {
+        endTime: new Date(startTime.getTime() + 313 * 1000),
+        count: 10,
+        channels: ['transcript']
+      }
+      const responses = await defaultAgentTypes.voiceAssistant.respond.call(agent, { messages: [] }, msg)
+      expect(responses).toHaveLength(1)
+      console.log(`A (Berky): ${responses[0].message.text}`)
+    },
+    testTimeout
+  )
+})

--- a/tests/agents/eventAssistant/voiceAssistant.agent.test.ts
+++ b/tests/agents/eventAssistant/voiceAssistant.agent.test.ts
@@ -350,18 +350,18 @@ describe('voiceAssistant parseOutput', () => {
     expect(result.body).toBe('🔊 "What is part-time work?"\nPart-time work is fewer hours.')
   })
 
-  it('truncates questions longer than 25 chars with ellipsis', () => {
+  it('truncates questions longer than 40 chars with ellipsis', () => {
     const longQuestion = 'What exactly does the speaker mean when they talk about flexible working arrangements?'
     const msg = makeVoiceMessage('They mean employees can choose their hours.', longQuestion)
     const result = defaultAgentTypes.voiceAssistant.parseOutput(msg)
-    expect(result.body).toBe('🔊 "What exactly does the spe..."\nThey mean employees can choose their hours.')
+    expect(result.body).toBe('🔊 "What exactly does the speaker mean when ..."\nThey mean employees can choose their hours.')
   })
 
-  it('does not add ellipsis when question is exactly 25 chars', () => {
-    const twentyFiveChars = 'A'.repeat(25)
-    const msg = makeVoiceMessage('Answer.', twentyFiveChars)
+  it('does not add ellipsis when question is exactly 40 chars', () => {
+    const fortyChars = 'A'.repeat(40)
+    const msg = makeVoiceMessage('Answer.', fortyChars)
     const result = defaultAgentTypes.voiceAssistant.parseOutput(msg)
-    expect(result.body).toBe(`🔊 "${twentyFiveChars}"\nAnswer.`)
+    expect(result.body).toBe(`🔊 "${fortyChars}"\nAnswer.`)
   })
 
   it('returns non-voice json messages unchanged', () => {

--- a/tests/agents/helpers/llmInputFormatters.test.ts
+++ b/tests/agents/helpers/llmInputFormatters.test.ts
@@ -155,6 +155,57 @@ describe('LLM Input Formatter Tests', () => {
     ])
   })
 
+  it('should expand a voice assistant response into a question/answer pair in multi-user history', async () => {
+    const msg1 = await createMessage('I think AI should have rights.', 'Pro AI Urban Woman')
+    const msg2 = await createMessage(
+      { text: 'Part-time work is working fewer hours than a full-time schedule.', source: 'voice', sourceMessage: 'What is part-time work?', sourcePseudonym: 'Curious Corgi' },
+      'Voice Assistant',
+      undefined,
+      true,
+      'json'
+    )
+    const msg3 = await createMessage('Interesting!', 'Pro AI Urban Woman')
+    const convHistory = getConversationHistory([msg1, msg2, msg3], { count: 100 })
+    const formattedMessages = formatMultiUserConversationHistory(convHistory)
+    expect(formattedMessages).toEqual([
+      { role: 'user', content: 'Pro AI Urban Woman: I think AI should have rights.' },
+      { role: 'user', content: 'Curious Corgi: What is part-time work?' },
+      { role: 'assistant', content: 'Part-time work is working fewer hours than a full-time schedule.' },
+      { role: 'user', content: 'Pro AI Urban Woman: Interesting!' }
+    ])
+  })
+
+  it('should fall back to "User" as asking pseudonym when sourcePseudonym is absent from voice response', async () => {
+    const msg1 = await createMessage(
+      { text: 'Part-time work is working fewer hours than a full-time schedule.', source: 'voice', sourceMessage: 'What is part-time work?' },
+      'Voice Assistant',
+      undefined,
+      true,
+      'json'
+    )
+    const convHistory = getConversationHistory([msg1], { count: 100 })
+    const formattedMessages = formatMultiUserConversationHistory(convHistory)
+    expect(formattedMessages).toEqual([
+      { role: 'user', content: 'User: What is part-time work?' },
+      { role: 'assistant', content: 'Part-time work is working fewer hours than a full-time schedule.' }
+    ])
+  })
+
+  it('should not expand agent json messages that are not voice responses', async () => {
+    const msg1 = await createMessage(
+      { text: 'Some agent response', type: 'on_topic_answer' },
+      'BOT',
+      undefined,
+      true,
+      'json'
+    )
+    const convHistory = getConversationHistory([msg1], { count: 100 })
+    const formattedMessages = formatMultiUserConversationHistory(convHistory)
+    expect(formattedMessages).toEqual([
+      { role: 'assistant', content: 'Some agent response' }
+    ])
+  })
+
   it('should format multi-user conversation history with json body type', async () => {
     const msg1 = await createMessage('I think AI should have rights if it demonstrates consciousness.', 'Pro AI Urban Woman')
     const msg2 = await createMessage(

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -196,6 +196,26 @@ const testAgentTypeSpecification = {
     defaultLLMPlatform,
     defaultLLMModel,
     useTranscriptRAGCollection: false
+  },
+  voiceAssistant: {
+    initialize: mockInitialize,
+    respond: mockRespond,
+    evaluate: mockEvaluate,
+    start: mockStart,
+    stop: mockStop,
+    name: 'Voice Assistant',
+    description: 'Test voice assistant agent',
+    maxTokens: 2000,
+    defaultTriggers: { perMessage: { channels: ['transcript'] } },
+    priority: 100,
+    llmTemplateVars: { contribution: [], voting: [] },
+    defaultLLMTemplates: {
+      contribution: 'You are a voice assistant agent',
+      voting: 'You should vote on this data {voteData}'
+    },
+    defaultLLMPlatform,
+    defaultLLMModel,
+    useTranscriptRAGCollection: true
   }
 }
 


### PR DESCRIPTION
## What is in this PR?

Adds an agent that listens to transcripts and answers questions when it hears 'Hey [botName]', using the same mechanism as eventAssistant. Responses are posted to the group chat, with an indication of the question to which the agent is responding (using properties of the message body)

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- feat: add voiceAssistant agent to listen for 'hey [botname]' and respond in group chat
- fix: eventAssistantPlus should evaluate json messages in group chat without error 
   - necessary because voiceAssistant is now posting json to the group chat 
- perf: only check user visual preference if answering question on direct 
- feat: add voice questions to chat conversation history to provide full context to agents
- feat: format voiceAssistant responses to include some of the original question in Zoom chat
   - Uses speaker emoji and first 25 chars of original message at beginning of response

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Test in conjunction with FE PR https://github.com/berkmancenter/nextspace/pull/95
- [ ] Create an EAP conversation with Nextspace and Zoom support
- [ ] Play some event for some context (not strictly necessary, but as with any other assistant testing, it will be limited in how it can respond w/out it)
- [ ] Pause video and ask a variety of questions using 'Hey Berkie' It should respond if you pause b/w Hey Berkie and the question (2 separate lines in the transcript) or if 'Hey Berkie <question>' is all one chunk. What does NOT currently work well is if you pause in the middle of your question. Don't do that :) (for now anyway)
- [ ] Try saying Hey Berkie mid-sentence. It should still answer whatever you say next (will not consider the part before Hey Berkie)
- [ ] Verify responses are shown in group chat in both NextSpace and Zoom. In NextSpace, should have an 'In reply to' banner above the bubble w/first 60 chars of original question. In Zoom, the chat message should show same speaker emoji and first 25 chars



## Additional information
