### PR TITLE
Setup Slack infrastructure for event setup agent

### DIFF
--- a/src/agents/eventSetup/SETUP.md
+++ b/src/agents/eventSetup/SETUP.md
@@ -1,0 +1,190 @@
+# Event Setup Agent — Setup Guide
+
+The event setup agent runs in a dedicated organizer Slack channel. Setting it up means creating a persistent "organizer conversation" that wires the agent to that channel. You do this once per environment — locally to test, then again when you deploy to production.
+
+---
+
+## Part 1: Slack App (one-time, shared across environments)
+
+Create the Slack app once. Both local and production point at the same app — you just add each environment's webhook URL separately.
+
+### Create the app
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From scratch**
+2. Name it (e.g. "Nextspace Events") and select your workspace
+
+### Configure OAuth scopes
+**OAuth & Permissions** → **Bot Token Scopes** → add:
+- `chat:write` — post messages to the channel
+- `channels:history` — read messages in public channels
+- `groups:history` — read messages in private channels
+
+Click **Install to Workspace** and approve. Copy the **Bot User OAuth Token** (`xoxb-...`) — you'll use this in both environments.
+
+### Get the Bot User ID
+```bash
+curl -H "Authorization: Bearer xoxb-..." https://slack.com/api/auth.test
+```
+Copy the `user_id` field (`U...`).
+
+### Collect credentials
+From **Basic Information** → **App Credentials**, copy the **Signing Secret** — you'll add this as `SLACK_SIGNING_SECRET` in both environments.
+
+---
+
+## Part 2: Local Development
+
+### 2a. Expose your local server
+
+Slack needs a public URL to deliver events. Use ngrok:
+
+```bash
+brew install ngrok   # if not already installed
+ngrok http 3000
+```
+
+Copy the `https://xxxx.ngrok-free.app` URL. Note: the free tier assigns a new URL each time ngrok restarts — you'll need to update the Slack webhook URL each session.
+
+### 2b. Add the signing secret to your local .env
+
+```
+SLACK_SIGNING_SECRET=<signing-secret from Part 1>
+```
+
+Restart the server after adding this.
+
+### 2c. Register the local webhook URL with Slack
+
+In your Slack app → **Event Subscriptions** → toggle on → set Request URL:
+```
+https://xxxx.ngrok-free.app/v1/webhooks/slack
+```
+
+Under **Subscribe to bot events** add `message.channels` and `message.groups`. Save — Slack will verify the URL immediately.
+
+### 2d. Create a test Slack channel
+
+1. Create a private channel (e.g. `#event-setup-dev`)
+2. Invite the bot: `/invite @<your-bot-name>`
+3. Right-click the channel → **View channel details** → scroll to the bottom for the Channel ID (`C...`)
+4. Your Workspace ID (`T...`) is visible in the Slack URL in a browser, or under **Settings & administration → Workspace settings**
+
+### 2e. Get a bearer token
+
+```bash
+curl -X POST http://localhost:3000/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "<your-admin-email>", "password": "<your-password>"}'
+```
+
+Copy `tokens.access.token`.
+
+### 2f. Create a topic
+
+```bash
+curl -X POST http://localhost:3000/v1/topics \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Event Setup", "description": "Parent topic for the organizer event setup channel"}'
+```
+
+Copy the `id`.
+
+### 2g. Create and start the organizer conversation
+
+```bash
+curl -X POST http://localhost:3000/v1/conversations/from-type \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "eventSetup",
+    "name": "Organizer Channel",
+    "platforms": ["slack"],
+    "topicId": "<id from 2f>",
+    "properties": {
+      "slackChannel": "C...",
+      "slackWorkspace": "T...",
+      "slackBotToken": "xoxb-...",
+      "slackBotUserId": "U...",
+      "botName": "Event Setup Bot"
+    }
+  }'
+
+curl -X POST http://localhost:3000/v1/conversations/<conversation-id>/start \
+  -H "Authorization: Bearer <token>"
+```
+
+### Verification
+
+Send in `#event-setup-dev`:
+- `"I want to setup a new event"` → bot replies "Event setup coming soon" ✓
+- `"hello everyone"` → bot stays silent ✓
+
+---
+
+## Part 3: Production Deployment
+
+### 3a. Add the signing secret to your production environment
+
+Set `SLACK_SIGNING_SECRET` in your production environment variables (however your deployment manages secrets — Railway, Render, Heroku config vars, etc.). Same value as local.
+
+### 3b. Register the production webhook URL with Slack
+
+In your Slack app → **Event Subscriptions** → add a second URL entry (or replace the local one):
+```
+https://<your-production-domain>/v1/webhooks/slack
+```
+
+Slack will verify it against the running production server.
+
+### 3c. Create a production Slack channel
+
+1. Create a private channel (e.g. `#event-setup`)
+2. Invite the bot: `/invite @<your-bot-name>`
+3. Collect the Channel ID and Workspace ID the same way as local
+
+### 3d. Get a bearer token
+
+```bash
+curl -X POST https://<your-production-domain>/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "<your-admin-email>", "password": "<your-password>"}'
+```
+
+### 3e. Create a topic
+
+```bash
+curl -X POST https://<your-production-domain>/v1/topics \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Event Setup", "description": "Parent topic for the organizer event setup channel"}'
+```
+
+### 3f. Create and start the organizer conversation
+
+```bash
+curl -X POST https://<your-production-domain>/v1/conversations/from-type \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "eventSetup",
+    "name": "Organizer Channel",
+    "platforms": ["slack"],
+    "topicId": "<id from 3e>",
+    "properties": {
+      "slackChannel": "C...",
+      "slackWorkspace": "T...",
+      "slackBotToken": "xoxb-...",
+      "slackBotUserId": "U...",
+      "botName": "Event Setup Bot"
+    }
+  }'
+
+curl -X POST https://<your-production-domain>/v1/conversations/<conversation-id>/start \
+  -H "Authorization: Bearer <token>"
+```
+
+### Verification
+
+Send in `#event-setup`:
+- `"I want to setup a new event"` → bot replies "Event setup coming soon" ✓
+- `"hello everyone"` → bot stays silent ✓

