### PR TITLE
feat: add eventHistorian agent and conv type to answer questions about past events on Slack

### DIFF
--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -2,7 +2,7 @@ import { ChatPostMessageResponse } from '@slack/web-api'
 import logger from '../../config/logger.js'
 import slackClientPool from './slackClientPool.js'
 import { AdapterMessage } from '../../types/adapter.types.js'
-import { Message } from '../../models/index.js'
+import Message from '../../models/message.model.js'
 
 function normalizeBotMention(text: string, botUserId: string, botName: string): string {
   if (!botUserId || !botName) return text

--- a/src/agents/engagement/engagementAgent.ts
+++ b/src/agents/engagement/engagementAgent.ts
@@ -138,7 +138,6 @@ export default verify({
   defaultLLMPlatform,
   defaultLLMModel,
   ragCollectionName: undefined,
-  useTranscriptRAGCollection: true,
 
   async initialize() {
     return true

--- a/src/agents/eventAssistant/eventAssistant.ts
+++ b/src/agents/eventAssistant/eventAssistant.ts
@@ -40,7 +40,6 @@ export default verify({
   defaultLLMPlatform,
   defaultLLMModel,
   ragCollectionName: undefined,
-  useTranscriptRAGCollection: true,
   defaultConversationHistorySettings: { count: 100, directMessages: true, channels: ['chat'] },
 
   async initialize() {

--- a/src/agents/eventAssistant/eventAssistantPlus.ts
+++ b/src/agents/eventAssistant/eventAssistantPlus.ts
@@ -104,7 +104,6 @@ export default verify({
     return translatedMsg
   },
   ragCollectionName: undefined,
-  useTranscriptRAGCollection: true,
   defaultConversationHistorySettings: { count: 100, directMessages: true, channels: ['chat'] },
 
   async initialize() {

--- a/src/agents/eventAssistant/voiceAssistant.ts
+++ b/src/agents/eventAssistant/voiceAssistant.ts
@@ -71,7 +71,6 @@ export default verify({
   defaultLLMPlatform,
   defaultLLMModel,
   ragCollectionName: undefined,
-  useTranscriptRAGCollection: true,
   defaultConversationHistorySettings: { count: 10, channels: ['transcript'] },
   parseOutput: (msg) => {
     if (msg.bodyType !== 'json' || msg.body?.source !== 'voice') {

--- a/src/agents/eventHistorian/eventHistorian.ts
+++ b/src/agents/eventHistorian/eventHistorian.ts
@@ -1,0 +1,168 @@
+import { getAgentStructuredResponse } from '../helpers/llmChain.js'
+import verify from '../helpers/verify.js'
+import { AgentMessageActions, ConversationHistory } from '../../types/index.types.js'
+import { formatMultiUserConversationHistory } from '../helpers/llmInputFormatters.js'
+import { buildSystemPromptWithPersonality } from '../helpers/agentPersonality.js'
+import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
+import { extractMessageText } from '../helpers/slashCommandParser.js'
+import createEventHistoryTools, { TopicRef } from '../tools/eventHistory.js'
+import Topic from '../../models/topic.model.js'
+import config from '../../config/config.js'
+
+const BASE_SYSTEM_PROMPT = `You are {botName}, a helpful, knowledgeable AI assistant participating in a group chat. You can engage with any topic or inquiry—from casual conversation to technical questions, creative tasks, analysis, debugging, writing, math, and beyond. There are no subject limits.
+
+**Guidelines:**
+- Be direct and substantive. Don't hedge unnecessarily.
+- Use conversation history for context—remember what's been discussed.
+- For factual questions, be accurate and acknowledge uncertainty when it exists.
+- For creative or open-ended tasks, engage fully and offer your perspective.
+- Match response depth to the question—short questions don't always need long answers.
+- You are talking in a shared channel, so keep context of the group conversation in mind.
+- The message you are being asked to respond to is labeled **## Question:**
+
+**Event history tools:**
+Your primary specialty is answering questions about past events and their transcripts. You have access to tools for this purpose — use them whenever a question touches on past events, speakers, topics discussed, or anything that may be in an event transcript.
+
+- \`get_event_list\`: list events by name/date across all series, with optional date or series filter
+- \`search_topic_transcripts\`: semantic search across all event transcripts; results are prefixed with the event name they came from
+- \`search_conversation_transcript\`: deep search within a specific event's transcript after identifying it via the above tools
+
+When searching, search across all series unless the question clearly refers to a specific one. Don't require the user to specify a series — use your judgment. Prefer \`search_topic_transcripts\` for broad questions; use \`search_conversation_transcript\` to retrieve specific quotes or details once you know which event to drill into. For questions that are clearly unrelated to past events, respond directly without calling any tools.
+{topicContext}`
+
+function buildTopicContext(topics: TopicRef[]): string {
+  const lines = topics.map((t) => {
+    const desc = t.description ? `: ${t.description}` : ''
+    return `- "${t.name}" (id: ${t.id})${desc}`
+  })
+  return `\n\n**Available event series:**\n${lines.join('\n')}`
+}
+
+export default verify({
+  name: 'Event Historian',
+  description:
+    'An AI assistant specialized in answering questions about past events and their transcripts, while also handling any general inquiry',
+  priority: 100,
+  maxTokens: 4000,
+  defaultTriggers: {
+    perMessage: { channels: ['historian'] }
+  },
+  agentConfig: {
+    enablePersonality: config.enableAgentPersonality,
+    topicIds: [] as string[]
+  },
+  llmTemplateVars: {
+    user: [{ name: 'question', description: 'The user message or question' }]
+  },
+  defaultLLMTemplates: {
+    user: '## Question:\n{question}'
+  },
+  defaultLLMPlatform,
+  defaultLLMModel,
+  ragCollectionName: undefined,
+  defaultConversationHistorySettings: { count: 100, channels: ['historian'] },
+
+  async initialize() {
+    return true
+  },
+
+  async evaluate(userMessage) {
+    // Only respond when explicitly mentioned with @BotName
+    if (!userMessage?.body?.toLowerCase().includes(`@${this.agentConfig.botName}`.toLowerCase())) {
+      return {
+        userMessage,
+        action: AgentMessageActions.OK,
+        userContributionVisible: true,
+        suggestion: undefined
+      }
+    }
+
+    return {
+      userMessage,
+      action: AgentMessageActions.CONTRIBUTE,
+      userContributionVisible: true,
+      suggestion: undefined
+    }
+  },
+
+  async respond(conversationHistory: ConversationHistory, userMessage) {
+    const chatHistory = formatMultiUserConversationHistory(conversationHistory)
+    const question = extractMessageText(userMessage).trim()
+
+    // Load topic metadata for system prompt and tools
+    const configuredTopicIds: string[] = this.agentConfig?.topicIds || []
+    let topicDocs
+    if (configuredTopicIds.length > 0) {
+      topicDocs = await Topic.find({ _id: { $in: configuredTopicIds } })
+        .select('_id name description')
+        .lean()
+    } else {
+      topicDocs = await Topic.find({ private: false, isDeleted: false }).select('_id name description').lean()
+    }
+    const topics: TopicRef[] = topicDocs.map((t) => ({ id: t._id.toString(), name: t.name, description: t.description }))
+
+    let personalityName: string | null = null
+    if (this.agentConfig?.personality !== undefined) {
+      personalityName = this.agentConfig.personality
+    } else if (config.enableAgentPersonality) {
+      personalityName = 'sarcastic-expert'
+    }
+
+    const systemPromptBase = BASE_SYSTEM_PROMPT.replace('{botName}', this.agentConfig.botName).replace(
+      '{topicContext}',
+      buildTopicContext(topics)
+    )
+    const systemPrompt = buildSystemPromptWithPersonality(systemPromptBase, personalityName)
+
+    const tools = topics.length > 0 ? createEventHistoryTools(topics) : []
+
+    const llm = await this.getLLM()
+
+    // Build message array: chat history + current question
+    const response = await getAgentStructuredResponse(
+      llm,
+      tools,
+      systemPrompt,
+      `## Question:\n${question}`,
+      undefined,
+      chatHistory,
+      10
+    )
+
+    const responseChannels = this.conversation.channels.filter((channel) => channel.name === 'historian')
+    const parentMessageId = userMessage.parentMessage
+
+    return [
+      {
+        visible: true,
+        message: response,
+        messageType: 'text',
+        channels: responseChannels,
+        parent: parentMessageId
+      }
+    ]
+  },
+
+  async start() {
+    return true
+  },
+
+  async stop() {
+    return true
+  },
+
+  formatTraceInput(_conversationHistory, userMessage) {
+    return userMessage?.body
+  },
+
+  formatTraceOutput(responses) {
+    return responses[0]?.message
+  },
+  getTraceMetadata(conversationHistory, userMessage, responses) {
+    return {
+      conversationHistory,
+      channels: userMessage?.channels,
+      topic: responses[0]?.topic
+    }
+  }
+})

--- a/src/agents/eventMediator/eventMediator.ts
+++ b/src/agents/eventMediator/eventMediator.ts
@@ -27,7 +27,6 @@ export default verify({
   defaultLLMPlatform,
   defaultLLMModel,
   ragCollectionName: undefined,
-  useTranscriptRAGCollection: true,
 
   async initialize() {
     return true

--- a/src/agents/eventMediator/eventMediatorPlus.ts
+++ b/src/agents/eventMediator/eventMediatorPlus.ts
@@ -44,7 +44,6 @@ ${msg.body.insights.map((insight: { value: string }) => `* ${insight.value}`).jo
     return translatedMsg
   },
   ragCollectionName: undefined,
-  useTranscriptRAGCollection: true,
 
   async initialize() {
     return true

--- a/src/agents/helpers/llmChain.ts
+++ b/src/agents/helpers/llmChain.ts
@@ -163,8 +163,6 @@ function createAgentOutputChain(responseSchema?) {
   const logAndExtractStep = async (agentResult) => {
     const { messages } = agentResult
 
-    logger.debug(`Agent executed ${messages.length} message exchanges`)
-
     // Log tool calls for debugging
     messages.forEach((msg, idx) => {
       const msgType = msg._getType()
@@ -177,8 +175,6 @@ function createAgentOutputChain(responseSchema?) {
             logger.debug(`  - Tool: ${tc.name}`)
             logger.debug(`    Args: ${JSON.stringify(tc.args)}`)
           })
-        } else {
-          logger.debug(`[${idx}] AIMessage (final response)`)
         }
       }
     })
@@ -365,7 +361,7 @@ async function getChatPromptResponse(
   platform?: string
 ) {
   // vLLM requires strict alternating human/ai turns; other platforms support consecutive same-role messages
-  const chatHistory = platform === 'vllm' ? ensureAlternatingChat(inputChatHistory || []) : (inputChatHistory || [])
+  const chatHistory = platform === 'vllm' ? ensureAlternatingChat(inputChatHistory || []) : inputChatHistory || []
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const messages: any = [
@@ -471,7 +467,15 @@ async function getRAGAugmentedResponse(
  *
 
  */
-async function getAgentStructuredResponse(llm, tools, systemPrompt, userMessage, responseSchema?) {
+async function getAgentStructuredResponse(
+  llm,
+  tools,
+  systemPrompt,
+  userMessage,
+  responseSchema?,
+  chatHistory?,
+  recursionLimit = 20
+) {
   // Add format instructions to system prompt if schema is provided
   let finalSystemPrompt = systemPrompt
   if (responseSchema) {
@@ -492,7 +496,18 @@ ${parser.getFormatInstructions()}`
     systemPrompt: new SystemMessage(finalSystemPrompt)
   })
 
-  const agentResult = await agent.invoke({ messages: [{ role: 'user', content: userMessage }] }, { recursionLimit: 20 })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const messages: any = [
+    ...(chatHistory && chatHistory.length > 0 ? chatHistory : []),
+    { role: 'user', content: userMessage }
+  ]
+
+  const agentResult = await agent.invoke(
+    {
+      messages
+    },
+    { recursionLimit }
+  )
 
   const outputChain = createAgentOutputChain(responseSchema)
   return outputChain.invoke(agentResult)

--- a/src/agents/helpers/rag.ts
+++ b/src/agents/helpers/rag.ts
@@ -151,9 +151,9 @@ async function addTextsToVectorStore(
   const docsWithMetadata = options?.metadataFn ? docs.map((doc) => options.metadataFn!(doc)) : docs
 
   // TODO use Hash to see if chunk stored previously?
-  logger.debug(`Adding docs to vector store: ${docs.length}...`)
+  logger.debug(`Adding ${docs.length} docs to vector store ${collectionName}...`)
   await vectorStore.addDocuments(docsWithMetadata)
-  logger.debug(`Added docs to vector store: ${docs.length}`)
+  logger.debug(`Added docs to vector store`)
 }
 
 async function addPDFToVectorStore(collectionName, file, metadataFn?, embeddingsPlatform?, embeddingsModelName?) {

--- a/src/agents/helpers/transcript.ts
+++ b/src/agents/helpers/transcript.ts
@@ -257,7 +257,7 @@ async function loadTranscriptIntoVectorStore(messages, conversationId) {
 async function loadTopicMetadataIntoVectorStore(topic) {
   const topicId = topic._id.toString()
   const collectionName = `${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`
-  const doc = `Series: ${topic.name}`
+  const doc = topic.description ? `Series: ${topic.name}. ${topic.description}` : `Series: ${topic.name}`
 
   try {
     await rag.removeFromVectorStore(collectionName, { type: 'series' })

--- a/src/agents/helpers/transcript.ts
+++ b/src/agents/helpers/transcript.ts
@@ -216,22 +216,14 @@ async function loadTranscriptIntoVectorStore(messages, conversationId) {
 }
 
 async function clearTranscript(conversation) {
-  let transcriptRAG = false
-  for (const agent of conversation.agents) {
-    if (agent.useTranscriptRAGCollection) {
-      transcriptRAG = true
-    }
-  }
-  if (transcriptRAG) {
-    logger.info(`Clearing transcript content from vector store for conversation ${conversation._id}`)
-    try {
-      // Remove only transcript-type documents, preserve event/speaker/moderator metadata
-      await rag.removeFromVectorStore(`${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`, {
-        type: 'transcript'
-      })
-    } catch {
-      logger.warn(`Failed to clear transcript from vector store: ${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`)
-    }
+  logger.info(`Clearing transcript content from vector store for conversation ${conversation._id}`)
+  try {
+    // Remove only transcript-type documents, preserve event/speaker/moderator metadata
+    await rag.removeFromVectorStore(`${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`, {
+      type: 'transcript'
+    })
+  } catch {
+    logger.warn(`Failed to clear transcript from vector store: ${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`)
   }
   // Find all messages for this conversation in transcript channel
   const messagesToDelete = await Message.find({
@@ -248,20 +240,12 @@ async function clearTranscript(conversation) {
 }
 
 async function deleteTranscript(conversation) {
-  let transcriptRAG = false
-  for (const agent of conversation.agents) {
-    if (agent.useTranscriptRAGCollection) {
-      transcriptRAG = true
-    }
-  }
-  if (transcriptRAG) {
-    logger.info(`Deleting transcript collection from vector store for conversation ${conversation._id}`)
-    try {
-      // Delete the entire collection including all metadata
-      await rag.deleteCollection(`${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`)
-    } catch {
-      logger.warn(`Failed to delete collection from vector store: ${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`)
-    }
+  logger.info(`Deleting transcript collection from vector store for conversation ${conversation._id}`)
+  try {
+    // Delete the entire collection including all metadata
+    await rag.deleteCollection(`${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`)
+  } catch {
+    logger.warn(`Failed to delete collection from vector store: ${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`)
   }
   // Find all messages for this conversation in transcript channel
   const messagesToDelete = await Message.find({

--- a/src/agents/helpers/transcript.ts
+++ b/src/agents/helpers/transcript.ts
@@ -5,6 +5,9 @@ import getConversationHistory from './getConversationHistory.js'
 import { formatTime, formatTranscript } from './llmInputFormatters.js'
 import rag, { TRANSCRIPT_COLLECTION_PREFIX } from './rag.js'
 import Conversation from '../../models/conversation.model.js'
+import Topic from '../../models/topic.model.js'
+
+export const TOPIC_TRANSCRIPT_COLLECTION_PREFIX = 'topic-transcript'
 
 /**
  * Convert time string into a Date object, inferring from the startTime
@@ -117,51 +120,68 @@ function getTranscript(conversation, timeWindow?, endTime?) {
 }
 
 async function loadEventMetadataIntoVectorStore(conversation) {
-  // Delete old metadata documents if they exist
+  const conversationId = conversation._id.toString()
+  const topicId = conversation.topic?._id?.toString() ?? conversation.topic?.toString()
+  const metadataTypeFilter = { type: { $in: ['event', 'presenter', 'moderator'] } }
+
+  // Remove stale metadata from per-conversation collection
   try {
-    await rag.removeFromVectorStore(`${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`, {
-      type: { $in: ['event', 'presenter', 'moderator'] }
-    })
+    await rag.removeFromVectorStore(`${TRANSCRIPT_COLLECTION_PREFIX}-${conversationId}`, metadataTypeFilter)
   } catch (error) {
     // Collection might not exist yet, which is fine
     logger.debug(`Could not remove old metadata (collection may not exist): ${error.message}`)
   }
+
+  // Remove stale metadata for this conversation from the topic collection
+  if (topicId) {
+    try {
+      await rag.removeFromVectorStore(`${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`, {
+        $and: [{ conversationId }, metadataTypeFilter]
+      })
+    } catch (error) {
+      logger.debug(`Could not remove old topic metadata (collection may not exist): ${error.message}`)
+    }
+  }
+
   const docs: string[] = []
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const metadatas: Record<string, any>[] = []
 
-  if (conversation.description) {
-    docs.push(`Event (Meeting Conversation Presentation) Description: ${conversation.description}`)
-    metadatas.push({
-      type: 'event'
-    })
-  }
+  const eventDoc = conversation.description
+    ? `Event: ${conversation.name}. ${conversation.description}`
+    : `Event: ${conversation.name}`
+  docs.push(eventDoc)
+  metadatas.push({ type: 'event' })
+
   if (conversation.presenters?.length) {
     conversation.presenters.forEach((presenter) => {
       const bioText = presenter.bio || 'No bio provided.'
       docs.push(`${presenter.name} is a speaker, presenter, and panelist at this event. ${bioText}`)
-      metadatas.push({
-        type: 'presenter',
-        presenterName: presenter.name
-      })
+      metadatas.push({ type: 'presenter', presenterName: presenter.name })
     })
   }
-
-  // Add moderator bios if provided
   if (conversation.moderators?.length) {
     conversation.moderators.forEach((moderator) => {
       const bioText = moderator.bio || 'No bio provided.'
       docs.push(`${moderator.name} is the moderator, facilitator, and host of this event. ${bioText}`)
-      metadatas.push({
-        type: 'moderator',
-        moderatorName: moderator.name
-      })
+      metadatas.push({ type: 'moderator', moderatorName: moderator.name })
     })
   }
 
-  // Only add to vector store if we have documents
-  if (docs.length > 0) {
-    await rag.addTextsToVectorStore(`${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`, docs, { metadatas })
+  const conversationIdentifierMetadatas = metadatas.map((m) => ({
+    ...m,
+    conversationId,
+    conversationName: conversation.name
+  }))
+
+  await rag.addTextsToVectorStore(`${TRANSCRIPT_COLLECTION_PREFIX}-${conversationId}`, docs, {
+    metadatas: conversationIdentifierMetadatas
+  })
+
+  if (topicId) {
+    await rag.addTextsToVectorStore(`${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`, docs, {
+      metadatas: conversationIdentifierMetadatas
+    })
   }
 }
 
@@ -170,6 +190,8 @@ async function loadTranscriptIntoVectorStore(messages, conversationId) {
     logger.warn('No messages to load')
     return
   }
+  const conversation = await Conversation.findById(conversationId).select('name topic transcript').lean()
+
   // Create a simple lookup map: formatted time -> original message
   const timeToMessageMap = new Map()
   messages.forEach((msg) => {
@@ -177,53 +199,148 @@ async function loadTranscriptIntoVectorStore(messages, conversationId) {
     timeToMessageMap.set(formattedTime, msg)
   })
 
-  const metadataFn = (doc) => {
-    const chunkLines = doc.pageContent.split('\n').filter((line) => line.trim())
-    // Extract timestamps from this chunk and map back to original ISO timestamps
-    const chunkTimestamps = chunkLines
-      .map((line) => {
-        const timeMatch = line.match(/^\[(.*?)\]/)
-        if (timeMatch) {
-          const formattedTime = timeMatch[1] // e.g., "14:30:25"
-          const originalMsg = timeToMessageMap.get(formattedTime)
-          return originalMsg ? originalMsg.createdAt : null
+  const formattedTranscript = formatTranscript(messages)
+  const embeddingsPlatform = conversation?.transcript?.vectorStore?.embeddingsPlatform
+  const embeddingsModelName = conversation?.transcript?.vectorStore?.embeddingsModelName
+
+  const makeMetadataFn =
+    (extraMetadata: Record<string, unknown> = {}) =>
+    (doc) => {
+      const chunkLines = doc.pageContent.split('\n').filter((line) => line.trim())
+      // Extract timestamps from this chunk and map back to original ISO timestamps
+      const chunkTimestamps = chunkLines
+        .map((line) => {
+          const timeMatch = line.match(/^\[(.*?)\]/)
+          if (timeMatch) {
+            const formattedTime = timeMatch[1] // e.g., "14:30:25"
+            const originalMsg = timeToMessageMap.get(formattedTime)
+            return originalMsg ? originalMsg.createdAt : null
+          }
+          return null
+        })
+        .filter(Boolean)
+        .sort((a, b) => a.getTime() - b.getTime())
+      return {
+        ...doc,
+        metadata: {
+          ...extraMetadata,
+          start: chunkTimestamps[0]?.getTime(),
+          end:
+            chunkTimestamps.length > 1
+              ? chunkTimestamps[chunkTimestamps.length - 1]?.getTime()
+              : chunkTimestamps[0]?.getTime(),
+          type: 'transcript'
         }
-        return null
-      })
-      .filter(Boolean)
-      .sort((a, b) => a.getTime() - b.getTime())
-    return {
-      ...doc,
-      metadata: {
-        start: chunkTimestamps[0]?.getTime(),
-        end:
-          chunkTimestamps.length > 1
-            ? chunkTimestamps[chunkTimestamps.length - 1]?.getTime()
-            : chunkTimestamps[0]?.getTime(),
-        type: 'transcript'
       }
     }
-  }
-  const formattedTranscript = formatTranscript(messages)
 
-  const conversation = await Conversation.findById(conversationId).select('transcript').lean()
+  const conversationIdentifierMetadata = { conversationId: conversationId.toString(), conversationName: conversation?.name }
 
+  // Always write to the per-conversation collection
   await rag.addTextsToVectorStore(`${TRANSCRIPT_COLLECTION_PREFIX}-${conversationId}`, [formattedTranscript], {
-    metadataFn,
-    embeddingsPlatform: conversation?.transcript?.vectorStore?.embeddingsPlatform,
-    embeddingsModelName: conversation?.transcript?.vectorStore?.embeddingsModelName
+    metadataFn: makeMetadataFn(conversationIdentifierMetadata),
+    embeddingsPlatform,
+    embeddingsModelName
   })
+
+  // Also write to the topic collection if the conversation belongs to one.
+  // Always use default embeddings for the topic collection so all conversations
+  // in a topic are embedded consistently, regardless of per-conversation overrides.
+  if (conversation?.topic) {
+    const topicId = conversation.topic._id?.toString() ?? conversation.topic.toString()
+    await rag.addTextsToVectorStore(`${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`, [formattedTranscript], {
+      metadataFn: makeMetadataFn(conversationIdentifierMetadata)
+    })
+  }
+}
+
+async function loadTopicMetadataIntoVectorStore(topic) {
+  const topicId = topic._id.toString()
+  const collectionName = `${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`
+  const doc = `Series: ${topic.name}`
+
+  try {
+    await rag.removeFromVectorStore(collectionName, { type: 'series' })
+  } catch (error) {
+    logger.debug(`Could not remove old series metadata (collection may not exist): ${error.message}`)
+  }
+
+  await rag.addTextsToVectorStore(collectionName, [doc], {
+    metadatas: [{ type: 'series', topicId }]
+  })
+}
+
+async function loadTopicTranscriptsIntoVectorStore(topicId) {
+  const topic = await Topic.findById(topicId).select('_id name description').lean()
+  if (topic) {
+    await loadTopicMetadataIntoVectorStore(topic)
+  }
+
+  const conversations = await Conversation.find({ topic: topicId })
+    .select('_id name description presenters moderators transcript')
+    .lean()
+
+  let loaded = 0
+  let skipped = 0
+  const collectionName = `${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`
+
+  for (const conversation of conversations) {
+    // Check if this conversation is already present in the topic collection
+    try {
+      const collection = await rag.getCollection(collectionName)
+      const existing = await collection.get({ where: { conversationId: conversation._id.toString() }, limit: 1 })
+      if (existing.ids.length > 0) {
+        logger.debug(`Topic transcript: skipping already-loaded conversation ${conversation._id}`)
+        skipped++
+        continue
+      }
+    } catch {
+      // Collection doesn't exist yet — proceed to load
+    }
+
+    const messages = await Message.find({
+      conversation: conversation._id,
+      channels: { $in: ['transcript'] }
+    })
+      .sort({ createdAt: 1 })
+      .lean()
+
+    await loadEventMetadataIntoVectorStore({ ...conversation, topic: topicId })
+
+    // loadTranscriptIntoVectorStore writes to both the per-conversation and topic collections
+    if (messages.length > 0) {
+      await loadTranscriptIntoVectorStore(messages, conversation._id)
+    } else {
+      logger.warn(`Topic transcript: no transcript messages found for conversation ${conversation._id}`)
+    }
+
+    logger.info(`Topic transcript: loaded conversation ${conversation._id} (${conversation.name}) into topic ${topicId}`)
+    loaded++
+  }
+
+  return { loaded, skipped }
 }
 
 async function clearTranscript(conversation) {
   logger.info(`Clearing transcript content from vector store for conversation ${conversation._id}`)
+  const conversationId = conversation._id.toString()
+  const transcriptTypeFilter = { type: 'transcript' }
   try {
     // Remove only transcript-type documents, preserve event/speaker/moderator metadata
-    await rag.removeFromVectorStore(`${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`, {
-      type: 'transcript'
-    })
+    await rag.removeFromVectorStore(`${TRANSCRIPT_COLLECTION_PREFIX}-${conversationId}`, transcriptTypeFilter)
   } catch {
-    logger.warn(`Failed to clear transcript from vector store: ${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`)
+    logger.warn(`Failed to clear transcript from vector store: ${TRANSCRIPT_COLLECTION_PREFIX}-${conversationId}`)
+  }
+
+  const topicId = conversation.topic?._id?.toString() ?? conversation.topic?.toString()
+  if (topicId) {
+    try {
+      await rag.removeFromVectorStore(`${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`, {
+        $and: [{ conversationId }, transcriptTypeFilter]
+      })
+    } catch {
+      logger.warn(`Failed to clear transcript from topic collection ${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`)
+    }
   }
   // Find all messages for this conversation in transcript channel
   const messagesToDelete = await Message.find({
@@ -242,10 +359,24 @@ async function clearTranscript(conversation) {
 async function deleteTranscript(conversation) {
   logger.info(`Deleting transcript collection from vector store for conversation ${conversation._id}`)
   try {
-    // Delete the entire collection including all metadata
+    // Delete the entire per-conversation collection including all metadata
     await rag.deleteCollection(`${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`)
   } catch {
     logger.warn(`Failed to delete collection from vector store: ${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`)
+  }
+
+  // Remove this conversation's documents from the topic collection
+  const topicId = conversation.topic?._id?.toString() ?? conversation.topic?.toString()
+  if (topicId) {
+    try {
+      await rag.removeFromVectorStore(`${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`, {
+        conversationId: conversation._id.toString()
+      })
+    } catch {
+      logger.warn(
+        `Failed to remove conversation ${conversation._id} from topic collection ${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`
+      )
+    }
   }
   // Find all messages for this conversation in transcript channel
   const messagesToDelete = await Message.find({
@@ -261,12 +392,26 @@ async function deleteTranscript(conversation) {
   })
 }
 
+async function deleteTopicCollection(topic) {
+  const topicId = topic._id.toString()
+  const collectionName = `${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`
+  try {
+    await rag.deleteCollection(collectionName)
+    logger.info(`Deleted RAG collection for topic ${topicId}`)
+  } catch (error) {
+    logger.warn(`Failed to delete RAG collection for topic ${topicId}: ${error.message}`)
+  }
+}
+
 export default {
   searchTranscript,
   loadTranscriptIntoVectorStore,
+  loadTopicTranscriptsIntoVectorStore,
+  loadTopicMetadataIntoVectorStore,
   loadEventMetadataIntoVectorStore,
   clearTranscript,
   deleteTranscript,
+  deleteTopicCollection,
   getTranscriptMessages,
   getTranscript
 }

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -9,6 +9,7 @@ import engagementAgent from './engagement/engagementAgent.js'
 import jargonFilterAgent from './jargonFilter/jargonFilter.js'
 import librarian from './librarian/librarianAgent.js'
 import chatbot from './chatbot/chatbot.js'
+import eventHistorian from './eventHistorian/eventHistorian.js'
 
 // Development agents
 import civilityPerMessage from './development/civilityPerMessage.js'
@@ -48,5 +49,6 @@ export default {
   engagementAgent,
   jargonFilterAgent,
   voiceAssistant,
-  librarian
+  librarian,
+  eventHistorian
 }

--- a/src/agents/tools/eventHistory.ts
+++ b/src/agents/tools/eventHistory.ts
@@ -1,0 +1,174 @@
+import { tool } from '@langchain/core/tools'
+import { z } from 'zod'
+import mongoose from 'mongoose'
+import Conversation from '../../models/conversation.model.js'
+import rag, { TRANSCRIPT_COLLECTION_PREFIX } from '../helpers/rag.js'
+import { TOPIC_TRANSCRIPT_COLLECTION_PREFIX } from '../helpers/transcript.js'
+import logger from '../../config/logger.js'
+
+export interface TopicRef {
+  id: string
+  name: string
+  description?: string
+}
+
+export default function createEventHistoryTools(topics: TopicRef[]) {
+  const topicIds = topics.map((t) => t.id)
+
+  const getEventListTool = tool(
+    async ({ since, until, topicId }) => {
+      const searchTopicIds = topicId ? [topicId] : topicIds
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const query: Record<string, any> = { topic: { $in: searchTopicIds.map((id) => new mongoose.Types.ObjectId(id)) } }
+      if (since || until) {
+        query.startTime = {}
+        if (since) query.startTime.$gte = new Date(since)
+        if (until) query.startTime.$lte = new Date(until)
+      }
+      const conversations = await Conversation.find(query)
+        .select('_id name description startTime endTime topic')
+        .populate('topic', 'name description')
+        .sort({ startTime: -1 })
+        .lean()
+
+      const results = conversations.map((c) => {
+        const topic = c.topic as unknown as { name: string; description?: string } | null
+        return {
+          id: c._id.toString(),
+          name: c.name,
+          series: topic?.name || null,
+          seriesDescription: topic?.description || null,
+          description: c.description || null,
+          startTime: c.startTime?.toISOString() || null,
+          endTime: c.endTime?.toISOString() || null
+        }
+      })
+      logger.debug(`get_event_list: ${results.length} events across ${searchTopicIds.length} topic(s)`)
+      return JSON.stringify(results)
+    },
+    {
+      name: 'get_event_list',
+      description:
+        'List events (conversations) across all event series with their names, dates, and descriptions. ' +
+        'Use this to answer questions about which events have occurred, when they happened, or to ' +
+        'identify a specific event by name or date before drilling into its transcript. ' +
+        'Optionally filter by a specific series topicId or a date range.',
+      schema: z.object({
+        since: z
+          .string()
+          .optional()
+          .describe('ISO date string — return events starting on or after this date, e.g. "2025-01-01"'),
+        until: z
+          .string()
+          .optional()
+          .describe('ISO date string — return events starting on or before this date, e.g. "2025-12-31"'),
+        topicId: z
+          .string()
+          .optional()
+          .describe('Limit results to a specific event series by its ID. Omit to search all series.')
+      })
+    }
+  )
+
+  const formatChunk = (doc) => {
+    const event = doc.metadata?.conversationName ? `[Event: ${doc.metadata.conversationName}]` : null
+    return event ? `${event}\n${doc.pageContent}` : doc.pageContent
+  }
+
+  const searchTopicTranscriptsTool = tool(
+    async ({ query, topicId }) => {
+      const searchTopicIds = topicId ? [topicId] : topicIds
+
+      const allChunks: string[] = []
+      await Promise.all(
+        searchTopicIds.map(async (id) => {
+          const collectionName = `${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${id}`
+          try {
+            const { chunks } = await rag.getContextChunksForQuestion(
+              collectionName,
+              query,
+              formatChunk,
+              undefined,
+              10,
+              undefined,
+              undefined,
+              0.8
+            )
+            if (chunks) allChunks.push(chunks)
+          } catch (error) {
+            logger.warn(`search_topic_transcripts: no data for topic ${id}: ${error.message}`)
+          }
+        })
+      )
+
+      if (allChunks.length === 0) return 'No relevant content found.'
+      return allChunks.join('\n\n---\n\n')
+    },
+    {
+      name: 'search_topic_transcripts',
+      description:
+        "Semantic search across all event transcripts in this channel's event series. Use this to find what was " +
+        'discussed across events, identify speakers by subject area, or determine which events ' +
+        'covered a particular topic. Each result chunk is prefixed with the event name it came from. ' +
+        'Optionally filter to a specific series by topicId.',
+      schema: z.object({
+        query: z
+          .string()
+          .describe('The search query, e.g. "AI regulation", "speaker who discussed cartoons", "breakfast cereals"'),
+        topicId: z
+          .string()
+          .optional()
+          .describe('Limit search to a specific event series by its ID. Omit to search all series.')
+      })
+    }
+  )
+
+  const searchConversationTranscriptTool = tool(
+    async ({ conversationId, query }) => {
+      if (!mongoose.Types.ObjectId.isValid(conversationId)) {
+        return `Invalid conversationId "${conversationId}". You must pass the "id" field from get_event_list results, not the event name.`
+      }
+      const collectionName = `${TRANSCRIPT_COLLECTION_PREFIX}-${conversationId}`
+      try {
+        const conversation = await Conversation.findById(conversationId).select('transcript').lean()
+        if (!conversation) {
+          return `Conversation with id ${conversationId} not found. Please ensure you are passing a valid conversationId from get_event_list results.`
+        }
+        const embeddingsPlatform = conversation.transcript?.vectorStore?.embeddingsPlatform
+        const embeddingsModelName = conversation.transcript?.vectorStore?.embeddingsModelName
+        const { chunks } = await rag.getContextChunksForQuestion(
+          collectionName,
+          query,
+          formatChunk,
+          undefined,
+          10,
+          embeddingsPlatform,
+          embeddingsModelName,
+          0.8
+        )
+        if (!chunks) return 'No relevant content found in that event.'
+        return chunks
+      } catch (error) {
+        logger.warn(`search_conversation_transcript failed for ${conversationId}: ${error.message}`)
+        return 'No transcript data available for that event.'
+      }
+    },
+    {
+      name: 'search_conversation_transcript',
+      description:
+        "Semantic search within a specific event's transcript. Use this after identifying the right " +
+        'event via get_event_list or search_topic_transcripts to retrieve exact quotes or details of ' +
+        'what a specific person said. ' +
+        'IMPORTANT: conversationId must be the "id" field (a hex string like "507f1f77bcf86cd799439011") ' +
+        'from get_event_list results — never the event name.',
+      schema: z.object({
+        conversationId: z
+          .string()
+          .describe('The "id" hex string from get_event_list results. Do NOT pass the event name here.'),
+        query: z.string().describe("The specific content to search for within this event's transcript")
+      })
+    }
+  )
+
+  return [getEventListTool, searchTopicTranscriptsTool, searchConversationTranscriptTool]
+}

--- a/src/conversations/eventHistorian.ts
+++ b/src/conversations/eventHistorian.ts
@@ -1,0 +1,98 @@
+import { supportedModels } from '../agents/helpers/getModelChat.js'
+import { ConversationType, Direction } from '../types/index.types.js'
+import config from '../config/config.js'
+
+const eventHistorian: ConversationType = {
+  name: 'eventHistorian',
+  label: 'Event Historian',
+  description:
+    'An AI assistant specialized in answering questions about past events and their transcripts accessible via a shared Slack channel',
+  platforms: [{ name: 'slack', label: 'Slack' }],
+  properties: [
+    {
+      name: 'slackChannel',
+      label: 'Slack Channel ID',
+      description: 'The ID of the Slack Channel the chatbot participates in (starts with C- or G-)',
+      required: true,
+      type: 'string'
+    },
+    {
+      name: 'slackWorkspace',
+      label: 'Slack Workspace ID',
+      description: 'The Slack workspace (team) ID (starts with T-)',
+      required: true,
+      type: 'string'
+    },
+    {
+      name: 'slackBotToken',
+      label: 'Slack Bot Token',
+      description: 'The Bot User OAuth token for the Slack app (starts with xoxb-)',
+      required: true,
+      type: 'string'
+    },
+    {
+      name: 'slackBotUserId',
+      label: 'Slack Bot User ID',
+      description: 'The user ID for the bot in Slack (starts with U-), used for routing incoming messages',
+      required: false,
+      type: 'string'
+    },
+    {
+      name: 'botName',
+      label: 'Bot Name',
+      description: 'The display name for the bot',
+      required: false,
+      type: 'string',
+      default: config.conversationBotName
+    },
+    {
+      name: 'llmModel',
+      label: 'Model that your agents will use',
+      required: false,
+      type: 'enum',
+      options: supportedModels,
+      validationKeys: ['llmModel', 'llmPlatform']
+    },
+    {
+      name: 'topicIds',
+      label: 'Event Series IDs',
+      description:
+        'IDs of topic series the assistant can search for past event history. Leave empty to search all public topics.',
+      required: false,
+      type: 'object'
+    }
+  ],
+  // internal
+  agents: [
+    {
+      name: 'eventHistorian',
+      properties: [
+        { $ref: 'llmModel.llmModel' },
+        { $ref: 'llmModel.llmPlatform' },
+        { $ref: 'botName', as: 'agentConfig.botName' },
+        { $ref: 'topicIds', as: 'agentConfig.topicIds' }
+      ]
+    }
+  ],
+  channels: [{ name: 'historian' }],
+  adapters: {
+    slack: {
+      type: 'slack',
+      config: {
+        channel: '{{{properties.slackChannel}}}',
+        workspace: '{{{properties.slackWorkspace}}}',
+        botToken: '{{{properties.slackBotToken}}}',
+        botUserId: '{{{properties.slackBotUserId}}}', // for normalizing incoming messages
+        botName: '{{{properties.botName}}}'
+      },
+      chatChannels: [
+        {
+          name: 'historian',
+          direction: Direction.BOTH
+        }
+      ]
+    }
+  }
+}
+
+export default eventHistorian

--- a/src/conversations/index.ts
+++ b/src/conversations/index.ts
@@ -3,10 +3,12 @@ import backChannel from './backChannel.js'
 import eventAssistantPlus from './eventAssistantPlus.js'
 import type { ConversationType } from '../types/index.types.js'
 import chatbot from './chatbot.js'
+import eventHistorian from './eventHistorian.js'
 
 // Internal conversation types are usable by the service but not exposed via the config API
 const internal: Record<string, ConversationType> = {
-  chatbot
+  chatbot,
+  eventHistorian
 }
 
 const defaultConversationTypes: Record<string, ConversationType> = {

--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -511,8 +511,6 @@ components:
           type: boolean
         conversationHistorySettings:
           $ref: '#/components/schemas/ConversationHistorySettings'
-        useTranscriptRAGCollection:
-          type: boolean
 
     ConfigProperty:
       type: object

--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -230,6 +230,9 @@ components:
           type: string
         name:
           type: string
+        description:
+          type: string
+          description: Optional description of the topic
         defaultSortAverage:
           type: number
         followed:

--- a/src/models/topic.model.ts
+++ b/src/models/topic.model.ts
@@ -10,6 +10,10 @@ const topicSchema = new mongoose.Schema<ITopic>(
       required: true,
       trim: true
     },
+    description: {
+      type: String,
+      trim: true
+    },
     slug: {
       type: String,
       required: true,

--- a/src/models/user.model/agent.model/index.ts
+++ b/src/models/user.model/agent.model/index.ts
@@ -125,10 +125,6 @@ const agentSchema = new mongoose.Schema<IAgent, AgentModel>(
     ragCollectionName: {
       type: String
     },
-    useTranscriptRAGCollection: {
-      type: Boolean,
-      default: undefined
-    },
     triggers: {
       type: mongoose.Schema.Types.Mixed,
       default: undefined
@@ -561,9 +557,6 @@ agentSchema.pre('validate', function () {
   }
   if (this.ragCollectionName === undefined) {
     this.ragCollectionName = agentTypes[this.agentType].ragCollectionName
-  }
-  if (this.useTranscriptRAGCollection === undefined) {
-    this.useTranscriptRAGCollection = agentTypes[this.agentType].useTranscriptRAGCollection
   }
   // custom preValidate call when needed
   const { preValidate } = agentTypes[this.agentType]

--- a/src/services/conversation.service.ts
+++ b/src/services/conversation.service.ts
@@ -87,18 +87,12 @@ const startConversation = async (conversationOrId, user) => {
   logger.debug(`Start conversation: ${conversation._id}`)
 
   conversation.startTime = Date.now()
-  let transcriptRAG = false
   for (const agent of conversation.agents) {
     // needed so agent has all conversation info for activation
     agent.conversation = conversation
     await agentService.startAgent(agent)
-    if (agent.useTranscriptRAGCollection) {
-      transcriptRAG = true
-    }
   }
-  if (transcriptRAG) {
-    await scheduleTranscriptBatching(conversation)
-  }
+  await scheduleTranscriptBatching(conversation)
   for (const adapter of conversation.adapters) {
     adapter.conversation = conversation
     await adapterService.start(adapter)
@@ -124,18 +118,12 @@ const stopConversation = async (conversationOrId, user) => {
   logger.debug(`Stop conversation: ${conversation._id}`)
 
   conversation.endTime = new Date(Date.now())
-  let transcriptRAG = false
   for (const agent of conversation.agents) {
     // needed so agent has all conversation info for activation
     agent.conversation = conversation
     await agentService.stopAgent(agent)
-    if (agent.useTranscriptRAGCollection) {
-      transcriptRAG = true
-    }
   }
-  if (transcriptRAG) {
-    await schedule.cancelBatchTranscript(conversation._id)
-  }
+  await schedule.cancelBatchTranscript(conversation._id)
 
   for (const adapter of conversation.adapters) {
     adapter.conversation = conversation
@@ -194,17 +182,12 @@ const createConversation = async (conversationBody, user) => {
   // need to save to get id
   await conversation.save()
 
-  let transcriptRAG = false
-
   for (const agentType of conversationBody.agentTypes || []) {
     let agent
     if (typeof agentType === 'string') {
       agent = await agentService.createAgent(agentType, conversation)
     } else {
       agent = await agentService.createAgent(agentType.name, conversation, agentType.properties)
-    }
-    if (agent.useTranscriptRAGCollection) {
-      transcriptRAG = true
     }
     conversation.agents.push(agent)
   }
@@ -220,9 +203,7 @@ const createConversation = async (conversationBody, user) => {
 
   topic.conversations.push(conversation.toObject())
   await Promise.all([conversation.save(), topic.save()])
-  if (transcriptRAG) {
-    await transcript.loadEventMetadataIntoVectorStore(conversation)
-  }
+  await transcript.loadEventMetadataIntoVectorStore(conversation)
 
   websocketGateway.broadcastNewConversation(conversation)
 
@@ -273,15 +254,7 @@ const updateConversation = async (conversationBody, user) => {
   }
   conversationDoc = updateDocument(conversationBody, conversationDoc)
   await conversationDoc!.save()
-  let transcriptRAG = false
-  for (const agent of conversationDoc!.agents) {
-    if (agent.useTranscriptRAGCollection) {
-      transcriptRAG = true
-    }
-  }
-  if (transcriptRAG) {
-    await transcript.loadEventMetadataIntoVectorStore(conversationDoc!)
-  }
+  await transcript.loadEventMetadataIntoVectorStore(conversationDoc!)
   websocketGateway.broadcastConversationUpdate(conversationDoc)
   return conversationDoc
 }

--- a/src/services/conversation.service.ts
+++ b/src/services/conversation.service.ts
@@ -299,7 +299,7 @@ const findByIdFull = async (id, user) => {
   if (!conversation) {
     throw new ApiError(httpStatus.NOT_FOUND, `Conversation with id ${id} not found`)
   }
-  const followed = Follower.findOne({ conversation, user }).select('_id').exec() !== null
+  const followed = (await Follower.findOne({ conversation, user }).select('_id').exec()) !== null
   const conversationPojo = conversation.toObject({
     transform: (doc, ret: ConversationDocument) => {
       // Only transform the top-level conversation document

--- a/src/services/experiment.service.ts
+++ b/src/services/experiment.service.ts
@@ -41,13 +41,11 @@ async function runPeriodicExperiment(agent, experiment, simulatedStartTime?) {
 }
 
 async function runPerMessageExperiment(agent, experiment) {
-  if (agent.useTranscriptRAGCollection) {
-    await transcript.loadEventMetadataIntoVectorStore(experiment.resultConversation)
-    const transcriptMsgs = experiment.resultConversation.messages.filter((message) =>
-      message.channels.some((channel) => channel === 'transcript')
-    )
-    await transcript.loadTranscriptIntoVectorStore(transcriptMsgs, experiment.resultConversation._id)
-  }
+  await transcript.loadEventMetadataIntoVectorStore(experiment.resultConversation)
+  const transcriptMsgs = experiment.resultConversation.messages.filter((message) =>
+    message.channels.some((channel) => channel === 'transcript')
+  )
+  await transcript.loadTranscriptIntoVectorStore(transcriptMsgs, experiment.resultConversation._id)
   let filteredMessages = experiment.resultConversation.messages
 
   if (agent.triggers.perMessage.directMessages || agent.triggers.perMessage.channels) {

--- a/src/services/topic.service.ts
+++ b/src/services/topic.service.ts
@@ -26,7 +26,7 @@ const topicsWithSortData = async (topicQuery) => {
       select: 'id',
       populate: [{ path: 'messages', select: ['id', 'createdAt'], match: { visible: true } }]
     })
-    .select('name slug private votingAllowed conversationCreationAllowed archiveEmail owner')
+    .select('name slug description private votingAllowed conversationCreationAllowed archiveEmail owner archived')
     .exec()
 
   const topics: Array<ITopic> = await Promise.all(
@@ -82,6 +82,7 @@ const createTopic = async (topicBody, user) => {
 
   const topic = await Topic.create({
     name: topicBody.name,
+    description: topicBody.description,
     votingAllowed: topicBody.votingAllowed,
     conversationCreationAllowed: topicBody.conversationCreationAllowed,
     private: config.enablePublicChannelCreation ? topicBody.private : true,
@@ -141,7 +142,7 @@ const allTopicsByUser = async (user) => {
 const findById = async (id) => {
   const topic = await Topic.findOne({ _id: id })
     .populate('followers')
-    .select('name slug private votingAllowed conversationCreationAllowed owner')
+    .select('name slug description private votingAllowed conversationCreationAllowed owner')
     .exec()
   return topic
 }

--- a/src/services/topic.service.ts
+++ b/src/services/topic.service.ts
@@ -7,6 +7,7 @@ import Token from '../models/token.model.js'
 import ApiError from '../utils/ApiError.js'
 import config from '../config/config.js'
 import updateDocument from '../utils/updateDocument.js'
+import transcript from '../agents/helpers/transcript.js'
 import User from '../models/user.model/user.model.js'
 import { ITopic } from '../types/index.types.js'
 import { ConversationDocument } from '../models/conversation.model.js'
@@ -89,6 +90,7 @@ const createTopic = async (topicBody, user) => {
     passcode,
     owner: user
   })
+  await transcript.loadTopicMetadataIntoVectorStore(topic)
   return topic
 }
 /**
@@ -103,6 +105,7 @@ const updateTopic = async (topicBody) => {
   }
   topicDoc = updateDocument(topicBody, topicDoc)
   await topicDoc!.save()
+  await transcript.loadTopicMetadataIntoVectorStore(topicDoc)
   return topicDoc
 }
 const userTopics = async (user) => {
@@ -152,6 +155,7 @@ const deleteTopic = async (id) => {
   if (!topic) throw new ApiError(httpStatus.NOT_FOUND, 'Channel does not exist')
   topic.isDeleted = true
   await topic.save()
+  await transcript.deleteTopicCollection(topic)
 }
 const verifyPasscode = async (topicId, passcode) => {
   const topic = await Topic.findById(topicId)

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -481,5 +481,4 @@ export interface IAgent {
   triggers?: Triggers
   active?: boolean
   conversationHistorySettings?: ConversationHistorySettings
-  useTranscriptRAGCollection?: boolean
 }

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -45,6 +45,7 @@ export interface ITopic {
   id?: string
   slug?: string
   name: string
+  description?: string
   defaultSortAverage?: number
   followed?: boolean
   conversations: IConversation[]

--- a/src/utils/loadTopicTranscripts.ts
+++ b/src/utils/loadTopicTranscripts.ts
@@ -1,0 +1,38 @@
+/**
+ * Loads all conversations for a topic into both the per-conversation and topic-level
+ * transcript vector stores. Skips conversations already present in the topic collection.
+ *
+ * USAGE:
+ * NODE_ENV=... node --loader ts-node/esm src/utils/loadTopicTranscripts.ts <topicId>
+ */
+/* eslint-disable no-console */
+
+import mongoose from 'mongoose'
+import config from '../config/config.js'
+import transcript from '../agents/helpers/transcript.js'
+import rag from '../agents/helpers/rag.js'
+
+async function main() {
+  const topicId = process.argv[2]
+  if (!topicId) throw new Error('Usage: loadTopicTranscripts.ts <topicId>')
+
+  mongoose.set('strict', true)
+  await mongoose.connect(config.mongoose.url, config.mongoose.options)
+  console.log('Connected to MongoDB')
+
+  try {
+    const result = await transcript.loadTopicTranscriptsIntoVectorStore(topicId)
+    console.log(`Loaded ${result.loaded} conversations, skipped ${result.skipped}`)
+
+    await rag.checkCollections()
+  } finally {
+    await mongoose.connection.close()
+    console.log('Connection closed.')
+    process.exit(0)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/validations/topic.validation.ts
+++ b/src/validations/topic.validation.ts
@@ -3,6 +3,7 @@ import Joi from 'joi'
 const createTopic = {
   body: Joi.object().keys({
     name: Joi.string().required(),
+    description: Joi.string().allow(null, ''),
     votingAllowed: Joi.boolean().required(),
     conversationCreationAllowed: Joi.boolean().required(),
     private: Joi.boolean().required(),
@@ -14,6 +15,7 @@ const updateTopic = {
   body: Joi.object().keys({
     id: Joi.string().required(),
     name: Joi.string(),
+    description: Joi.string().allow(null, ''),
     slug: Joi.string(),
     votingAllowed: Joi.boolean(),
     conversationCreationAllowed: Joi.boolean(),

--- a/tests/agents/eventHistorian/eventHistorian.agent.test.ts
+++ b/tests/agents/eventHistorian/eventHistorian.agent.test.ts
@@ -1,0 +1,366 @@
+/* eslint-disable no-console */
+import mongoose from 'mongoose'
+import setupAgentTest from '../../utils/setupAgentTest.js'
+import defaultAgentTypes from '../../../src/agents/index.js'
+import {
+  createUser,
+  createConversation,
+  createPublicTopic,
+  createMessage,
+  loadPartTimeWorkTranscript,
+  loadAliensTranscript
+} from '../../utils/agentTestHelpers.js'
+import { Agent, Channel } from '../../../src/models/index.js'
+import { ConversationHistory } from '../../../src/types/index.types.js'
+import { newPublicTopic, insertTopics } from '../../fixtures/topic.fixture.js'
+
+jest.setTimeout(300000)
+
+const testConfig = setupAgentTest('eventHistorian')
+
+const BOT_NAME = 'Berkie'
+
+describe('eventHistorian agent tests', () => {
+  let agent
+  let conversation
+  let topic
+  let user1
+  let user2
+  let user3
+
+  async function createEventHistorianConversation() {
+    const conv = await createConversation({ name: 'Event Historian Test Conversation' }, user1, topic)
+    const testAgent = new Agent({
+      agentType: 'eventHistorian',
+      conversation: conv,
+      llmPlatform: testConfig.llmPlatform,
+      llmModel: testConfig.llmModel,
+      agentConfig: { botName: BOT_NAME }
+    })
+    const channels = await Channel.create([{ name: 'eventHistorian' }])
+    conv.channels.push(...channels)
+    await testAgent.save()
+    conv.agents.push(testAgent)
+    await conv.save()
+    await testAgent.initialize()
+    await testAgent.start()
+    return { conv, testAgent }
+  }
+
+  beforeEach(async () => {
+    topic = await createPublicTopic()
+    user1 = await createUser('Alice')
+    user2 = await createUser('Bob')
+    user3 = await createUser('Carol')
+    const result = await createEventHistorianConversation()
+    conversation = result.conv
+    agent = result.testAgent
+  })
+
+  function buildHistory(messages): ConversationHistory {
+    return {
+      start: new Date(Date.now() - 60 * 60 * 1000),
+      end: new Date(),
+      messages
+    }
+  }
+
+  async function ask(body, user = user1) {
+    console.log(`Q (${user.pseudonyms[0].pseudonym}): ${body}`)
+    return createMessage(body, user, conversation, ['historian'])
+  }
+
+  async function respond(history: ConversationHistory, userMessage) {
+    const responses = await defaultAgentTypes.eventHistorian.respond.call(agent, history, userMessage)
+    console.log(`A: ${responses[0]?.message}`)
+    return responses
+  }
+
+  it('responds to a direct @mention with no prior history', async () => {
+    const msg = await ask(`@${BOT_NAME} what is the capital of France?`)
+    const responses = await respond(buildHistory([]), msg)
+
+    expect(responses).toHaveLength(1)
+    expect(responses[0].message).toBeDefined()
+    expect(responses[0].message.toLowerCase()).toContain('paris')
+  })
+
+  it('responds sensibly with multi-user history containing consecutive user messages', async () => {
+    // Simulate a multi-user group chat where multiple users post back-to-back
+    // without any agent response in between — this creates consecutive 'user' role
+    // messages that previously triggered placeholder injection
+    const t = Date.now()
+    const history = buildHistory([
+      await createMessage(
+        'Anyone know a good way to learn TypeScript?',
+        user1,
+        conversation,
+        ['historian'],
+        new Date(t - 5000)
+      ),
+      await createMessage(
+        'I found the official docs really helpful',
+        user2,
+        conversation,
+        ['historian'],
+        new Date(t - 4000)
+      ),
+      await createMessage(
+        'Same, plus the TS playground is great for experimenting',
+        user3,
+        conversation,
+        ['historian'],
+        new Date(t - 3000)
+      ),
+      await createMessage('What about books?', user2, conversation, ['historian'], new Date(t - 2000)),
+      await createMessage(
+        'Programming TypeScript by Boris Cherny is solid',
+        user1,
+        conversation,
+        ['historian'],
+        new Date(t - 1000)
+      )
+    ])
+
+    const msg = await ask(`@${BOT_NAME} can you summarize the best ways to learn TypeScript?`)
+    const responses = await respond(history, msg)
+
+    expect(responses).toHaveLength(1)
+    expect(responses[0].message).toBeDefined()
+    // Should synthesize the conversation — mention at least one concrete resource
+    expect(responses[0].message.toLowerCase()).toMatch(/docs|playground|book|typescript/)
+  })
+
+  it('uses prior conversation context when answering a follow-up', async () => {
+    // Agent's own prior response should appear as 'assistant' role in history
+    const t = Date.now()
+    const agentPriorResponse = {
+      body: 'The Eiffel Tower is located in Paris, France.',
+      bodyType: 'text',
+      conversation: conversation._id,
+      pseudonym: BOT_NAME,
+      pseudonymId: new mongoose.Types.ObjectId(),
+      owner: agent._id,
+      channels: ['historian'],
+      fromAgent: true,
+      visible: true,
+      createdAt: new Date(t - 2000),
+      updatedAt: new Date(t - 2000),
+      upVotes: [],
+      downVotes: [],
+      pause: false
+    }
+
+    const history = buildHistory([
+      await createMessage(`@${BOT_NAME} where is the Eiffel Tower?`, user1, conversation, ['historian'], new Date(t - 3000)),
+      agentPriorResponse,
+      await createMessage('Interesting!', user2, conversation, ['historian'], new Date(t - 1000))
+    ])
+
+    const msg = await ask(`@${BOT_NAME} how tall is it?`)
+    const responses = await respond(history, msg)
+
+    // Should reference the Eiffel Tower from context without needing it re-stated
+    expect(responses[0].message.toLowerCase()).toMatch(/\d+\s*(meter|metre|feet|foot|m\b|ft\b)/)
+  })
+
+  describe('answers event history questions using event history tools', () => {
+    let eventTopic
+    let partTimeConv
+    let aliensConv
+    let eventHistorian
+    let eventConversation
+
+    beforeEach(async () => {
+      // Create a dedicated topic holding the event series
+      eventTopic = newPublicTopic()
+      await insertTopics([eventTopic])
+
+      // Two past events in that series with realistic dates in the current year
+      partTimeConv = await createConversation(
+        {
+          name: 'Why your company should consider part-time work',
+          description: `No one wants to work anymore." Entrepreneur Jessica Drain believes otherwise—instead it's that businesses aren't structuring jobs to attract and retain the widest number of people possible, including those with a limited number of hours to give to a career. 
+
+Speaking about her own experience as a single mother and professional, Jessica delineates how she's grown a seven-figure business in part-time hours with a small team of part-time employees, and how recent research shows that jobs with lower hour requirements improve employee recruitment, retention, and productivity – not the other way around.  A career marketer and graphic designer, Jessica has helped businesses brand and market themselves for almost two decades.
+
+In 2018, she and her sister innovated a new tool for the sewing world – SewTites® Magnetic Sewing Pins™ – and founded a company with the same name.
+
+Since then, Jessica has led the company to a 7-figure annual business – all in part-time hours with a small team of part-time employees.
+
+A single mom of two children with primary custody, she is passionate about finding value in and creating work for people who don’t have the desire or ability to work full-time hours but still want and need to earn a living.`,
+          presenters: [{ name: 'Jessica Drain', bio: 'Entrepreneur and advocate for flexible work arrangements' }]
+        },
+        user1,
+        eventTopic,
+        new Date('2026-01-15T18:00:00Z')
+      )
+      aliensConv = await createConversation(
+        {
+          name: 'Where are all the aliens?',
+          description: `The universe is incredibly old, astoundingly vast and populated by trillions of planets -- so where are all the aliens? Astronomer Stephen Webb has an explanation: we're alone in the universe. In a mind-expanding talk, he spells out the remarkable barriers a planet would need to clear in order to host an extraterrestrial civilization -- and makes a case for the beauty of our potential cosmic loneliness. "The silence of the universe is shouting, 'We're the creatures who got lucky,'" Webb says.`,
+          presenters: [
+            {
+              name: 'Stephen Webb',
+              bio: 'Stephen Webb is a physicist and author of numerous popular science and math books, as well as academic publications.'
+            }
+          ]
+        },
+        user1,
+        eventTopic,
+        new Date('2026-03-10T18:00:00Z')
+      )
+
+      // Load transcripts into both per-conversation and topic-level vector stores
+      await loadPartTimeWorkTranscript(partTimeConv, true)
+      await loadAliensTranscript(aliensConv, true)
+
+      // Create an eventHistorian agent configured to know about this event series
+      eventConversation = await createConversation({ name: 'Event Historian Test' }, user1, topic)
+      eventHistorian = new Agent({
+        agentType: 'eventHistorian',
+        conversation: eventConversation,
+        llmPlatform: testConfig.llmPlatform,
+        llmModel: testConfig.llmModel,
+        agentConfig: { botName: BOT_NAME, topicIds: [eventTopic._id.toString()] }
+      })
+      const channels = await Channel.create([{ name: 'historian' }])
+      eventConversation.channels.push(...channels)
+      await eventHistorian.save()
+      eventConversation.agents.push(eventHistorian)
+      await eventConversation.save()
+      await eventHistorian.initialize()
+      await eventHistorian.start()
+    })
+
+    async function askEventHistorian(body: string) {
+      console.log(`Q: ${body}`)
+      const msg = await createMessage(body, user1, eventConversation, ['historian'])
+      const responses = await defaultAgentTypes.eventHistorian.respond.call(eventHistorian, buildHistory([]), msg)
+      console.log(`A: ${responses[0]?.message}`)
+      return responses
+    }
+
+    it('lists all events since January with one-sentence summaries', async () => {
+      const responses = await askEventHistorian(
+        `@${BOT_NAME} give me a one sentence summary and name of all events since January 2026`
+      )
+
+      expect(responses).toHaveLength(1)
+      expect(responses[0].message).toBeDefined()
+      // Should name both events that exist in the series
+      expect(responses[0].message).toContain('Why your company should consider part-time work')
+      expect(responses[0].message).toContain('Where are all the aliens?')
+    })
+
+    it('identifies a speaker on extraterrestrials and UFOs', async () => {
+      const responses = await askEventHistorian(`@${BOT_NAME} who was the speaker we had that talked about UFOs and aliens?`)
+
+      expect(responses).toHaveLength(1)
+      expect(responses[0].message).toBeDefined()
+      expect(responses[0].message.toLowerCase()).toMatch(/Webb/i)
+    })
+
+    it('identifies which events covered part-time work and flexible employment', async () => {
+      const responses = await askEventHistorian(`@${BOT_NAME} which events covered part-time work or flexible employment?`)
+
+      expect(responses).toHaveLength(1)
+      expect(responses[0].message).toBeDefined()
+      expect(responses[0].message).toContain('Why your company should consider part-time work')
+      expect(responses[0].message.toLowerCase()).toMatch(/part.time|flexib|work/)
+    })
+
+    it('retrieves what a specific presenter said on a specific topic at a specific event', async () => {
+      const responses = await askEventHistorian(
+        `@${BOT_NAME} what did Jessica say about working 40 hours per week at the part-time work event?`
+      )
+
+      expect(responses).toHaveLength(1)
+      expect(responses[0].message).toBeDefined()
+      // Jessica's transcript explicitly challenges the 40-hour full-time norm
+      expect(responses[0].message.toLowerCase()).toMatch(/40 hours|fulltime|full.time|framework|hundred years/)
+    })
+  })
+
+  describe('uses all public topics when topicIds is not configured', () => {
+    let eventTopic
+    let partTimeConv
+    let aliensConv
+    let eventHistorianNoTopicIds
+    let eventConversation
+
+    beforeEach(async () => {
+      // Create a public topic — not passed to agentConfig, should be auto-discovered
+      eventTopic = newPublicTopic()
+      await insertTopics([eventTopic])
+
+      partTimeConv = await createConversation(
+        {
+          name: 'Why your company should consider part-time work',
+          description: 'Talk by Jessica Drain about building a seven-figure business with part-time employees.',
+          presenters: [{ name: 'Jessica Drain', bio: 'Entrepreneur and advocate for flexible work arrangements' }]
+        },
+        user1,
+        eventTopic,
+        new Date('2026-01-15T18:00:00Z')
+      )
+      aliensConv = await createConversation(
+        {
+          name: 'Where are all the aliens?',
+          description: 'Astronomer Stephen Webb makes the case that we may be alone in the universe.',
+          presenters: [{ name: 'Stephen Webb', bio: 'Physicist and popular science author.' }]
+        },
+        user1,
+        eventTopic,
+        new Date('2026-03-10T18:00:00Z')
+      )
+
+      await loadPartTimeWorkTranscript(partTimeConv, true)
+      await loadAliensTranscript(aliensConv, true)
+
+      // Agent created with NO topicIds — should fall back to all public topics
+      eventConversation = await createConversation({ name: 'Event Historian No TopicIds Test' }, user1, topic)
+      eventHistorianNoTopicIds = new Agent({
+        agentType: 'eventHistorian',
+        conversation: eventConversation,
+        llmPlatform: testConfig.llmPlatform,
+        llmModel: testConfig.llmModel,
+        agentConfig: { botName: BOT_NAME }
+      })
+      const channels = await Channel.create([{ name: 'historian' }])
+      eventConversation.channels.push(...channels)
+      await eventHistorianNoTopicIds.save()
+      eventConversation.agents.push(eventHistorianNoTopicIds)
+      await eventConversation.save()
+      await eventHistorianNoTopicIds.initialize()
+      await eventHistorianNoTopicIds.start()
+    })
+
+    async function askNoTopicIds(body: string) {
+      console.log(`Q: ${body}`)
+      const msg = await createMessage(body, user1, eventConversation, ['historian'])
+      const responses = await defaultAgentTypes.eventHistorian.respond.call(eventHistorianNoTopicIds, buildHistory([]), msg)
+      console.log(`A: ${responses[0]?.message}`)
+      return responses
+    }
+
+    it('lists events from auto-discovered public topics', async () => {
+      const responses = await askNoTopicIds(
+        `@${BOT_NAME} give me a one sentence summary and name of all events since January 2026`
+      )
+
+      expect(responses).toHaveLength(1)
+      expect(responses[0].message).toBeDefined()
+      expect(responses[0].message).toContain('Why your company should consider part-time work')
+      expect(responses[0].message).toContain('Where are all the aliens?')
+    })
+
+    it('answers a speaker question using auto-discovered topics', async () => {
+      const responses = await askNoTopicIds(`@${BOT_NAME} who was the speaker that talked about aliens?`)
+
+      expect(responses).toHaveLength(1)
+      expect(responses[0].message).toBeDefined()
+      expect(responses[0].message.toLowerCase()).toMatch(/webb/i)
+    })
+  })
+})

--- a/tests/agents/helpers/transcript.test.ts
+++ b/tests/agents/helpers/transcript.test.ts
@@ -1090,10 +1090,7 @@ describe('transcript', () => {
     })
 
     it('should clear only transcript content from vector store and preserve metadata', async () => {
-      const conversation = {
-        _id: 'conv123',
-        agents: [{ useTranscriptRAGCollection: true }]
-      }
+      const conversation = { _id: 'conv123' }
 
       await transcript.clearTranscript(conversation)
 
@@ -1113,27 +1110,8 @@ describe('transcript', () => {
       })
     })
 
-    it('should skip vector store operations when no agents use RAG', async () => {
-      const conversation = {
-        _id: 'conv123',
-        agents: [{ useTranscriptRAGCollection: false }]
-      }
-
-      await transcript.clearTranscript(conversation)
-
-      expect(ragRemoveFromVectorStoreSpy).not.toHaveBeenCalled()
-      expect(ragDeleteCollectionSpy).not.toHaveBeenCalled()
-
-      // Should still delete messages
-      expect(messageFindSpy).toHaveBeenCalled()
-      expect(messageDeleteManySpy).toHaveBeenCalled()
-    })
-
     it('should handle errors when clearing from vector store', async () => {
-      const conversation = {
-        _id: 'conv123',
-        agents: [{ useTranscriptRAGCollection: true }]
-      }
+      const conversation = { _id: 'conv123' }
 
       ragRemoveFromVectorStoreSpy.mockRejectedValue(new Error('Vector store error'))
 
@@ -1167,10 +1145,7 @@ describe('transcript', () => {
     })
 
     it('should delete entire collection from vector store including metadata', async () => {
-      const conversation = {
-        _id: 'conv123',
-        agents: [{ useTranscriptRAGCollection: true }]
-      }
+      const conversation = { _id: 'conv123' }
 
       await transcript.deleteTranscript(conversation)
 
@@ -1187,26 +1162,8 @@ describe('transcript', () => {
       })
     })
 
-    it('should skip vector store operations when no agents use RAG', async () => {
-      const conversation = {
-        _id: 'conv123',
-        agents: [{ useTranscriptRAGCollection: false }]
-      }
-
-      await transcript.deleteTranscript(conversation)
-
-      expect(ragDeleteCollectionSpy).not.toHaveBeenCalled()
-
-      // Should still delete messages
-      expect(messageFindSpy).toHaveBeenCalled()
-      expect(messageDeleteManySpy).toHaveBeenCalled()
-    })
-
     it('should handle errors when deleting collection', async () => {
-      const conversation = {
-        _id: 'conv123',
-        agents: [{ useTranscriptRAGCollection: true }]
-      }
+      const conversation = { _id: 'conv123' }
 
       ragDeleteCollectionSpy.mockRejectedValue(new Error('Collection delete error'))
 
@@ -1215,22 +1172,6 @@ describe('transcript', () => {
 
       // Should still delete messages
       expect(messageDeleteManySpy).toHaveBeenCalled()
-    })
-
-    it('should handle conversations with multiple agents', async () => {
-      const conversation = {
-        _id: 'conv123',
-        agents: [
-          { useTranscriptRAGCollection: false },
-          { useTranscriptRAGCollection: true },
-          { useTranscriptRAGCollection: false }
-        ]
-      }
-
-      await transcript.deleteTranscript(conversation)
-
-      // Should delete collection if at least one agent uses RAG
-      expect(ragDeleteCollectionSpy).toHaveBeenCalledWith(`${TRANSCRIPT_COLLECTION_PREFIX}-conv123`)
     })
   })
 })

--- a/tests/agents/helpers/transcript.test.ts
+++ b/tests/agents/helpers/transcript.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import transcript from '../../../src/agents/helpers/transcript.js'
+import transcript, { TOPIC_TRANSCRIPT_COLLECTION_PREFIX } from '../../../src/agents/helpers/transcript.js'
 import rag, { TRANSCRIPT_COLLECTION_PREFIX } from '../../../src/agents/helpers/rag.js'
 import Conversation from '../../../src/models/conversation.model.js'
 import Message from '../../../src/models/message.model.js'
@@ -226,6 +226,7 @@ describe('transcript', () => {
   let ragAddToVectorStoreSpy
   let ragRemoveFromVectorStoreSpy
   const localHour = new Date('2024-01-15T10:00:00Z').getHours()
+  const utcHour = new Date('2024-01-15T10:00:00Z').getUTCHours()
 
   beforeEach(() => {
     // Create spies on the rag module methods
@@ -685,16 +686,23 @@ describe('transcript', () => {
         channels: ['transcript']
       }
     ]
-    const mockFormattedTranscript = `[${localHour}:05:30 AM] Hello everyone
-[${localHour}:06:15 AM] Let's start the meeting
-[${localHour}:07:00 AM] First item on the agenda`
+    const mockFormattedTranscript = `[${utcHour}:05:30 AM] Hello everyone
+[${utcHour}:06:15 AM] Let's start the meeting
+[${utcHour}:07:00 AM] First item on the agenda`
 
     beforeEach(() => {
       ragAddToVectorStoreSpy.mockResolvedValue()
     })
 
-    it('should load transcript into vector store with proper metadata', async () => {
+    it('should load transcript into per-conversation vector store with proper metadata', async () => {
+      jest.spyOn(Conversation, 'findById').mockReturnValue({
+        select() {
+          return { lean: async () => ({ name: 'Test Conversation', topic: null, transcript: {} }) }
+        }
+      } as any)
+
       await transcript.loadTranscriptIntoVectorStore(mockMessages, mockConversationId)
+
       expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
         'event-transcript-conversation456',
         [mockFormattedTranscript],
@@ -713,8 +721,78 @@ describe('transcript', () => {
       expect(newDoc.metadata!).toEqual({
         start: new Date('2024-01-15T10:05:30Z').getTime(),
         end: new Date('2024-01-15T10:07:00Z').getTime(),
-        type: 'transcript'
+        type: 'transcript',
+        conversationId: 'conversation456',
+        conversationName: 'Test Conversation'
       })
+    })
+
+    it('should also write to topic collection when conversation belongs to a topic', async () => {
+      jest.spyOn(Conversation, 'findById').mockReturnValue({
+        select() {
+          return { lean: async () => ({ name: 'Test Conversation', topic: 'topic789', transcript: {} }) }
+        }
+      } as any)
+
+      await transcript.loadTranscriptIntoVectorStore(mockMessages, mockConversationId)
+
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledTimes(2)
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
+        'event-transcript-conversation456',
+        [mockFormattedTranscript],
+        expect.objectContaining({ metadataFn: expect.any(Function) })
+      )
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
+        `${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-topic789`,
+        [mockFormattedTranscript],
+        expect.objectContaining({ metadataFn: expect.any(Function) })
+      )
+    })
+
+    it('should use per-conversation embeddings for per-conv collection but default embeddings for topic collection', async () => {
+      jest.spyOn(Conversation, 'findById').mockReturnValue({
+        select() {
+          return {
+            lean: async () => ({
+              name: 'Test Conversation',
+              topic: 'topic789',
+              transcript: { vectorStore: { embeddingsPlatform: 'openai', embeddingsModelName: 'text-embedding-3-large' } }
+            })
+          }
+        }
+      } as any)
+
+      await transcript.loadTranscriptIntoVectorStore(mockMessages, mockConversationId)
+
+      // Per-conversation collection gets custom embeddings
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
+        'event-transcript-conversation456',
+        expect.any(Array),
+        expect.objectContaining({ embeddingsPlatform: 'openai', embeddingsModelName: 'text-embedding-3-large' })
+      )
+      // Topic collection always uses default embeddings (no platform/model passed)
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
+        `${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-topic789`,
+        expect.any(Array),
+        expect.not.objectContaining({ embeddingsPlatform: expect.anything() })
+      )
+    })
+
+    it('should not write to topic collection when conversation has no topic', async () => {
+      jest.spyOn(Conversation, 'findById').mockReturnValue({
+        select() {
+          return { lean: async () => ({ name: 'Test Conversation', topic: null, transcript: {} }) }
+        }
+      } as any)
+
+      await transcript.loadTranscriptIntoVectorStore(mockMessages, mockConversationId)
+
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledTimes(1)
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
+        'event-transcript-conversation456',
+        expect.any(Array),
+        expect.any(Object)
+      )
     })
 
     it('should handle empty messages array', async () => {
@@ -840,12 +918,18 @@ describe('transcript', () => {
     })
   })
   describe('loadEventMetadataIntoVectorStore', () => {
+    const convId = 'test-conversation-id'
+    const convName = 'Test Event'
+
     beforeEach(() => {
       ragAddToVectorStoreSpy.mockResolvedValue()
+      ragRemoveFromVectorStoreSpy.mockResolvedValue()
     })
+
     it('should load all event metadata when all parameters provided', async () => {
       const conversation = {
-        _id: 'test-conversation-id',
+        _id: convId,
+        name: convName,
         description: 'This is a test event description about AI and machine learning.',
         presenters: [
           { name: 'Jane Doe', bio: 'Jane is a leading researcher in AI with 10 years of experience.' },
@@ -857,83 +941,103 @@ describe('transcript', () => {
       await transcript.loadEventMetadataIntoVectorStore(conversation)
 
       expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalled()
-
       expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
-        `${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`,
+        `${TRANSCRIPT_COLLECTION_PREFIX}-${convId}`,
         [
-          'Event (Meeting Conversation Presentation) Description: This is a test event description about AI and machine learning.',
+          'Event: Test Event. This is a test event description about AI and machine learning.',
           'Jane Doe is a speaker, presenter, and panelist at this event. Jane is a leading researcher in AI with 10 years of experience.',
           'John Smith is a speaker, presenter, and panelist at this event. John specializes in machine learning applications.',
           'Alice Johnson is the moderator, facilitator, and host of this event. Alice has moderated tech panels for 5 years.'
         ],
         {
           metadatas: [
-            { type: 'event' },
-            { type: 'presenter', presenterName: 'Jane Doe' },
-            { type: 'presenter', presenterName: 'John Smith' },
-            { type: 'moderator', moderatorName: 'Alice Johnson' }
+            { type: 'event', conversationId: convId, conversationName: convName },
+            { type: 'presenter', presenterName: 'Jane Doe', conversationId: convId, conversationName: convName },
+            { type: 'presenter', presenterName: 'John Smith', conversationId: convId, conversationName: convName },
+            { type: 'moderator', moderatorName: 'Alice Johnson', conversationId: convId, conversationName: convName }
           ]
         }
       )
     })
 
-    it('should load only event description when only that is provided', async () => {
-      const conversation = { _id: 'test-conversation-id', description: 'This is a test event description.' }
+    it('should include event name and description in event doc', async () => {
+      const conversation = { _id: convId, name: convName, description: 'This is a test event description.' }
 
       await transcript.loadEventMetadataIntoVectorStore(conversation)
 
-      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalled()
-
       expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
-        `${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`,
-        ['Event (Meeting Conversation Presentation) Description: This is a test event description.'],
+        `${TRANSCRIPT_COLLECTION_PREFIX}-${convId}`,
+        ['Event: Test Event. This is a test event description.'],
         {
-          metadatas: [{ type: 'event' }]
+          metadatas: [{ type: 'event', conversationId: convId, conversationName: convName }]
         }
       )
     })
 
-    it('should load only presenters when only those are provided', async () => {
+    it('should always write event name doc even with no description or presenters', async () => {
+      const conversation = { _id: convId, name: convName }
+
+      await transcript.loadEventMetadataIntoVectorStore(conversation)
+
+      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalled()
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
+        `${TRANSCRIPT_COLLECTION_PREFIX}-${convId}`,
+        ['Event: Test Event'],
+        {
+          metadatas: [{ type: 'event', conversationId: convId, conversationName: convName }]
+        }
+      )
+    })
+
+    it('should write event name doc plus presenters when only presenters provided', async () => {
       const conversation = {
-        _id: 'test-conversation-id',
+        _id: convId,
+        name: convName,
         presenters: [{ name: 'Jane Doe', bio: 'Jane is a leading researcher.' }]
       }
 
       await transcript.loadEventMetadataIntoVectorStore(conversation)
 
-      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalled()
-
       expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
-        `${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`,
-        ['Jane Doe is a speaker, presenter, and panelist at this event. Jane is a leading researcher.'],
+        `${TRANSCRIPT_COLLECTION_PREFIX}-${convId}`,
+        ['Event: Test Event', 'Jane Doe is a speaker, presenter, and panelist at this event. Jane is a leading researcher.'],
         {
-          metadatas: [{ type: 'presenter', presenterName: 'Jane Doe' }]
+          metadatas: [
+            { type: 'event', conversationId: convId, conversationName: convName },
+            { type: 'presenter', presenterName: 'Jane Doe', conversationId: convId, conversationName: convName }
+          ]
         }
       )
     })
 
-    it('should load only moderators when only those are provided', async () => {
+    it('should write event name doc plus moderators when only moderators provided', async () => {
       const conversation = {
-        _id: 'test-conversation-id',
+        _id: convId,
+        name: convName,
         moderators: [{ name: 'Alice Johnson', bio: 'Alice has moderated panels.' }]
       }
 
       await transcript.loadEventMetadataIntoVectorStore(conversation)
 
-      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalled()
-
       expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
-        `${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`,
-        ['Alice Johnson is the moderator, facilitator, and host of this event. Alice has moderated panels.'],
+        `${TRANSCRIPT_COLLECTION_PREFIX}-${convId}`,
+        [
+          'Event: Test Event',
+          'Alice Johnson is the moderator, facilitator, and host of this event. Alice has moderated panels.'
+        ],
         {
-          metadatas: [{ type: 'moderator', moderatorName: 'Alice Johnson' }]
+          metadatas: [
+            { type: 'event', conversationId: convId, conversationName: convName },
+            { type: 'moderator', moderatorName: 'Alice Johnson', conversationId: convId, conversationName: convName }
+          ]
         }
       )
     })
 
     it('should handle presenters without bios', async () => {
       const conversation = {
-        _id: 'test-conversation-id',
+        _id: convId,
+        name: convName,
         presenters: [
           { name: 'Jane Doe', bio: null },
           { name: 'John Smith' } // no bio property
@@ -942,18 +1046,18 @@ describe('transcript', () => {
 
       await transcript.loadEventMetadataIntoVectorStore(conversation)
 
-      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalled()
-
       expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
-        `${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`,
+        `${TRANSCRIPT_COLLECTION_PREFIX}-${convId}`,
         [
+          'Event: Test Event',
           'Jane Doe is a speaker, presenter, and panelist at this event. No bio provided.',
           'John Smith is a speaker, presenter, and panelist at this event. No bio provided.'
         ],
         {
           metadatas: [
-            { type: 'presenter', presenterName: 'Jane Doe' },
-            { type: 'presenter', presenterName: 'John Smith' }
+            { type: 'event', conversationId: convId, conversationName: convName },
+            { type: 'presenter', presenterName: 'Jane Doe', conversationId: convId, conversationName: convName },
+            { type: 'presenter', presenterName: 'John Smith', conversationId: convId, conversationName: convName }
           ]
         }
       )
@@ -961,24 +1065,25 @@ describe('transcript', () => {
 
     it('should handle moderators without bios', async () => {
       const conversation = {
-        _id: 'test-conversation-id',
+        _id: convId,
+        name: convName,
         moderators: [{ name: 'Alice Johnson', bio: '' }, { name: 'Bob Wilson' }]
       }
 
       await transcript.loadEventMetadataIntoVectorStore(conversation)
 
-      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalled()
-
       expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
-        `${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`,
+        `${TRANSCRIPT_COLLECTION_PREFIX}-${convId}`,
         [
+          'Event: Test Event',
           'Alice Johnson is the moderator, facilitator, and host of this event. No bio provided.',
           'Bob Wilson is the moderator, facilitator, and host of this event. No bio provided.'
         ],
         {
           metadatas: [
-            { type: 'moderator', moderatorName: 'Alice Johnson' },
-            { type: 'moderator', moderatorName: 'Bob Wilson' }
+            { type: 'event', conversationId: convId, conversationName: convName },
+            { type: 'moderator', moderatorName: 'Alice Johnson', conversationId: convId, conversationName: convName },
+            { type: 'moderator', moderatorName: 'Bob Wilson', conversationId: convId, conversationName: convName }
           ]
         }
       )
@@ -986,7 +1091,8 @@ describe('transcript', () => {
 
     it('should handle multiple presenters and moderators', async () => {
       const conversation = {
-        _id: 'test-conversation-id',
+        _id: convId,
+        name: convName,
         presenters: [
           { name: 'Presenter 1', bio: 'Bio 1' },
           { name: 'Presenter 2', bio: 'Bio 2' },
@@ -1000,11 +1106,10 @@ describe('transcript', () => {
 
       await transcript.loadEventMetadataIntoVectorStore(conversation)
 
-      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalled()
-
       expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
-        `${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`,
+        `${TRANSCRIPT_COLLECTION_PREFIX}-${convId}`,
         [
+          'Event: Test Event',
           'Presenter 1 is a speaker, presenter, and panelist at this event. Bio 1',
           'Presenter 2 is a speaker, presenter, and panelist at this event. Bio 2',
           'Presenter 3 is a speaker, presenter, and panelist at this event. Bio 3',
@@ -1013,56 +1118,71 @@ describe('transcript', () => {
         ],
         {
           metadatas: [
-            { type: 'presenter', presenterName: 'Presenter 1' },
-            { type: 'presenter', presenterName: 'Presenter 2' },
-            { type: 'presenter', presenterName: 'Presenter 3' },
-            { type: 'moderator', moderatorName: 'Moderator 1' },
-            { type: 'moderator', moderatorName: 'Moderator 2' }
+            { type: 'event', conversationId: convId, conversationName: convName },
+            { type: 'presenter', presenterName: 'Presenter 1', conversationId: convId, conversationName: convName },
+            { type: 'presenter', presenterName: 'Presenter 2', conversationId: convId, conversationName: convName },
+            { type: 'presenter', presenterName: 'Presenter 3', conversationId: convId, conversationName: convName },
+            { type: 'moderator', moderatorName: 'Moderator 1', conversationId: convId, conversationName: convName },
+            { type: 'moderator', moderatorName: 'Moderator 2', conversationId: convId, conversationName: convName }
           ]
         }
       )
     })
 
-    it('should handle empty presenters array', async () => {
-      const conversation = { _id: 'test-conversation-id', description: 'Test event', presenters: [] }
+    it('should also write to topic collection when conversation has a topic', async () => {
+      const topicId = 'topic-abc'
+      const conversation = {
+        _id: convId,
+        name: convName,
+        topic: topicId,
+        description: 'An event about AI.',
+        presenters: [{ name: 'Jane Doe', bio: 'AI researcher.' }]
+      }
+      const expectedDocs = [
+        'Event: Test Event. An event about AI.',
+        'Jane Doe is a speaker, presenter, and panelist at this event. AI researcher.'
+      ]
+      const expectedMetadatas = [
+        { type: 'event', conversationId: convId, conversationName: convName },
+        { type: 'presenter', presenterName: 'Jane Doe', conversationId: convId, conversationName: convName }
+      ]
 
       await transcript.loadEventMetadataIntoVectorStore(conversation)
 
-      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalled()
-
-      expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
-        `${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`,
-        ['Event (Meeting Conversation Presentation) Description: Test event'],
-        {
-          metadatas: [{ type: 'event' }]
-        }
-      )
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledTimes(2)
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(`${TRANSCRIPT_COLLECTION_PREFIX}-${convId}`, expectedDocs, {
+        metadatas: expectedMetadatas
+      })
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(`${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`, expectedDocs, {
+        metadatas: expectedMetadatas
+      })
     })
 
-    it('should handle empty moderators array', async () => {
-      const conversation = { _id: 'test-conversation-id', description: 'Test event', moderators: [] }
+    it('should remove stale metadata from topic collection using $and filter', async () => {
+      const topicId = 'topic-abc'
+      const conversation = { _id: convId, name: convName, topic: topicId }
 
       await transcript.loadEventMetadataIntoVectorStore(conversation)
 
-      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalled()
-
-      expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
-        `${TRANSCRIPT_COLLECTION_PREFIX}-${conversation._id}`,
-        ['Event (Meeting Conversation Presentation) Description: Test event'],
-        {
-          metadatas: [{ type: 'event' }]
-        }
-      )
+      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalledWith(`${TRANSCRIPT_COLLECTION_PREFIX}-${convId}`, {
+        type: { $in: ['event', 'presenter', 'moderator'] }
+      })
+      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalledWith(`${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-${topicId}`, {
+        $and: [{ conversationId: convId }, { type: { $in: ['event', 'presenter', 'moderator'] } }]
+      })
     })
 
-    it('should not call addTextsToVectorStore when no metadata provided', async () => {
-      const conversation = { _id: 'test-conversation-id' }
+    it('should not write to topic collection when conversation has no topic', async () => {
+      const conversation = { _id: convId, name: convName }
 
       await transcript.loadEventMetadataIntoVectorStore(conversation)
 
-      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalled()
-
-      expect(ragAddToVectorStoreSpy).not.toHaveBeenCalled()
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledTimes(1)
+      expect(ragAddToVectorStoreSpy).toHaveBeenCalledWith(
+        `${TRANSCRIPT_COLLECTION_PREFIX}-${convId}`,
+        expect.any(Array),
+        expect.any(Object)
+      )
     })
   })
 
@@ -1110,6 +1230,30 @@ describe('transcript', () => {
       })
     })
 
+    it('should also clear transcript from topic collection using $and filter', async () => {
+      const conversation = { _id: 'conv123', topic: { _id: 'topic456' } }
+
+      await transcript.clearTranscript(conversation)
+
+      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalledWith(`${TRANSCRIPT_COLLECTION_PREFIX}-conv123`, {
+        type: 'transcript'
+      })
+      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalledWith(`${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-topic456`, {
+        $and: [{ conversationId: 'conv123' }, { type: 'transcript' }]
+      })
+    })
+
+    it('should not remove from topic collection when conversation has no topic', async () => {
+      const conversation = { _id: 'conv123' }
+
+      await transcript.clearTranscript(conversation)
+
+      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalledTimes(1)
+      expect(ragRemoveFromVectorStoreSpy).toHaveBeenCalledWith(`${TRANSCRIPT_COLLECTION_PREFIX}-conv123`, {
+        type: 'transcript'
+      })
+    })
+
     it('should handle errors when clearing from vector store', async () => {
       const conversation = { _id: 'conv123' }
 
@@ -1125,11 +1269,13 @@ describe('transcript', () => {
 
   describe('deleteTranscript', () => {
     let ragDeleteCollectionSpy
+    let ragRemoveFromVectorStoreDeleteSpy
     let messageFindSpy
     let messageDeleteManySpy
 
     beforeEach(() => {
       ragDeleteCollectionSpy = jest.spyOn(rag, 'deleteCollection').mockResolvedValue()
+      ragRemoveFromVectorStoreDeleteSpy = jest.spyOn(rag, 'removeFromVectorStore').mockResolvedValue()
       messageFindSpy = jest.spyOn(Message, 'find').mockReturnValue({
         select: jest.fn().mockReturnValue({
           lean: jest.fn().mockResolvedValue([{ _id: 'msg1' }, { _id: 'msg2' }])
@@ -1140,11 +1286,12 @@ describe('transcript', () => {
 
     afterEach(() => {
       ragDeleteCollectionSpy.mockRestore()
+      ragRemoveFromVectorStoreDeleteSpy.mockRestore()
       messageFindSpy.mockRestore()
       messageDeleteManySpy.mockRestore()
     })
 
-    it('should delete entire collection from vector store including metadata', async () => {
+    it('should delete entire per-conversation collection from vector store including metadata', async () => {
       const conversation = { _id: 'conv123' }
 
       await transcript.deleteTranscript(conversation)
@@ -1160,6 +1307,26 @@ describe('transcript', () => {
       expect(messageDeleteManySpy).toHaveBeenCalledWith({
         _id: { $in: [{ _id: 'msg1' }, { _id: 'msg2' }] }
       })
+    })
+
+    it('should also remove conversation documents from topic collection', async () => {
+      const conversation = { _id: 'conv123', topic: { _id: 'topic456' } }
+
+      await transcript.deleteTranscript(conversation)
+
+      expect(ragDeleteCollectionSpy).toHaveBeenCalledWith(`${TRANSCRIPT_COLLECTION_PREFIX}-conv123`)
+      expect(ragRemoveFromVectorStoreDeleteSpy).toHaveBeenCalledWith(`${TOPIC_TRANSCRIPT_COLLECTION_PREFIX}-topic456`, {
+        conversationId: 'conv123'
+      })
+    })
+
+    it('should not remove from topic collection when conversation has no topic', async () => {
+      const conversation = { _id: 'conv123' }
+
+      await transcript.deleteTranscript(conversation)
+
+      expect(ragDeleteCollectionSpy).toHaveBeenCalledWith(`${TRANSCRIPT_COLLECTION_PREFIX}-conv123`)
+      expect(ragRemoveFromVectorStoreDeleteSpy).not.toHaveBeenCalled()
     })
 
     it('should handle errors when deleting collection', async () => {

--- a/tests/agents/tools/eventHistory.test.ts
+++ b/tests/agents/tools/eventHistory.test.ts
@@ -1,0 +1,194 @@
+/* eslint-disable no-console */
+import monogoose from 'mongoose'
+import setupAgentTest from '../../utils/setupAgentTest.js'
+import {
+  createUser,
+  createConversation,
+  createPublicTopic,
+  loadPartTimeWorkTranscript,
+  loadAliensTranscript
+} from '../../utils/agentTestHelpers.js'
+import createEventHistoryTools, { TopicRef } from '../../../src/agents/tools/eventHistory.js'
+import { newPublicTopic, insertTopics } from '../../fixtures/topic.fixture.js'
+
+jest.setTimeout(300000)
+
+setupAgentTest()
+
+describe('eventHistory tools', () => {
+  let topic
+  let otherTopic
+  let conv1
+  let conv2
+  let tools
+
+  beforeEach(async () => {
+    const user = await createUser('Test User')
+    topic = await createPublicTopic()
+
+    // Create a second topic with its own conversation to verify topicId filtering
+    otherTopic = newPublicTopic()
+    await insertTopics([otherTopic])
+    await createConversation(
+      { name: 'Unrelated Event', description: 'An event in a different series' },
+      user,
+      otherTopic,
+      new Date('2025-03-15T18:00:00Z')
+    )
+
+    const startTime1 = new Date('2025-03-01T18:00:00Z')
+    const startTime2 = new Date('2025-04-01T18:00:00Z')
+
+    conv1 = await createConversation(
+      {
+        name: 'Part-Time Work Panel',
+        description: 'A discussion on part-time work arrangements and workforce flexibility',
+        presenters: [{ name: 'Jessica Drain', bio: 'Entrepreneur and advocate for flexible work arrangements' }]
+      },
+      user,
+      topic,
+      startTime1
+    )
+    conv2 = await createConversation(
+      {
+        name: 'Aliens and Cinema',
+        description: 'An exploration of how aliens are portrayed in film and popular culture'
+      },
+      user,
+      topic,
+      startTime2
+    )
+
+    // Load transcripts into both per-conversation and topic collections
+    await loadPartTimeWorkTranscript(conv1, true)
+    await loadAliensTranscript(conv2, true)
+
+    const topicRefs: TopicRef[] = [{ id: topic._id.toString(), name: topic.name }]
+    tools = createEventHistoryTools(topicRefs)
+  })
+
+  const getEventListTool = () => tools.find((t) => t.name === 'get_event_list')
+  const searchTopicTool = () => tools.find((t) => t.name === 'search_topic_transcripts')
+  const searchConvTool = () => tools.find((t) => t.name === 'search_conversation_transcript')
+
+  describe('get_event_list', () => {
+    it('returns all events in the topic', async () => {
+      const result = JSON.parse(await getEventListTool().invoke({}))
+      console.log('get_event_list (all):', JSON.stringify(result, null, 2))
+
+      expect(result).toHaveLength(2)
+      const names = result.map((r) => r.name)
+      expect(names).toContain('Part-Time Work Panel')
+      expect(names).toContain('Aliens and Cinema')
+      const partTime = result.find((r) => r.name === 'Part-Time Work Panel')
+
+      expect(partTime.id).toBeDefined()
+      expect(partTime.startTime).toBeDefined()
+      expect(partTime.description).toContain('part-time')
+    })
+
+    it('filters by date range', async () => {
+      const result = JSON.parse(await getEventListTool().invoke({ since: '2025-04-01', until: '2025-04-30' }))
+      console.log('get_event_list (April filter):', JSON.stringify(result, null, 2))
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('Aliens and Cinema')
+    })
+
+    it('filters to a specific topicId', async () => {
+      const result = JSON.parse(await getEventListTool().invoke({ topicId: topic._id.toString() }))
+      expect(result).toHaveLength(2)
+      const names = result.map((r) => r.name)
+      expect(names).not.toContain('Unrelated Event')
+    })
+  })
+
+  describe('search_topic_transcripts', () => {
+    it('finds content about part-time work across topic', async () => {
+      const result = await searchTopicTool().invoke({ query: 'part-time work flexibility employers' })
+      console.log('search_topic_transcripts (part-time work):', result.slice(0, 300))
+
+      expect(result).not.toBe('No relevant content found.')
+      expect(result.toLowerCase()).toMatch(/part.time|work|employer|flexib/)
+
+      // ensure prefixed with event name
+      expect(result).toContain('[Event:')
+    })
+
+    it('finds presenter metadata by name and subject', async () => {
+      const result = await searchTopicTool().invoke({ query: 'Jessica Drain speaker presenter' })
+      console.log('search_topic_transcripts (presenter):', result.slice(0, 300))
+
+      expect(result.toLowerCase()).toContain('jessica')
+    })
+
+    it('finds content from the second conversation', async () => {
+      const result = await searchTopicTool().invoke({ query: 'aliens film cinema' })
+      console.log('search_topic_transcripts (aliens):', result.slice(0, 300))
+
+      expect(result).not.toBe('No relevant content found.')
+    })
+
+    it('returns no relevant content for completely unrelated query', async () => {
+      // Score threshold of 0.8 should filter out very weak matches
+      const result = await searchTopicTool().invoke({ query: 'quantum physics subatomic particles' })
+      console.log('search_topic_transcripts (off-topic):', result.slice(0, 100))
+      // Either no results or low-relevance — just ensure it doesn't throw
+      expect(typeof result).toBe('string')
+    })
+  })
+
+  describe('search_conversation_transcript', () => {
+    it('finds specific content within a conversation', async () => {
+      const result = await searchConvTool().invoke({
+        conversationId: conv1._id.toString(),
+        query: 'part-time work 40 hours per week'
+      })
+      console.log('search_conversation_transcript (part-time):', result.slice(0, 300))
+
+      expect(result).not.toBe('No relevant content found in that event.')
+      expect(result.toLowerCase()).toMatch(/part.time|hours|work/)
+    })
+
+    it('returns event name prefix in results', async () => {
+      const result = await searchConvTool().invoke({
+        conversationId: conv1._id.toString(),
+        query: 'employers workers'
+      })
+
+      expect(result).toContain('[Event:')
+    })
+
+    it('returns invalid conversation for malformed conversation id', async () => {
+      const result = await searchConvTool().invoke({
+        conversationId: 'A great conversation',
+        query: 'anything'
+      })
+
+      expect(result).toContain('Invalid conversationId')
+    })
+
+    it('returns not found for non-existent conversation', async () => {
+      const result = await searchConvTool().invoke({
+        conversationId: new monogoose.Types.ObjectId().toString(),
+        query: 'anything'
+      })
+
+      expect(result).toContain('not found')
+    })
+
+    it('does not return content from the other conversation', async () => {
+      // Searching conv1 for aliens content should not find it
+      const result = await searchConvTool().invoke({
+        conversationId: conv1._id.toString(),
+        query: 'aliens extraterrestrial film'
+      })
+      console.log('search_conversation_transcript (cross-conv check):', result.slice(0, 200))
+
+      // Either no results or score below threshold — should not mention aliens prominently
+      if (result !== 'No relevant content found in that event.') {
+        expect(result.toLowerCase()).not.toContain('alien')
+      }
+    })
+  })
+})

--- a/tests/integration/conversation.test.ts
+++ b/tests/integration/conversation.test.ts
@@ -76,8 +76,7 @@ const testAgentTypeSpecification = {
       voting: 'You should vote on this data {voteData}'
     },
     defaultLLMPlatform,
-    defaultLLMModel,
-    useTranscriptRAGCollection: true
+    defaultLLMModel
   },
   testManual: {
     initialize: mockInitialize,
@@ -96,8 +95,7 @@ const testAgentTypeSpecification = {
       voting: 'You should vote on this data {voteData}'
     },
     defaultLLMPlatform,
-    defaultLLMModel,
-    useTranscriptRAGCollection: true
+    defaultLLMModel
   }
 }
 
@@ -1963,8 +1961,7 @@ describe('Conversation routes', () => {
       // Create test agents for the conversation
       const testAgent = new Agent({
         agentType: 'test',
-        conversation: activeConversation._id,
-        useTranscriptRAGCollection: true
+        conversation: activeConversation._id
       })
       await testAgent.save()
       activeConversation.agents = [testAgent]
@@ -1998,8 +1995,7 @@ describe('Conversation routes', () => {
 
       const ragAgent = new Agent({
         agentType: 'test',
-        conversation: ragConversation._id,
-        useTranscriptRAGCollection: true
+        conversation: ragConversation._id
       })
       await ragAgent.save()
       ragConversation.agents = [ragAgent]
@@ -2202,8 +2198,7 @@ describe('Conversation routes', () => {
 
       const ragAgent = new Agent({
         agentType: 'test',
-        conversation: ragConversation._id,
-        useTranscriptRAGCollection: true
+        conversation: ragConversation._id
       })
       await ragAgent.save()
       ragConversation.agents = [ragAgent]
@@ -2221,24 +2216,6 @@ describe('Conversation routes', () => {
         .expect(httpStatus.OK)
 
       expect(transcriptSpy).toHaveBeenCalledWith(expect.objectContaining({ _id: ragConversation._id }))
-      transcriptSpy.mockRestore()
-    })
-
-    test('should not update transcript RAG when conversation has no RAG-enabled agents', async () => {
-      const transcriptSpy = jest.spyOn(transcript, 'loadEventMetadataIntoVectorStore').mockResolvedValue()
-
-      const updateBody = {
-        id: conversationOne._id,
-        name: 'Updated No RAG Conversation'
-      }
-
-      await request(app)
-        .put('/v1/conversations')
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send(updateBody)
-        .expect(httpStatus.OK)
-
-      expect(transcriptSpy).not.toHaveBeenCalled()
       transcriptSpy.mockRestore()
     })
 

--- a/tests/integration/experiment.test.ts
+++ b/tests/integration/experiment.test.ts
@@ -2415,7 +2415,6 @@ ${formatTime(msg7Time)}  DMTestAgent2: Hello! How can I help?
         maxTokens: 2000,
         defaultTriggers: { perMessage: { channels: ['transcript'] } },
         priority: 100,
-        useTranscriptRAGCollection: true,
         llmTemplateVars: { main: [] },
         defaultLLMTemplates: {
           main: 'You respond using transcript data. Message: {lastMessage}'

--- a/tests/integration/topic.test.ts
+++ b/tests/integration/topic.test.ts
@@ -15,6 +15,7 @@ import Token from '../../src/models/token.model.js'
 import { insertFollowers } from '../fixtures/follower.fixture.js'
 import { conversationThree, insertConversations } from '../fixtures/conversation.fixture.js'
 import { messageFour, invisibleMessage, insertMessages } from '../fixtures/message.fixture.js'
+import transcript from '../../src/agents/helpers/transcript.js'
 
 setupIntTest()
 
@@ -22,6 +23,19 @@ const publicTopic = newPublicTopic()
 const privateTopic = newPrivateTopic()
 
 describe('Topic routes', () => {
+  let loadTopicMetadataSpy
+  let deleteTopicCollectionSpy
+
+  beforeEach(() => {
+    loadTopicMetadataSpy = jest.spyOn(transcript, 'loadTopicMetadataIntoVectorStore').mockResolvedValue()
+    deleteTopicCollectionSpy = jest.spyOn(transcript, 'deleteTopicCollection').mockResolvedValue()
+  })
+
+  afterEach(() => {
+    loadTopicMetadataSpy.mockRestore()
+    deleteTopicCollectionSpy.mockRestore()
+  })
+
   describe('POST /v1/topics/', () => {
     test('should return 201 and create a topic', async () => {
       await insertUsers([registeredUser])
@@ -30,6 +44,18 @@ describe('Topic routes', () => {
         .set('Authorization', `Bearer ${registeredUserAccessToken}`)
         .send(topicPost)
         .expect(httpStatus.CREATED)
+    })
+
+    test('should return 201 and include description in response', async () => {
+      await insertUsers([registeredUser])
+
+      const resp = await request(app)
+        .post(`/v1/topics`)
+        .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+        .send({ ...topicPost, description: 'A series about distributed systems' })
+        .expect(httpStatus.CREATED)
+
+      expect(resp.body.description).toBe('A series about distributed systems')
     })
 
     test('should return 400 if missing a required field', async () => {
@@ -105,6 +131,19 @@ describe('Topic routes', () => {
       expect(topicDoc!.conversationCreationAllowed).toEqual(publicTopic.conversationCreationAllowed)
     })
 
+    test('should return 200 and include description in response', async () => {
+      await insertUsers([registeredUser])
+      await insertTopics([publicTopic])
+
+      const resp = await request(app)
+        .put(`/v1/topics/`)
+        .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+        .send({ id: publicTopic._id, description: 'A weekly panel on tech trends' })
+        .expect(httpStatus.OK)
+
+      expect(resp.body.description).toBe('A weekly panel on tech trends')
+    })
+
     test('should return 400 if missing topic id', async () => {
       await insertUsers([registeredUser])
       const topicBody = { name: 'favorite dogs' }
@@ -123,6 +162,17 @@ describe('Topic routes', () => {
         .set('Authorization', `Bearer ${registeredUserAccessToken}`)
         .send({ id: publicTopic._id, name: 'favorite dogs', isArchiveNotified: true })
         .expect(httpStatus.BAD_REQUEST)
+    })
+  })
+
+  describe('GET /v1/topics/:topicId', () => {
+    test('should return 200 and include description', async () => {
+      const topicWithDesc = { ...newPublicTopic(), description: 'A series about open source software' }
+      await insertTopics([topicWithDesc])
+
+      const resp = await request(app).get(`/v1/topics/${topicWithDesc._id}`).send().expect(httpStatus.OK)
+
+      expect(resp.body.description).toBe('A series about open source software')
     })
   })
 
@@ -216,6 +266,22 @@ describe('Topic routes', () => {
         .expect(httpStatus.OK)
 
       expect(resp.body).toHaveLength(2)
+    })
+
+    test('should include description in userTopics response', async () => {
+      await insertUsers([userOne])
+      const topicWithDesc = { ...newPublicTopic(), description: 'A series about machine learning' }
+      await insertTopics([topicWithDesc])
+
+      const resp = await request(app)
+        .get(`/v1/topics/userTopics`)
+        .set('Authorization', `Bearer ${userOneAccessToken}`)
+        .send()
+        .expect(httpStatus.OK)
+
+      const found = resp.body.find((t) => t.id === topicWithDesc._id.toString())
+      expect(found).toBeDefined()
+      expect(found.description).toBe('A series about machine learning')
     })
 
     test('should return 200 and conversations should include followed', async () => {

--- a/tests/integration/transcript.test.ts
+++ b/tests/integration/transcript.test.ts
@@ -36,8 +36,7 @@ const testAgentTypeSpecification = {
       voting: 'You should vote on this data {voteData}'
     },
     defaultLLMPlatform,
-    defaultLLMModel,
-    useTranscriptRAGCollection: true
+    defaultLLMModel
   }
 }
 
@@ -201,11 +200,7 @@ describe('Transcript routes', () => {
       })
       await conversation.save()
 
-      const ragAgent = new Agent({
-        agentType: 'test',
-        conversation: conversation._id,
-        useTranscriptRAGCollection: true
-      })
+      const ragAgent = new Agent({ agentType: 'test', conversation: conversation._id })
       await ragAgent.save()
 
       conversation.agents = [ragAgent]
@@ -236,63 +231,6 @@ describe('Transcript routes', () => {
       })
 
       // Verify messages are deleted
-      const transcriptMessagesAfter = await Message.find({
-        conversation: conversation._id,
-        channels: { $in: ['transcript'] }
-      })
-      expect(transcriptMessagesAfter).toHaveLength(0)
-
-      removeFromVectorStoreSpy.mockRestore()
-    })
-
-    test('should return 204 and not touch RAG when conversation has no RAG-enabled agents', async () => {
-      const removeFromVectorStoreSpy = jest.spyOn(rag, 'removeFromVectorStore').mockResolvedValue()
-
-      // Create conversation without RAG-enabled agents
-      const conversation = new Conversation({
-        name: 'No RAG Conversation',
-        owner: userOne._id,
-        topic: publicTopic._id,
-        agents: [],
-        messages: [],
-        transcript: { status: 'stopped' }
-      })
-      await conversation.save()
-
-      // Create agent without RAG
-      const agent = new Agent({
-        agentType: 'test',
-        conversation: conversation._id,
-        useTranscriptRAGCollection: false
-      })
-      await agent.save()
-
-      conversation.agents = [agent]
-      await conversation.save()
-
-      // Create transcript message
-      const transcriptMessage = new Message({
-        conversation: conversation._id,
-        body: 'Non-RAG transcript message',
-        channels: ['transcript'],
-        owner: registeredUser._id,
-        pseudonymId: registeredUser.pseudonyms[0]._id,
-        pseudonym: registeredUser.pseudonyms[0].pseudonym,
-        createdAt: new Date()
-      })
-      await transcriptMessage.save()
-
-      // Delete transcript
-      await request(app)
-        .delete(`/v1/transcript/${conversation._id}`)
-        .set('Authorization', `Bearer ${userOneAccessToken}`)
-        .send()
-        .expect(httpStatus.NO_CONTENT)
-
-      // Verify RAG was not touched
-      expect(removeFromVectorStoreSpy).not.toHaveBeenCalled()
-
-      // Verify messages are still deleted
       const transcriptMessagesAfter = await Message.find({
         conversation: conversation._id,
         channels: { $in: ['transcript'] }
@@ -377,11 +315,7 @@ describe('Transcript routes', () => {
       })
       await conversation.save()
 
-      const ragAgent = new Agent({
-        agentType: 'test',
-        conversation: conversation._id,
-        useTranscriptRAGCollection: true
-      })
+      const ragAgent = new Agent({ agentType: 'test', conversation: conversation._id })
       await ragAgent.save()
 
       conversation.agents = [ragAgent]

--- a/tests/jobs/handlers/transcript.handlers.test.ts
+++ b/tests/jobs/handlers/transcript.handlers.test.ts
@@ -162,12 +162,7 @@ describe('transcript handler tests', () => {
       fourMonthsAgo.setMonth(fourMonthsAgo.getMonth() - 4)
       conversation.startTime = fourMonthsAgo
 
-      // Create an agent with transcript RAG enabled
-      const agent = new Agent({
-        agentType: 'perMessageWithMin',
-        conversation,
-        useTranscriptRAGCollection: true
-      })
+      const agent = new Agent({ agentType: 'perMessageWithMin', conversation })
       await agent.save()
 
       // Add agent to conversation
@@ -202,12 +197,7 @@ describe('transcript handler tests', () => {
       await expect(rag.getCollection(collectionName)).rejects.toThrow()
     })
     test('should not delete recent transcript messages', async () => {
-      // Create an agent with transcript RAG enabled
-      const agent = new Agent({
-        agentType: 'perMessageWithMin',
-        conversation,
-        useTranscriptRAGCollection: true
-      })
+      const agent = new Agent({ agentType: 'perMessageWithMin', conversation })
       await agent.save()
 
       // Add agent to conversation
@@ -243,38 +233,6 @@ describe('transcript handler tests', () => {
       const collAfter = await rag.getCollection(collectionName)
       expect(collAfter).toBeDefined()
     })
-    test('should handle conversations without RAG-enabled agents', async () => {
-      const fourMonthsAgo = new Date()
-      fourMonthsAgo.setMonth(fourMonthsAgo.getMonth() - 4)
-      conversation.startTime = fourMonthsAgo
-      // Create agent without transcript RAG
-      const agent = new Agent({
-        agentType: 'perMessageWithMin',
-        conversation,
-        useTranscriptRAGCollection: false
-      })
-      await agent.save()
-
-      conversation.agents.push(agent)
-      await conversation.save()
-
-      await loadTestTranscript(conversation, `${transcript1}\n${transcript2}\n${transcript3}`, false)
-      // Verify messages exist before cleanup
-      const messagesBeforeCleanup = await Message.find({
-        conversation: conversation._id,
-        channels: { $in: ['transcript'] }
-      })
-      expect(messagesBeforeCleanup).not.toHaveLength(0)
-      // Run cleanup
-      await JobHandlers.cleanUpTranscripts()
-
-      // Verify messages are still deleted even without RAG
-      const messagesAfterCleanup = await Message.find({
-        conversation: conversation._id,
-        channels: { $in: ['transcript'] }
-      })
-      expect(messagesAfterCleanup).toHaveLength(0)
-    })
     test('should handle empty result gracefully', async () => {
       // Run cleanup when there are no old transcripts
       await expect(JobHandlers.cleanUpTranscripts()).resolves.not.toThrow()
@@ -287,11 +245,7 @@ describe('transcript handler tests', () => {
       const conv1 = new Conversation({ ...conversationAgentsEnabled, _id: new mongoose.Types.ObjectId() })
       conv1.startTime = fourMonthsAgo
 
-      const agent = new Agent({
-        agentType: 'perMessageWithMin',
-        conversation,
-        useTranscriptRAGCollection: true
-      })
+      const agent = new Agent({ agentType: 'perMessageWithMin', conversation })
       await agent.save()
 
       // Add agent to conversation

--- a/tests/models/agent.model.test.ts
+++ b/tests/models/agent.model.test.ts
@@ -40,8 +40,7 @@ const testAgentTypes = {
     defaultLLMPlatform,
     defaultLLMModel,
     defaultLLMModelOptions: { prop: 'value' },
-    defaultConversationHistorySettings: { timeWindow: 45 },
-    useTranscriptRAGCollection: true
+    defaultConversationHistorySettings: { timeWindow: 45 }
   },
   periodic: {
     initialize: mockInitialize,
@@ -204,7 +203,6 @@ describe('agent tests', () => {
     expect(agent.llmModelOptions!.prop).toBe('value')
     expect(agent.triggers).toBe(testAgentTypes.perMessageWithMin.defaultTriggers)
     expect(agent.conversationHistorySettings).toBe(testAgentTypes.perMessageWithMin.defaultConversationHistorySettings)
-    expect(agent.useTranscriptRAGCollection).toBe(true)
   })
 
   test('should introduce itself on a specified channel', async () => {

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -52,8 +52,7 @@ const testAgentTypeSpecification = {
       voting: 'You should vote on this data {voteData}'
     },
     defaultLLMPlatform,
-    defaultLLMModel,
-    useTranscriptRAGCollection: true
+    defaultLLMModel
   },
   eventAssistantPlus: {
     initialize: mockInitialize,
@@ -72,8 +71,7 @@ const testAgentTypeSpecification = {
       voting: 'You should vote on this data {voteData}'
     },
     defaultLLMPlatform,
-    defaultLLMModel,
-    useTranscriptRAGCollection: true
+    defaultLLMModel
   },
   backChannelInsights: {
     initialize: mockInitialize,
@@ -91,8 +89,7 @@ const testAgentTypeSpecification = {
       voting: 'You should vote on this data {voteData}'
     },
     defaultLLMPlatform,
-    defaultLLMModel,
-    useTranscriptRAGCollection: true
+    defaultLLMModel
   },
   backChannelMetrics: {
     initialize: mockInitialize,
@@ -110,8 +107,7 @@ const testAgentTypeSpecification = {
       voting: 'You should vote on this data {voteData}'
     },
     defaultLLMPlatform,
-    defaultLLMModel,
-    useTranscriptRAGCollection: true
+    defaultLLMModel
   },
   eventMediator: {
     initialize: mockInitialize,
@@ -130,7 +126,6 @@ const testAgentTypeSpecification = {
     },
     defaultLLMPlatform,
     defaultLLMModel,
-    useTranscriptRAGCollection: true,
     agentConfig: {
       mediatorMinInterval: 1,
       personality: 'sarcastic-expert'
@@ -153,7 +148,6 @@ const testAgentTypeSpecification = {
     },
     defaultLLMPlatform,
     defaultLLMModel,
-    useTranscriptRAGCollection: true,
     agentConfig: {
       mediatorMinInterval: 1,
       personality: 'sarcastic-expert'
@@ -175,8 +169,7 @@ const testAgentTypeSpecification = {
       voting: 'You should vote on this data {voteData}'
     },
     defaultLLMPlatform,
-    defaultLLMModel,
-    useTranscriptRAGCollection: true
+    defaultLLMModel
   },
   jargonFilterAgent: {
     initialize: mockInitialize,
@@ -194,8 +187,7 @@ const testAgentTypeSpecification = {
       user: 'Analyze this transcript: {transcript}'
     },
     defaultLLMPlatform,
-    defaultLLMModel,
-    useTranscriptRAGCollection: false
+    defaultLLMModel
   },
   voiceAssistant: {
     initialize: mockInitialize,
@@ -214,8 +206,7 @@ const testAgentTypeSpecification = {
       voting: 'You should vote on this data {voteData}'
     },
     defaultLLMPlatform,
-    defaultLLMModel,
-    useTranscriptRAGCollection: true
+    defaultLLMModel
   }
 }
 

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -13,8 +13,12 @@ import { setAdapterTypes } from '../../src/models/adapter.model.js'
 import { setAgentTypes } from '../../src/models/user.model/agent.model/index.js'
 import defaultAgentTypes from '../../src/agents/index.js'
 import config from '../../src/config/config.js'
+import schedule from '../../src/jobs/schedule.js'
+import defineJob from '../../src/jobs/define.js'
+import transcript from '../../src/agents/helpers/transcript.js'
 
 jest.setTimeout(10000)
+jest.mock('agenda')
 setupIntTest()
 const topicOne = newPublicTopic()
 
@@ -218,6 +222,18 @@ describe('Conversation service methods', () => {
 
   beforeEach(async () => {
     jest.spyOn(websocketGateway, 'broadcastNewConversation').mockResolvedValue()
+    jest.spyOn(transcript, 'loadEventMetadataIntoVectorStore').mockResolvedValue()
+    jest.spyOn(transcript, 'deleteTranscript').mockResolvedValue()
+    jest.spyOn(schedule, 'cancelBatchTranscript').mockResolvedValue()
+    jest.spyOn(schedule, 'batchTranscript').mockResolvedValue()
+    jest.spyOn(schedule, 'cancelPeriodicAgent').mockResolvedValue()
+    jest.spyOn(schedule, 'periodicAgent').mockResolvedValue()
+    jest.spyOn(schedule, 'agentResponse').mockResolvedValue()
+    jest.spyOn(schedule, 'agentIntroduction').mockResolvedValue()
+    jest.spyOn(defineJob, 'batchTranscript').mockResolvedValue()
+    jest.spyOn(defineJob, 'periodicAgent').mockResolvedValue()
+    jest.spyOn(defineJob, 'agentResponse').mockResolvedValue()
+    jest.spyOn(defineJob, 'agentIntroduction').mockResolvedValue()
     mockGetUniqueKeys.mockReturnValue([])
   })
 

--- a/tests/services/message.service.test.ts
+++ b/tests/services/message.service.test.ts
@@ -61,8 +61,7 @@ const testAgentTypes = {
     },
     defaultLLMPlatform,
     defaultLLMModel,
-    defaultLLMModelOptions: { prop: 'value' },
-    useTranscriptRAGCollection: true
+    defaultLLMModelOptions: { prop: 'value' }
   }
 }
 

--- a/tests/services/topic.service.test.ts
+++ b/tests/services/topic.service.test.ts
@@ -8,6 +8,7 @@ import { Token } from '../../src/models/index.js'
 import { conversationOne, insertConversations } from '../fixtures/conversation.fixture.js'
 import { messageOne, invisibleMessage, insertMessages } from '../fixtures/message.fixture.js'
 import Conversation from '../../src/models/conversation.model.js'
+import transcript from '../../src/agents/helpers/transcript.js'
 
 setupIntTest()
 
@@ -20,6 +21,76 @@ beforeEach(() => {
 })
 
 describe('Topic service methods', () => {
+  describe('createTopic()', () => {
+    let loadTopicMetadataSpy
+
+    beforeEach(async () => {
+      await insertUsers([userOne])
+      loadTopicMetadataSpy = jest.spyOn(transcript, 'loadTopicMetadataIntoVectorStore').mockResolvedValue()
+    })
+
+    afterEach(() => {
+      loadTopicMetadataSpy.mockRestore()
+    })
+
+    test('should persist description and call loadTopicMetadataIntoVectorStore', async () => {
+      const topicBody = {
+        name: 'Test Series',
+        description: 'A series about testing distributed systems',
+        votingAllowed: true,
+        conversationCreationAllowed: true,
+        private: false,
+        archivable: true
+      }
+
+      const topic = await topicService.createTopic(topicBody, userOne)
+
+      expect(topic.description).toBe(topicBody.description)
+      expect(loadTopicMetadataSpy).toHaveBeenCalledWith(expect.objectContaining({ description: topicBody.description }))
+    })
+
+    test('should call loadTopicMetadataIntoVectorStore even when no description provided', async () => {
+      const topicBody = {
+        name: 'No Description Series',
+        votingAllowed: true,
+        conversationCreationAllowed: true,
+        private: false,
+        archivable: true
+      }
+
+      await topicService.createTopic(topicBody, userOne)
+
+      expect(loadTopicMetadataSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('deleteTopic()', () => {
+    let deleteTopicCollectionSpy
+
+    beforeEach(async () => {
+      await insertUsers([userOne])
+      await insertTopics([publicTopic])
+      deleteTopicCollectionSpy = jest.spyOn(transcript, 'deleteTopicCollection').mockResolvedValue()
+    })
+
+    afterEach(() => {
+      deleteTopicCollectionSpy.mockRestore()
+    })
+
+    test('should soft delete the topic and call deleteTopicCollection', async () => {
+      await topicService.deleteTopic(publicTopic._id)
+
+      const dbTopic = await Topic.findById(publicTopic._id)
+      expect(dbTopic!.isDeleted).toBe(true)
+      expect(deleteTopicCollectionSpy).toHaveBeenCalledWith(expect.objectContaining({ _id: publicTopic._id }))
+    })
+
+    test('should throw if topic does not exist', async () => {
+      await expect(topicService.deleteTopic(newPublicTopic()._id)).rejects.toThrow('Channel does not exist')
+      expect(deleteTopicCollectionSpy).not.toHaveBeenCalled()
+    })
+  })
+
   describe('deleteOldTopics()', () => {
     // Set created date to 98 days ago
     let oldDate = ''

--- a/tests/services/webhook.service.test.ts
+++ b/tests/services/webhook.service.test.ts
@@ -31,8 +31,7 @@ const testAgentTypeSpecification = {
       voting: 'You should vote on this data {voteData}'
     },
     defaultLLMPlatform,
-    defaultLLMModel,
-    useTranscriptRAGCollection: true
+    defaultLLMModel
   }
 }
 


### PR DESCRIPTION
## What is in this PR?

Adds an `eventHistorian` that searches across per-topic (series) RAG collections to answer questions about past events (and also any general inquiry) using configurable personality

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- refactor: always store transcripts in RAG, regardless of whether convo has agent that uses it (cleanup task)
- feat: add topic RAG collection for searcing events across a series
- feat: add optional description property to topic for additional context
- feat: add command line utility to load topic info into RAG (needs to be run against existing topics)
- feat: add eventHistory agent tool to support answering questions about events in a series
- feat: add eventHistorian agent and conv type to answer questions about past events on Slack 
- fix: unawaited Follower.find causing MongoClientClosed errors in conversation.service.test (old bug, unrelated but causing CI failures)
## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] We've been testing this out in a private Slack channel - asking various questions about past events, both broad and detailed. Code review is probably sufficient here

## Additional information

This task required some database migrations to assign events to the proper topics, update topic descriptions, add some missing speakers and descriptions to some conversations, etc. See me for the full list/script if interested. I will run it on the dev server once this merges.