--- a/src/agents/eventSetup/eventSetup.ts
+++ b/src/agents/eventSetup/eventSetup.ts
@@ -1,0 +1,85 @@
+import verify from '../helpers/verify.js'
+import { AgentMessageActions, ConversationHistory } from '../../types/index.types.js'
+import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
+
+const SETUP_INTENT_PATTERNS = [/\bsetup\b/i, /\bcreate event\b/i, /\bcreate an? event\b/i, /\bnew event\b/i]
+
+export default verify({
+  name: 'Event Setup',
+  description: 'Collects event details from organizers via Slack and creates a new nextspace event',
+  priority: 100,
+  maxTokens: 4000,
+  defaultTriggers: {
+    perMessage: { channels: ['setup'] }
+  },
+  agentConfig: {
+    botName: 'Event Setup Bot'
+  },
+  llmTemplateVars: {},
+  defaultLLMTemplates: {},
+  defaultLLMPlatform,
+  defaultLLMModel,
+  ragCollectionName: undefined,
+  defaultConversationHistorySettings: { count: 50, channels: ['setup'] },
+
+  async evaluate(userMessage) {
+    const body = userMessage?.body ?? ''
+    const hasBotMention = body.toLowerCase().includes(`@${this.agentConfig.botName}`.toLowerCase())
+    const hasSetupIntent = SETUP_INTENT_PATTERNS.some((pattern) => pattern.test(body))
+
+    if (hasBotMention || hasSetupIntent) {
+      return {
+        userMessage,
+        action: AgentMessageActions.CONTRIBUTE,
+        userContributionVisible: true,
+        suggestion: undefined
+      }
+    }
+
+    return {
+      userMessage,
+      action: AgentMessageActions.OK,
+      userContributionVisible: true,
+      suggestion: undefined
+    }
+  },
+
+  async respond(_conversationHistory: ConversationHistory, userMessage) {
+    const setupChannel = this.conversation.channels.find((channel) => channel.name === 'setup')
+    const parentMessageId = userMessage.parentMessage
+
+    return [
+      {
+        visible: true,
+        message: 'Event setup coming soon',
+        messageType: 'text',
+        channels: setupChannel ? [setupChannel] : [],
+        parent: parentMessageId
+      }
+    ]
+  },
+
+  async start() {
+    return true
+  },
+
+  async stop() {
+    return true
+  },
+
+  formatTraceInput(_conversationHistory, userMessage) {
+    return userMessage?.body
+  },
+
+  formatTraceOutput(responses) {
+    return responses[0]?.message
+  },
+
+  getTraceMetadata(conversationHistory, userMessage, responses) {
+    return {
+      conversationHistory,
+      channels: userMessage?.channels,
+      topic: responses[0]?.topic
+    }
+  }
+})

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -9,6 +9,7 @@ import jargonFilterAgent from './jargonFilter/jargonFilter.js'
 import librarian from './librarian/librarianAgent.js'
 import chatbot from './chatbot/chatbot.js'
 import eventHistorian from './eventHistorian/eventHistorian.js'
+import eventSetup from './eventSetup/eventSetup.js'
 
 // Development agents
 import civilityPerMessage from './development/civilityPerMessage.js'
@@ -48,5 +49,6 @@ export default {
   jargonFilterAgent,
   voiceAssistant,
   librarian,
-  eventHistorian
+  eventHistorian,
+  eventSetup
 }

--- a/src/conversations/eventSetup.ts
+++ b/src/conversations/eventSetup.ts
@@ -1,0 +1,87 @@
+import { supportedModels } from '../agents/helpers/getModelChat.js'
+import { ConversationType, Direction } from '../types/index.types.js'
+import config from '../config/config.js'
+
+const eventSetup: ConversationType = {
+  name: 'eventSetup',
+  label: 'Event Setup',
+  description: 'An AI assistant for creating and configuring nextspace events via a dedicated organizer Slack channel',
+  platforms: [{ name: 'slack', label: 'Slack' }],
+  properties: [
+    {
+      name: 'slackChannel',
+      label: 'Slack Channel ID',
+      description: 'The ID of the Slack channel organizers use to set up events (starts with C- or G-)',
+      required: true,
+      type: 'string'
+    },
+    {
+      name: 'slackWorkspace',
+      label: 'Slack Workspace ID',
+      description: 'The Slack workspace (team) ID (starts with T-)',
+      required: true,
+      type: 'string'
+    },
+    {
+      name: 'slackBotToken',
+      label: 'Slack Bot Token',
+      description: 'The Bot User OAuth token for the Slack app (starts with xoxb-)',
+      required: true,
+      type: 'string'
+    },
+    {
+      name: 'slackBotUserId',
+      label: 'Slack Bot User ID',
+      description: 'The user ID for the bot in Slack (starts with U-), used for routing incoming messages',
+      required: false,
+      type: 'string'
+    },
+    {
+      name: 'botName',
+      label: 'Bot Name',
+      description: 'The display name for the bot',
+      required: false,
+      type: 'string',
+      default: config.conversationBotName
+    },
+    {
+      name: 'llmModel',
+      label: 'Model that your agents will use',
+      required: false,
+      type: 'enum',
+      options: supportedModels,
+      validationKeys: ['llmModel', 'llmPlatform']
+    }
+  ],
+  agents: [
+    {
+      name: 'eventSetup',
+      properties: [
+        { $ref: 'llmModel.llmModel' },
+        { $ref: 'llmModel.llmPlatform' },
+        { $ref: 'botName', as: 'agentConfig.botName' }
+      ]
+    }
+  ],
+  channels: [{ name: 'setup' }],
+  adapters: {
+    slack: {
+      type: 'slack',
+      config: {
+        channel: '{{{properties.slackChannel}}}',
+        workspace: '{{{properties.slackWorkspace}}}',
+        botToken: '{{{properties.slackBotToken}}}',
+        botUserId: '{{{properties.slackBotUserId}}}',
+        botName: '{{{properties.botName}}}'
+      },
+      chatChannels: [
+        {
+          name: 'setup',
+          direction: Direction.BOTH
+        }
+      ]
+    }
+  }
+}
+
+export default eventSetup

--- a/src/conversations/index.ts
+++ b/src/conversations/index.ts
@@ -3,11 +3,13 @@ import backChannel from './backChannel.js'
 import type { ConversationType } from '../types/index.types.js'
 import chatbot from './chatbot.js'
 import eventHistorian from './eventHistorian.js'
+import eventSetup from './eventSetup.js'
 
 // Internal conversation types are usable by the service but not exposed via the config API
 const internal: Record<string, ConversationType> = {
   chatbot,
-  eventHistorian
+  eventHistorian,
+  eventSetup
 }
 
 const defaultConversationTypes: Record<string, ConversationType> = {

--- a/src/handlers/slack.ts
+++ b/src/handlers/slack.ts
@@ -6,6 +6,21 @@ import logger from '../config/logger.js'
 import validateSignature from './helpers/validateSignature.js'
 import webhookService from '../services/webhook.service.js'
 
+// Slack retries webhook delivery if it doesn't get a 200 fast enough (common through ngrok).
+// event_id stays the same on retries, so we track it to skip duplicates.
+const DEDUP_WINDOW_MS = 5 * 60 * 1000 // 5 minutes — well beyond Slack's retry window
+const seenEventIds = new Map<string, number>()
+
+function isDuplicate(eventId: string): boolean {
+  const now = Date.now()
+  for (const [id, timestamp] of seenEventIds) {
+    if (now - timestamp > DEDUP_WINDOW_MS) seenEventIds.delete(id)
+  }
+  if (seenEventIds.has(eventId)) return true
+  seenEventIds.set(eventId, now)
+  return false
+}
+
 const handleEvent = async (req, res) => {
   const payload = req.body
 
@@ -14,6 +29,13 @@ const handleEvent = async (req, res) => {
     res.status(httpStatus.OK).send(payload.challenge)
     return
   }
+  const eventId = payload.event_id
+  if (eventId && isDuplicate(eventId)) {
+    logger.debug(`Slack duplicate event skipped: ${eventId}`)
+    res.status(httpStatus.OK).send('ok')
+    return
+  }
+
   const { event } = payload
   if (!event) {
     logger.info(`Received payload from Slack without an event: ${payload}`)

--- a/tests/agents/eventSetup/eventSetup.agent.test.ts
+++ b/tests/agents/eventSetup/eventSetup.agent.test.ts
@@ -1,0 +1,109 @@
+import setupAgentTest from '../../utils/setupAgentTest.js'
+import defaultAgentTypes from '../../../src/agents/index.js'
+import { createUser, createConversation, createPublicTopic, createMessage } from '../../utils/agentTestHelpers.js'
+import { Agent, Channel } from '../../../src/models/index.js'
+import { AgentMessageActions, ConversationHistory } from '../../../src/types/index.types.js'
+
+jest.setTimeout(30000)
+
+const testConfig = setupAgentTest('eventSetup')
+
+const BOT_NAME = 'Event Setup Bot'
+
+describe('eventSetup agent tests', () => {
+  let agent
+  let conversation
+  let topic
+  let user1
+
+  async function createEventSetupConversation() {
+    const conv = await createConversation({ name: 'Event Setup Test Conversation' }, user1, topic)
+    const testAgent = new Agent({
+      agentType: 'eventSetup',
+      conversation: conv,
+      llmPlatform: testConfig.llmPlatform,
+      llmModel: testConfig.llmModel,
+      agentConfig: { botName: BOT_NAME }
+    })
+    const channels = await Channel.create([{ name: 'setup' }])
+    conv.channels.push(...channels)
+    await testAgent.save()
+    conv.agents.push(testAgent)
+    await conv.save()
+    await testAgent.start()
+    return { conv, testAgent }
+  }
+
+  beforeEach(async () => {
+    topic = await createPublicTopic()
+    user1 = await createUser('Alice')
+    const result = await createEventSetupConversation()
+    conversation = result.conv
+    agent = result.testAgent
+  })
+
+  function buildHistory(messages): ConversationHistory {
+    return {
+      start: new Date(Date.now() - 60 * 60 * 1000),
+      end: new Date(),
+      messages
+    }
+  }
+
+  async function evaluate(body, user = user1) {
+    const msg = await createMessage(body, user, conversation, ['setup'])
+    return defaultAgentTypes.eventSetup.evaluate.call(agent, msg)
+  }
+
+  describe('evaluate()', () => {
+    it('returns CONTRIBUTE when message contains "setup"', async () => {
+      const result = await evaluate('I want to setup a new event')
+      expect(result.action).toBe(AgentMessageActions.CONTRIBUTE)
+    })
+
+    it('returns CONTRIBUTE when message contains "create event" or "create an event"', async () => {
+      const withoutArticle = await evaluate('Can you create event for next Thursday?')
+      expect(withoutArticle.action).toBe(AgentMessageActions.CONTRIBUTE)
+
+      const withArticle = await evaluate('Can you create an event for next Thursday?')
+      expect(withArticle.action).toBe(AgentMessageActions.CONTRIBUTE)
+    })
+
+    it('returns CONTRIBUTE when message contains "new event"', async () => {
+      const result = await evaluate('Let us kick off a new event about AI')
+      expect(result.action).toBe(AgentMessageActions.CONTRIBUTE)
+    })
+
+    it('returns CONTRIBUTE when message is a direct @mention', async () => {
+      const result = await evaluate(`@${BOT_NAME} can you help me?`)
+      expect(result.action).toBe(AgentMessageActions.CONTRIBUTE)
+    })
+
+    it('returns OK when message has no setup intent', async () => {
+      const result = await evaluate('Good morning everyone!')
+      expect(result.action).toBe(AgentMessageActions.OK)
+    })
+  })
+
+  describe('respond()', () => {
+    it('returns a placeholder response', async () => {
+      const msg = await createMessage('setup a new event', user1, conversation, ['setup'])
+      const history = buildHistory([])
+      const responses = await defaultAgentTypes.eventSetup.respond.call(agent, history, msg)
+
+      expect(responses).toHaveLength(1)
+      expect(responses[0].visible).toBe(true)
+      expect(responses[0].message).toBe('Event setup coming soon')
+      expect(responses[0].messageType).toBe('text')
+    })
+
+    it('routes the response to the setup channel', async () => {
+      const msg = await createMessage('setup a new event', user1, conversation, ['setup'])
+      const history = buildHistory([])
+      const responses = await defaultAgentTypes.eventSetup.respond.call(agent, history, msg)
+
+      const channelNames = responses[0].channels.map((c) => c.name)
+      expect(channelNames).toContain('setup')
+    })
+  })
+})

--- a/tests/handlers/slack.handler.test.ts
+++ b/tests/handlers/slack.handler.test.ts
@@ -335,6 +335,99 @@ describe('POST /v1/webhooks/slack', () => {
       expect(receiveMessageSpy).not.toHaveBeenCalled()
     })
 
+    test('should process two messages with different event_ids', async () => {
+      const makePayload = (eventId: string) => ({
+        event_id: eventId,
+        event: {
+          type: 'message',
+          text: 'Hello from Slack!',
+          channel: 'C1234567890',
+          team: '123456',
+          user: 'U1234567890',
+          ts: '1234567890.123456'
+        }
+      })
+
+      const timestamp = Math.floor(Date.now() / 1000).toString()
+
+      const payload1 = makePayload('Ev0FIRST1234')
+      await request(app)
+        .post('/v1/webhooks/slack')
+        .set('x-slack-signature', generateSlackSignature(timestamp, JSON.stringify(payload1)))
+        .set('x-slack-request-timestamp', timestamp)
+        .send(payload1)
+        .expect(httpStatus.OK)
+
+      const payload2 = makePayload('Ev0SECOND123')
+      await request(app)
+        .post('/v1/webhooks/slack')
+        .set('x-slack-signature', generateSlackSignature(timestamp, JSON.stringify(payload2)))
+        .set('x-slack-request-timestamp', timestamp)
+        .send(payload2)
+        .expect(httpStatus.OK)
+
+      expect(receiveMessageSpy).toHaveBeenCalledTimes(2)
+    })
+
+    test('should process messages with no event_id', async () => {
+      const payload = {
+        event: {
+          type: 'message',
+          text: 'Hello from Slack!',
+          channel: 'C1234567890',
+          team: '123456',
+          user: 'U1234567890',
+          ts: '1234567890.123456'
+        }
+      }
+      const timestamp = Math.floor(Date.now() / 1000).toString()
+      const signature = generateSlackSignature(timestamp, JSON.stringify(payload))
+
+      await request(app)
+        .post('/v1/webhooks/slack')
+        .set('x-slack-signature', signature)
+        .set('x-slack-request-timestamp', timestamp)
+        .send(payload)
+        .expect(httpStatus.OK)
+
+      await request(app)
+        .post('/v1/webhooks/slack')
+        .set('x-slack-signature', signature)
+        .set('x-slack-request-timestamp', timestamp)
+        .send(payload)
+        .expect(httpStatus.OK)
+
+      expect(receiveMessageSpy).toHaveBeenCalledTimes(2)
+    })
+
+    test('should not process the same event_id twice', async () => {
+      const payload = {
+        event_id: 'Ev0TEST12345',
+        event: {
+          type: 'message',
+          text: 'Hello from Slack!',
+          channel: 'C1234567890',
+          team: '123456',
+          user: 'U1234567890',
+          ts: '1234567890.123456'
+        }
+      }
+      const timestamp = Math.floor(Date.now() / 1000).toString()
+      const signature = generateSlackSignature(timestamp, JSON.stringify(payload))
+
+      const sendRequest = () =>
+        request(app)
+          .post('/v1/webhooks/slack')
+          .set('x-slack-signature', signature)
+          .set('x-slack-request-timestamp', timestamp)
+          .send(payload)
+
+      await sendRequest().expect(httpStatus.OK)
+      await sendRequest().expect(httpStatus.OK)
+
+      expect(receiveMessageSpy).toHaveBeenCalledTimes(1)
+    })
+
     test('should handle payload without event', async () => {
       const payload = { type: 'event_callback' } // Missing event property
       const timestamp = Math.floor(Date.now() / 1000).toString()


### PR DESCRIPTION
## What is in this PR?

Scaffolds the event setup agent. Gets it wired up and responding in the organizer Slack channel, future updates have something to build on. No field collection yet; the bot replies with a generic "Event setup coming soon" for now.

## Changes in the codebase

- `src/conversations/eventSetup.ts` — a "conversation type" is a config object that tells the engine how to connect agents to adapters. This one maps a Slack channel to the event setup agent. It's registered as internal, meaning it won't appear in the public config API.
- `src/agents/eventSetup/eventSetup.ts` — the agent. `evaluate()` checks whether the agent should respond (fires on "setup", "create event", "create an event", "new event", or a direct @mention). `respond()` returns a static placeholder.
- `src/agents/index.ts` + `src/conversations/index.ts` — one-line additions to register both so the engine finds them.
- `src/agents/eventSetup/SETUP.md` — guide for standing up the organizer Slack channel, with separate sections for local dev and production.

## Documentation and automated testing

Did you:
- [x] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [x] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

> `SLACK_SIGNING_SECRET` is required but already in `.env.example` (commented out). No new env vars.

## Testing this PR

- [ ] Join the test slack channel (DM me for access)
- [ ] Send a message with "setup" or "create an event" — bot should reply "Event setup coming soon"
- [ ] Send an unrelated message — bot should stay silent

## Additional information
I'm breaking this larger epic down into smaller GH issues & PRs. 