### PR TITLE
feat: guided event setup flow in Slack with confirmation and link generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,25 @@ DEFAULT_OPENAI_API_KEY=
 # (Optional) Configuration for Slack
 # SLACK_SIGNING_SECRET=
 
+# (Optional) Event Setup Slack Bot. Only needed if you run the eventSetup
+# agent. See docs/pages/platforms/slack.md for details.
+#
+# Base URL of the frontend that hosts the participant/moderator pages.
+# EVENT_UI_BASE_URL=
+
+# Template for participant links. Placeholders: {host}, {conversationId},
+# {slug}, {<channelName>_passcode}. Wrap optional segments in [ ] so they
+# drop out when the referenced passcode is missing.
+# EVENT_PARTICIPANT_URL_TEMPLATE={host}/assistant/?conversationId={conversationId}[&channel=transcript,{transcript_passcode}][&channel=chat,{chat_passcode}][&channel=resources,{resources_passcode}]
+# EVENT_MODERATOR_URL_TEMPLATE={host}/moderator/?conversationId={conversationId}&channel=moderator,{moderator_passcode}[&channel=transcript,{transcript_passcode}]
+
+# IANA timezone used to render dates in the confirmation summary when the
+# organizer doesn't specify one in the message text.
+# EVENT_DISPLAY_TIMEZONE=America/New_York
+
+# Calendar deep link the "Add to Calendar" link points at.
+# CALENDAR_DEEPLINK_BASE_URL=
+
 # (Optional) For using vLLM models hosted on various platforms for INFERENCE
 # Example for runpod.io
 # VLLM_API_URL=https://api.runpod.ai/v2/ENDPOINT_ID/openai/v1

--- a/docs/pages/installing/index.md
+++ b/docs/pages/installing/index.md
@@ -66,3 +66,7 @@ If you would like to use LLM Engine with the Nextspace client, see our [nextspac
 ## Optional: Zoom integration
 
 If you would like to use LLM Engine with Zoom, see our [zoom guide](../platforms/zoom.md).
+
+## Optional: Slack integration
+
+If you would like to use LLM Engine with Slack, including the Event Setup Bot for organizers, see our [slack guide](../platforms/slack.md).

--- a/docs/pages/platforms/slack.md
+++ b/docs/pages/platforms/slack.md
@@ -85,3 +85,27 @@ Example conversation body:
         "dmChannels": [{ "direct": true, "agent": "playfulPerMessage", "direction": "both"}]}]
 }
 ```
+
+### Event Setup Bot configuration
+
+The `eventSetup` agent runs in Slack and walks an organizer through a multi-step setup flow (event name, date/time, description, Zoom link, topic, speakers, moderators) before creating an `eventAssistant` conversation. All of its env vars are optional and only need to be set if you run this agent.
+
+```
+# Frontend base URL used to build participant/moderator links
+EVENT_UI_BASE_URL=
+
+# URL templates for the final-reply links. Placeholders: {host},
+# {conversationId}, {slug}, {<channelName>_passcode}. Wrap optional
+# segments in [ ] so they drop out when the referenced passcode is missing.
+EVENT_PARTICIPANT_URL_TEMPLATE={host}/assistant/?conversationId={conversationId}[&channel=transcript,{transcript_passcode}][&channel=chat,{chat_passcode}][&channel=resources,{resources_passcode}]
+EVENT_MODERATOR_URL_TEMPLATE={host}/moderator/?conversationId={conversationId}&channel=moderator,{moderator_passcode}[&channel=transcript,{transcript_passcode}]
+
+# IANA timezone for the date/time shown in the confirmation summary when
+# the organizer doesn't mention one in the message text
+EVENT_DISPLAY_TIMEZONE=America/New_York
+
+# Calendar deep link the "Add to Calendar" link points at. Set this to the
+# /calendar/0/deeplink/compose endpoint of whichever calendar host your
+# organizers sign into (e.g. work/school Microsoft 365 vs personal Outlook.com).
+CALENDAR_DEEPLINK_BASE_URL=
+```

--- a/src/agents/eventSetup/eventSetup.ts
+++ b/src/agents/eventSetup/eventSetup.ts
@@ -3,7 +3,7 @@ import { AgentMessageActions, ConversationHistory } from '../../types/index.type
 import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
 import { matchBotMention, normalizeBotMention } from '../helpers/intentChecks.js'
 import {
-  ROUND_PROMPTS,
+  getRoundPrompt,
   buildConfirmationPrompt,
   createEvent,
   extractFieldsFromThread,
@@ -91,7 +91,7 @@ export default verify({
       return reply(buildConfirmationPrompt(fields, confirmationOptions))
     }
     if (nextRound !== 'complete') {
-      return reply(ROUND_PROMPTS[nextRound])
+      return reply(getRoundPrompt(nextRound, fields))
     }
 
     const topicResult = await lookupTopicByName(fields.topicName!)

--- a/src/agents/eventSetup/eventSetup.ts
+++ b/src/agents/eventSetup/eventSetup.ts
@@ -13,6 +13,7 @@ import {
   lookupTopicByName
 } from './fieldCollection.js'
 import logger from '../../config/logger.js'
+import { SETUP_CHANNEL_NAME } from '../../conversations/eventSetup.js'
 
 const SETUP_INTENT_PATTERNS = [/\bsetup\b/i, /\bcreate event\b/i, /\bcreate an? event\b/i, /\bnew event\b/i]
 
@@ -22,7 +23,7 @@ export default verify({
   priority: 100,
   maxTokens: 4000,
   defaultTriggers: {
-    perMessage: { channels: ['setup'] }
+    perMessage: { channels: [SETUP_CHANNEL_NAME] }
   },
   agentConfig: {
     botName: 'Eventbot'
@@ -32,7 +33,7 @@ export default verify({
   defaultLLMPlatform,
   defaultLLMModel,
   ragCollectionName: undefined,
-  defaultConversationHistorySettings: { count: 50, channels: ['setup'] },
+  defaultConversationHistorySettings: { count: 50, channels: [SETUP_CHANNEL_NAME] },
 
   async evaluate(userMessage) {
     const body = userMessage?.body ?? ''
@@ -64,7 +65,7 @@ export default verify({
   },
 
   async respond(conversationHistory: ConversationHistory, userMessage) {
-    const setupChannel = this.conversation.channels.find((channel) => channel.name === 'setup')
+    const setupChannel = this.conversation.channels.find((channel) => channel.name === SETUP_CHANNEL_NAME)
     const channels = setupChannel ? [setupChannel] : []
     // Reply in-thread so the setup exchange stays grouped under the
     // organizer's first message.

--- a/src/agents/eventSetup/eventSetup.ts
+++ b/src/agents/eventSetup/eventSetup.ts
@@ -1,6 +1,18 @@
 import verify from '../helpers/verify.js'
 import { AgentMessageActions, ConversationHistory } from '../../types/index.types.js'
 import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
+import { matchBotMention, normalizeBotMention } from '../helpers/intentChecks.js'
+import {
+  ROUND_PROMPTS,
+  buildConfirmationPrompt,
+  createEvent,
+  extractFieldsFromThread,
+  formatCompletionReply,
+  getNextRound,
+  getThreadMessages,
+  lookupTopicByName
+} from './fieldCollection.js'
+import logger from '../../config/logger.js'
 
 const SETUP_INTENT_PATTERNS = [/\bsetup\b/i, /\bcreate event\b/i, /\bcreate an? event\b/i, /\bnew event\b/i]
 
@@ -13,7 +25,7 @@ export default verify({
     perMessage: { channels: ['setup'] }
   },
   agentConfig: {
-    botName: 'Event Setup Bot'
+    botName: 'Eventbot'
   },
   llmTemplateVars: {},
   defaultLLMTemplates: {},
@@ -24,12 +36,19 @@ export default verify({
 
   async evaluate(userMessage) {
     const body = userMessage?.body ?? ''
-    const hasBotMention = body.toLowerCase().includes(`@${this.agentConfig.botName}`.toLowerCase())
-    const hasSetupIntent = SETUP_INTENT_PATTERNS.some((pattern) => pattern.test(body))
+    const { botName } = this.agentConfig
+    const words = body.trim().split(/\s+/)
 
-    if (hasBotMention || hasSetupIntent) {
+    const hasBotMention = matchBotMention(words, botName)
+    const hasSetupIntent = SETUP_INTENT_PATTERNS.some((pattern) => pattern.test(body))
+    // A threaded reply means the organizer is mid-setup, so accept it
+    // without requiring a bot mention.
+    const isThreadReply = Boolean(userMessage?.parentMessage)
+
+    if (hasBotMention || hasSetupIntent || isThreadReply) {
+      const modifiedMessage = hasBotMention ? { ...userMessage, body: normalizeBotMention(body, botName) } : userMessage
       return {
-        userMessage,
+        userMessage: modifiedMessage,
         action: AgentMessageActions.CONTRIBUTE,
         userContributionVisible: true,
         suggestion: undefined
@@ -44,19 +63,54 @@ export default verify({
     }
   },
 
-  async respond(_conversationHistory: ConversationHistory, userMessage) {
+  async respond(conversationHistory: ConversationHistory, userMessage) {
     const setupChannel = this.conversation.channels.find((channel) => channel.name === 'setup')
-    const parentMessageId = userMessage.parentMessage
+    const channels = setupChannel ? [setupChannel] : []
+    // Reply in-thread so the setup exchange stays grouped under the
+    // organizer's first message.
+    const parent = userMessage.parentMessage || userMessage._id
 
-    return [
-      {
-        visible: true,
-        message: 'Event setup coming soon',
-        messageType: 'text',
-        channels: setupChannel ? [setupChannel] : [],
-        parent: parentMessageId
+    const reply = (message: string) => [{ visible: true, message, messageType: 'text', channels, parent }]
+
+    const llm = await this.getLLM()
+    const thread = getThreadMessages(conversationHistory, userMessage)
+    const fields = await extractFieldsFromThread(llm, thread, new Date(), this.agentConfig.botName)
+    logger.debug(`eventSetup extracted fields: ${JSON.stringify(fields)}`)
+    const nextRound = getNextRound(fields)
+
+    if (nextRound === 'confirmation') {
+      const topicResult = await lookupTopicByName(fields.topicName!)
+      if (topicResult.options && topicResult.options.length > 1) {
+        const list = topicResult.options.map((t, i) => `${i + 1}. ${t.name}`).join('\n')
+        return reply(`I found multiple topics matching "${fields.topicName}". Which one?\n${list}`)
       }
-    ]
+      const confirmationOptions = topicResult.match
+        ? { resolvedTopicName: topicResult.match.name }
+        : { topicWarning: "couldn't find this topic in Nextspace — create it there first, then tell me the name" }
+      return reply(buildConfirmationPrompt(fields, confirmationOptions))
+    }
+    if (nextRound !== 'complete') {
+      return reply(ROUND_PROMPTS[nextRound])
+    }
+
+    const topicResult = await lookupTopicByName(fields.topicName!)
+    if (!topicResult.match) {
+      if (topicResult.options && topicResult.options.length > 1) {
+        const list = topicResult.options.map((t, i) => `${i + 1}. ${t.name}`).join('\n')
+        return reply(`I found multiple topics matching "${fields.topicName}". Which one?\n${list}`)
+      }
+      return reply(
+        `I couldn't find a topic named "${fields.topicName}" in Nextspace. Please create it there first, then reply with the topic name.`
+      )
+    }
+
+    try {
+      const event = await createEvent(fields, String(topicResult.match.id ?? topicResult.match._id))
+      return reply(formatCompletionReply(event, fields))
+    } catch (err) {
+      logger.error(`eventSetup createEvent failed: ${(err as Error).message}`)
+      return reply(`I hit an error creating the event: ${(err as Error).message}`)
+    }
   },
 
   async start() {

--- a/src/agents/eventSetup/fieldCollection.ts
+++ b/src/agents/eventSetup/fieldCollection.ts
@@ -2,6 +2,8 @@ import { z } from 'zod'
 import mongoose from 'mongoose'
 import { getChatPromptResponse } from '../helpers/llmChain.js'
 import { ConversationHistory, IMessage } from '../../types/index.types.js'
+import { getConversationType } from '../../conversations/index.js'
+import { ZOOM_MEETING_URL_PROPERTY } from '../../conversations/eventAssistant.js'
 
 // Lazy imports to avoid a circular dependency: these modules load the agent
 // registry, which imports this file.
@@ -212,11 +214,14 @@ export async function createEvent(fields: CollectedFields, topicId: mongoose.Typ
       type: 'eventAssistant',
       name: fields.eventName,
       description: fields.description,
-      platforms: ['zoom'],
+      platforms: ['nextspace', 'zoom'],
       topicId: topicId.toString(),
       properties: {
-        zoomMeetingUrl: fields.zoomLink
+        [ZOOM_MEETING_URL_PROPERTY]: fields.zoomLink
       },
+      features: (getConversationType('eventAssistant')?.features ?? [])
+        .filter(f => f.default)
+        .map(f => ({ name: f.name })),
       scheduledTime: fields.dateTime,
       presenters: fields.speakers ?? [],
       moderators: fields.moderators ?? []
@@ -425,7 +430,7 @@ export function formatCompletionReply(event, fields?: CollectedFields): string {
       )
     })
   }
-  const zoomLink = event.properties?.zoomMeetingUrl ?? fields?.zoomLink
+  const zoomLink = event.properties?.[ZOOM_MEETING_URL_PROPERTY] ?? fields?.zoomLink
   // The conversation model stores scheduledTime + scheduledEndTime, not
   // duration — so we fall back to the collected fields for the deep-link
   // start/duration pair.

--- a/src/agents/eventSetup/fieldCollection.ts
+++ b/src/agents/eventSetup/fieldCollection.ts
@@ -1,0 +1,451 @@
+import { z } from 'zod'
+import mongoose from 'mongoose'
+import { getChatPromptResponse } from '../helpers/llmChain.js'
+import { ConversationHistory, IMessage } from '../../types/index.types.js'
+
+// Lazy imports to avoid a circular dependency: these modules load the agent
+// registry, which imports this file.
+
+export interface Speaker {
+  name: string
+  bio: string
+  alternateName?: string
+}
+
+export interface CollectedFields {
+  eventName?: string
+  dateTime?: string
+  duration?: number
+  description?: string
+  zoomLink?: string
+  hasResources?: boolean
+  topicName?: string
+  speakers?: Speaker[]
+  moderators?: Speaker[]
+  skipSpeakers?: boolean
+  skipModerators?: boolean
+  confirmed?: boolean
+  timeZone?: string
+}
+
+export type RoundKey = 'round1' | 'round2' | 'round3' | 'round4' | 'round5' | 'confirmation' | 'complete'
+
+export const ROUND_PROMPTS: Record<Exclude<RoundKey, 'complete' | 'confirmation'>, string> = {
+  round1:
+    "Sure, let's get this event set up. To start, please share:\n• The event name\n• The date and time\n• The duration (in minutes)",
+  round2:
+    'Got it. Next:\n• A short description of the event\n• The Zoom link\n• Whether the event needs a *resources* channel for sharing files and links during the event (yes/no)',
+  round3: 'What topic should this event be under?',
+  round4:
+    'Who is speaking? For each speaker, share their name plus an optional bio and an optional alternate name (nickname or other name) if they go by one. Reply *skip* if there are no speakers yet.',
+  round5:
+    'And who is moderating? For each moderator, share their name plus an optional bio and an optional alternate name. Reply *skip* if there are no moderators yet.'
+}
+
+/**
+ * Which round to prompt for next, or `'complete'` once every required field
+ * is set.
+ */
+export function getNextRound(fields: CollectedFields): RoundKey {
+  if (!fields.eventName || !fields.dateTime || typeof fields.duration !== 'number') return 'round1'
+  if (!fields.description || !fields.zoomLink || typeof fields.hasResources !== 'boolean') return 'round2'
+  if (!fields.topicName) return 'round3'
+  if (!fields.skipSpeakers && (!fields.speakers || fields.speakers.length === 0)) return 'round4'
+  if (!fields.skipModerators && (!fields.moderators || fields.moderators.length === 0)) return 'round5'
+  if (!fields.confirmed) return 'confirmation'
+  return 'complete'
+}
+
+const speakerSchema = z.object({
+  name: z.string(),
+  bio: z.string(),
+  alternateName: z.string().optional().describe('Nickname or stage name the speaker also goes by')
+})
+
+const collectedFieldsSchema = z.object({
+  eventName: z.string().optional(),
+  dateTime: z.string().optional().describe('ISO 8601 datetime string'),
+  duration: z.number().optional().describe('Duration in minutes'),
+  description: z.string().optional(),
+  zoomLink: z.string().optional(),
+  hasResources: z.boolean().optional().describe('True if the organizer wants a resources channel for sharing files/links'),
+  topicName: z.string().optional(),
+  speakers: z.array(speakerSchema).optional(),
+  moderators: z.array(speakerSchema).optional(),
+  skipSpeakers: z.boolean().optional(),
+  skipModerators: z.boolean().optional(),
+  confirmed: z.boolean().optional().describe('True when the organizer explicitly approves the summary'),
+  timeZone: z
+    .string()
+    .optional()
+    .describe(
+      'IANA timezone (e.g. America/New_York) inferred from any timezone the organizer mentioned, like ET, Eastern, PST, or GMT+1'
+    )
+})
+
+/**
+ * Filters history down to the current setup thread, so the LLM extractor
+ * doesn't see unrelated channel messages.
+ */
+export function getThreadMessages(history: ConversationHistory, userMessage: IMessage): IMessage[] {
+  if (!userMessage.parentMessage) {
+    return [userMessage]
+  }
+  const parentId = userMessage.parentMessage.toString()
+  const thread = history.messages.filter((m) => {
+    if (m._id?.toString() === parentId) return true
+    return m.parentMessage?.toString() === parentId
+  })
+  if (!thread.some((m) => m._id?.toString() === userMessage._id?.toString())) {
+    thread.push(userMessage)
+  }
+  return thread
+}
+
+const EXTRACTION_SYSTEM_PROMPT = `You extract structured event details from a Slack conversation between an organizer and a setup bot.
+
+Today's date (for resolving relative dates like "tomorrow"): {today}
+
+Rules:
+- Extract from the ENTIRE conversation, not just the most recent message. Earlier messages still count; carry their values forward.
+- Extract every field that appears anywhere in the conversation. Leave a field undefined only if it has never been mentioned.
+- For dateTime, return ISO 8601 in UTC (always end with Z). Resolve relative dates from "today" above.
+- If the organizer mentions a timezone (e.g. "5pm ET", "6:30 Pacific", "14:00 GMT+1"), use that timezone to compute the UTC dateTime, AND set timeZone to the matching IANA name (e.g. America/New_York for ET/Eastern, America/Los_Angeles for PT/Pacific, Europe/London for GMT/BST, etc.). If no timezone is mentioned, leave timeZone undefined.
+- duration is in minutes.
+- When the organizer answers the resources question, set hasResources=true on an affirmative reply (yes, yeah, sure, please) and hasResources=false on a negative reply (no, nope, skip, none). Leave undefined until they answer.
+- If the organizer says "skip" or "none" for speakers, set skipSpeakers=true.
+- If they say "skip" or "none" for moderators, set skipModerators=true.
+- speakers and moderators are arrays of {{name, bio, alternateName?}}. Include a speaker or moderator entry as soon as a name is provided, even if the bio is missing — set bio to an empty string in that case. Capture alternateName only when the organizer gives an explicit alias such as "also goes by", "aka", "nickname", or "stage name"; leave it undefined otherwise.
+- topicName must be the EXACT text the organizer typed when answering the topic question. Do not shorten, paraphrase, drop leading words, normalize casing, or "clean up" the value — preserve it character-for-character (you may trim surrounding whitespace).
+- Only tokens that begin with a literal "@" character are bot mentions. Strip them. Words without an "@" prefix are normal text — never drop or alter them even if they resemble a bot name.
+- If the bot has shown a summary of the event and the organizer's most recent reply is an affirmative such as "confirm", "yes", "yep", "looks good", "lgtm", "go ahead", or "create it", set confirmed=true. If the organizer's reply changes a field instead, leave confirmed undefined and apply the change.`
+
+/**
+ * Rebuilds the field state from the thread text via one LLM call. We don't
+ * persist state between turns.
+ */
+export async function extractFieldsFromThread(
+  llm,
+  thread: IMessage[],
+  today: Date = new Date(),
+  botName?: string
+): Promise<CollectedFields> {
+  // Strip bot @-mentions before the LLM sees the transcript so they can't
+  // be misread as part of a field value (e.g. "@Eventbot Setup Test" → "Setup Test").
+  const escapedBotName = botName?.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const mentionPattern = escapedBotName ? new RegExp(`@${escapedBotName}\\b`, 'gi') : null
+  const transcript = thread
+    .map((m) => {
+      const role = m.fromAgent ? 'Bot' : 'Organizer'
+      let body = typeof m.body === 'string' ? m.body : JSON.stringify(m.body)
+      if (mentionPattern) body = body.replace(mentionPattern, '').replace(/\s+/g, ' ').trim()
+      return `${role}: ${body}`
+    })
+    .join('\n')
+
+  const systemPrompt = EXTRACTION_SYSTEM_PROMPT.replace('{today}', today.toISOString().split('T')[0])
+
+  try {
+    const result = await getChatPromptResponse(
+      llm,
+      systemPrompt,
+      'Conversation:\n{transcript}',
+      { transcript },
+      [],
+      collectedFieldsSchema
+    )
+    const fields = (result ?? {}) as CollectedFields
+    // Warn if the LLM returned nothing but the thread had agent prompts already.
+    // That means we just lost state and the user will see the flow restart.
+    if (Object.keys(fields).length === 0 && thread.some((m) => m.fromAgent)) {
+      const { default: logger } = await import('../../config/logger.js')
+      logger.warn(
+        `eventSetup extractFieldsFromThread returned empty for a thread with ${thread.length} messages. Transcript:\n${transcript}`
+      )
+    }
+    return fields
+  } catch (err) {
+    const { default: logger } = await import('../../config/logger.js')
+    logger.error(`eventSetup extractFieldsFromThread failed: ${(err as Error).message}`)
+    return {}
+  }
+}
+
+/**
+ * Finds a public topic by name. Match is case-insensitive and ignores
+ * whitespace, hyphens, and underscores on both sides — so "Event Setup Test"
+ * matches a topic named "EventSetupTest" or "event_setup_test". Returns a
+ * single match, or a list of options when several topics match.
+ */
+export async function lookupTopicByName(name: string) {
+  const { default: topicService } = await import('../../services/topic.service.js')
+  const topics = await topicService.allPublicTopics()
+  const normalize = (s: string) => s.toLowerCase().replace(/[\s\-_]+/g, '')
+  const needle = normalize(name)
+  if (!needle) return { match: null, options: [] }
+  const exact = topics.filter((t) => t.name && normalize(t.name) === needle)
+  if (exact.length === 1) return { match: exact[0], options: null }
+  if (exact.length > 1) return { match: null, options: exact }
+  const partial = topics.filter((t) => t.name && normalize(t.name).includes(needle))
+  if (partial.length === 1) return { match: partial[0], options: null }
+  if (partial.length > 1) return { match: null, options: partial }
+  return { match: null, options: [] }
+}
+
+/**
+ * Creates an eventAssistant conversation from the collected fields. Uses
+ * the topic owner as the acting user, since this agent has no user
+ * identity of its own.
+ */
+export async function createEvent(fields: CollectedFields, topicId: mongoose.Types.ObjectId | string) {
+  const { default: topicService } = await import('../../services/topic.service.js')
+  const { default: conversationService } = await import('../../services/conversation.service/index.js')
+  const { default: User } = await import('../../models/user.model/user.model.js')
+
+  const topic = await topicService.findById(topicId)
+  if (!topic) throw new Error(`Topic ${topicId} not found`)
+  const owner = await User.findById(topic.owner)
+  if (!owner) throw new Error(`Topic owner ${topic.owner} not found`)
+
+  const created = await conversationService.createConversationFromType(
+    {
+      type: 'eventAssistant',
+      name: fields.eventName,
+      description: fields.description,
+      platforms: ['zoom'],
+      topicId: topicId.toString(),
+      properties: {
+        zoomMeetingUrl: fields.zoomLink
+      },
+      scheduledTime: fields.dateTime,
+      presenters: fields.speakers ?? [],
+      moderators: fields.moderators ?? []
+    },
+    owner
+  )
+
+  // Re-fetch with channels populated so the caller can read channel
+  // passcodes for the participant/moderator links.
+  const populated = await conversationService.findByIdFull(String(created._id ?? created.id), owner)
+  return populated ?? created
+}
+
+/**
+ * Renders an ISO datetime in a human-friendly form for the organizer's
+ * confirmation summary. Timezone defaults to America/New_York and is
+ * overridable via the EVENT_DISPLAY_TIMEZONE env var.
+ */
+export function formatDisplayDateTime(iso: string, timeZoneOverride?: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  const timeZone = timeZoneOverride || process.env.EVENT_DISPLAY_TIMEZONE || 'America/New_York'
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZoneName: 'short'
+  }).formatToParts(date)
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? ''
+  const hour12 = get('hour')
+  const minute = get('minute')
+  const dayPeriod = get('dayPeriod')
+  const tz = get('timeZoneName')
+  return `${get('month')} ${get('day')}, ${get('year')} at ${hour12}:${minute} ${dayPeriod} ${tz}`
+}
+
+function formatPeople(people?: Speaker[]): string {
+  if (!people || people.length === 0) return 'None'
+  return people
+    .map((p) => {
+      const displayName = p.alternateName ? `${p.name} (aka ${p.alternateName})` : p.name
+      return p.bio ? `${displayName} — ${p.bio}` : displayName
+    })
+    .join(', ')
+}
+
+interface ConfirmationOptions {
+  /** Canonical topic name from the DB, shown instead of the raw user input. */
+  resolvedTopicName?: string
+  /** Inline warning rendered next to the topic line (e.g. no match found). */
+  topicWarning?: string
+}
+
+/**
+ * Renders the summary the bot shows before creating the event so the
+ * organizer can spot-check every field and reply "confirm".
+ */
+export function buildConfirmationPrompt(fields: CollectedFields, options: ConfirmationOptions = {}): string {
+  const speakers = fields.skipSpeakers ? 'None' : formatPeople(fields.speakers)
+  const moderators = fields.skipModerators ? 'None' : formatPeople(fields.moderators)
+  const topicDisplay = options.resolvedTopicName || fields.topicName
+  const topicLine = options.topicWarning ? `• Topic: ${topicDisplay} (${options.topicWarning})` : `• Topic: ${topicDisplay}`
+  return [
+    'Here is what I have so far:',
+    `• Name: ${fields.eventName}`,
+    `• Date/time: ${fields.dateTime ? formatDisplayDateTime(fields.dateTime, fields.timeZone) : ''}`,
+    `• Duration: ${fields.duration} minutes`,
+    `• Description: ${fields.description}`,
+    `• Zoom link: ${fields.zoomLink}`,
+    topicLine,
+    `• Speakers: ${speakers}`,
+    `• Moderators: ${moderators}`,
+    '',
+    'Reply *confirm* to create the event, or tell me what to change.'
+  ].join('\n')
+}
+
+interface EventLinkInputs {
+  name: string
+  description?: string
+  zoomLink?: string
+  dateTime: string
+  duration: number
+}
+
+/**
+ * Builds an "add to calendar" deep link. Returns an empty string when the
+ * deployment hasn't configured CALENDAR_DEEPLINK_BASE_URL, so callers can
+ * conditionally skip the link instead of pointing organizers at a generic
+ * landing page.
+ */
+export function buildCalendarLink({ name, description, zoomLink, dateTime, duration }: EventLinkInputs): string {
+  const base = process.env.CALENDAR_DEEPLINK_BASE_URL
+  if (!base) return ''
+  const start = new Date(dateTime)
+  const end = new Date(start.getTime() + duration * 60 * 1000)
+  const params: Record<string, string> = {
+    path: '/calendar/action/compose',
+    rru: 'addevent',
+    subject: name,
+    startdt: start.toISOString(),
+    enddt: end.toISOString(),
+    body: description || '',
+    location: zoomLink || ''
+  }
+  // encodeURIComponent (vs URLSearchParams) keeps spaces as %20, which is
+  // what most calendar deep-link endpoints expect.
+  const query = Object.entries(params)
+    .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
+    .join('&')
+  return `${base}?${query}`
+}
+
+const DEFAULT_PARTICIPANT_TEMPLATE =
+  '{host}/assistant/?conversationId={conversationId}[&channel=transcript,{transcript_passcode}][&channel=chat,{chat_passcode}][&channel=resources,{resources_passcode}]'
+
+const DEFAULT_MODERATOR_TEMPLATE =
+  '{host}/moderator/?conversationId={conversationId}&channel=moderator,{moderator_passcode}[&channel=transcript,{transcript_passcode}]'
+
+interface ChannelLike {
+  name?: string
+  passcode?: string
+}
+interface ConversationLike {
+  id?: string
+  _id?: { toString(): string } | string
+  slug?: string
+  channels?: ChannelLike[]
+}
+
+function renderTemplate(template: string, vars: Record<string, string | undefined>): string {
+  // Optional `[...]` segments drop out when any placeholder inside them is
+  // missing — mirrors nextspace's "only include this query param if the
+  // channel exists" behavior. Required placeholders sit outside the brackets.
+  const withOptionalsApplied = template.replace(/\[([^\]]+)\]/g, (_match, inner: string) => {
+    const placeholders: string[] = inner.match(/\{([^}]+)\}/g) || []
+    const allResolved = placeholders.every((p) => Boolean(vars[p.slice(1, -1)]))
+    return allResolved ? inner : ''
+  })
+  return withOptionalsApplied.replace(/\{([^}]+)\}/g, (_match, key: string) => vars[key] ?? '')
+}
+
+/**
+ * Builds participant and moderator URLs from the conversation. Templates are
+ * env-driven so other frontends can override the URL shape without changing
+ * this file. The moderator URL is empty when the moderator channel lacks a
+ * passcode (e.g. moderator support disabled).
+ */
+export function buildEventLinks(
+  conversation: ConversationLike,
+  host: string,
+  options: { includeResources?: boolean } = {}
+): { participantUrl: string; moderatorUrl: string } {
+  const { includeResources = true } = options
+  const participantTemplate = process.env.EVENT_PARTICIPANT_URL_TEMPLATE || DEFAULT_PARTICIPANT_TEMPLATE
+  const moderatorTemplate = process.env.EVENT_MODERATOR_URL_TEMPLATE || DEFAULT_MODERATOR_TEMPLATE
+  const conversationId =
+    conversation.id ?? (typeof conversation._id === 'string' ? conversation._id : conversation._id?.toString())
+
+  const vars: Record<string, string | undefined> = {
+    host,
+    conversationId,
+    slug: conversation.slug
+  }
+  for (const channel of conversation.channels ?? []) {
+    if (channel.name && channel.passcode) {
+      // Skip the resources passcode when the organizer didn't ask for a
+      // resources section, so the bracket segment drops out of the URL.
+      if (channel.name === 'resources' && !includeResources) continue
+      vars[`${channel.name}_passcode`] = channel.passcode
+    }
+  }
+
+  const participantUrl = renderTemplate(participantTemplate, vars)
+  // Skip the moderator link entirely if the conversation has no moderator
+  // passcode — the rendered URL would be missing the required token.
+  const moderatorUrl = vars.moderator_passcode ? renderTemplate(moderatorTemplate, vars) : ''
+  return { participantUrl, moderatorUrl }
+}
+
+function eventTypeSupportsModerators(event): boolean {
+  const features = event?.features
+  if (!Array.isArray(features)) return false
+  return features.some((f) => f?.name === 'moderatorSupport' && f?.enabled !== false)
+}
+
+export function formatCompletionReply(event, fields?: CollectedFields): string {
+  // EVENT_UI_BASE_URL points at the frontend (e.g. http://localhost:8080).
+  // APP_HOST is the llm_engine server itself, so it's only a fallback for
+  // dev setups where both run on the same host.
+  const host = process.env.EVENT_UI_BASE_URL || process.env.APP_HOST || ''
+  const { participantUrl, moderatorUrl } = buildEventLinks(event, host, {
+    includeResources: fields?.hasResources ?? false
+  })
+  if (eventTypeSupportsModerators(event) && !moderatorUrl) {
+    // moderatorSupport is on, but we couldn't build a link — usually means
+    // the moderator channel passcode was stripped when the conversation was
+    // re-fetched (passcodes are only returned to the owner or an admin).
+    import('../../config/logger.js').then(({ default: logger }) => {
+      logger.warn(
+        `eventSetup: moderator link is empty even though moderatorSupport is enabled on conversation ${event?._id ?? event?.id}. Check that the topic owner can see channel passcodes.`
+      )
+    })
+  }
+  const zoomLink = event.properties?.zoomMeetingUrl ?? fields?.zoomLink
+  // The conversation model stores scheduledTime + scheduledEndTime, not
+  // duration — so we fall back to the collected fields for the deep-link
+  // start/duration pair.
+  const dateTime = fields?.dateTime || event.scheduledTime
+  const duration = fields?.duration
+  const calendarLink =
+    dateTime && duration
+      ? buildCalendarLink({
+          name: event.name,
+          description: fields?.description ?? event.description,
+          zoomLink,
+          dateTime,
+          duration
+        })
+      : ''
+
+  const lines = [`Your event is set up!`, `*${event.name}*`]
+  if (participantUrl) lines.push(`• Participant link: ${participantUrl}`)
+  if (moderatorUrl) lines.push(`• Moderator link: ${moderatorUrl}`)
+  if (zoomLink) lines.push(`• Zoom: ${zoomLink}`)
+  if (calendarLink) lines.push(`• Add to Calendar: ${calendarLink}`)
+  return lines.join('\n\n')
+}

--- a/src/agents/eventSetup/fieldCollection.ts
+++ b/src/agents/eventSetup/fieldCollection.ts
@@ -3,6 +3,7 @@ import mongoose from 'mongoose'
 import { getChatPromptResponse } from '../helpers/llmChain.js'
 import { ConversationHistory, IMessage } from '../../types/index.types.js'
 import { getConversationType } from '../../conversations/index.js'
+import logger from '../../config/logger.js'
 import {
   ZOOM_MEETING_URL_PROPERTY,
   TRANSCRIPT_CHANNEL,
@@ -121,6 +122,11 @@ const collectedFieldsSchema = z.object({
  */
 export function getThreadMessages(history: ConversationHistory, userMessage: IMessage): IMessage[] {
   if (!userMessage.parentMessage) {
+    if (history.messages.length > 0) {
+      logger.warn(
+        `eventSetup getThreadMessages: root message with no parentMessage but history has ${history.messages.length} messages — prior context will not be included in extraction`
+      )
+    }
     return [userMessage]
   }
   const parentId = userMessage.parentMessage.toString()
@@ -165,6 +171,7 @@ export async function extractFieldsFromThread(
   // Strip bot @-mentions before the LLM sees the transcript so they can't
   // be misread as part of a field value (e.g. "@Eventbot Setup Test" → "Setup Test").
   const escapedBotName = botName?.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  // eslint-disable-next-line security/detect-non-literal-regexp
   const mentionPattern = escapedBotName ? new RegExp(`@${escapedBotName}\\b`, 'gi') : null
   const transcript = thread
     .map((m) => {
@@ -190,14 +197,12 @@ export async function extractFieldsFromThread(
     // Warn if the LLM returned nothing but the thread had agent prompts already.
     // That means we just lost state and the user will see the flow restart.
     if (Object.keys(fields).length === 0 && thread.some((m) => m.fromAgent)) {
-      const { default: logger } = await import('../../config/logger.js')
       logger.warn(
         `eventSetup extractFieldsFromThread returned empty for a thread with ${thread.length} messages. Transcript:\n${transcript}`
       )
     }
     return fields
   } catch (err) {
-    const { default: logger } = await import('../../config/logger.js')
     logger.error(`eventSetup extractFieldsFromThread failed: ${(err as Error).message}`)
     return {}
   }
@@ -253,8 +258,8 @@ export async function createEvent(fields: CollectedFields, topicId: mongoose.Typ
         .filter(f => f.default)
         .map(f => ({ name: f.name })),
       scheduledTime: fields.dateTime,
-      presenters: fields.speakers ?? [],
-      moderators: fields.moderators ?? []
+      presenters: fields.skipSpeakers ? [] : (fields.speakers ?? []),
+      moderators: fields.skipModerators ? [] : (fields.moderators ?? [])
     },
     owner
   )
@@ -459,11 +464,9 @@ export function formatCompletionReply(event, fields?: CollectedFields): string {
     // moderatorSupport is on, but we couldn't build a link — usually means
     // the moderator channel passcode was stripped when the conversation was
     // re-fetched (passcodes are only returned to the owner or an admin).
-    import('../../config/logger.js').then(({ default: logger }) => {
-      logger.warn(
-        `eventSetup: moderator link is empty even though moderatorSupport is enabled on conversation ${event?._id ?? event?.id}. Check that the topic owner can see channel passcodes.`
-      )
-    })
+    logger.warn(
+      `eventSetup: moderator link is empty even though moderatorSupport is enabled on conversation ${event?._id ?? event?.id}. Check that the topic owner can see channel passcodes.`
+    )
   }
   const zoomLink = event.properties?.[ZOOM_MEETING_URL_PROPERTY] ?? fields?.zoomLink
   // The conversation model stores scheduledTime + scheduledEndTime, not

--- a/src/agents/eventSetup/fieldCollection.ts
+++ b/src/agents/eventSetup/fieldCollection.ts
@@ -3,7 +3,13 @@ import mongoose from 'mongoose'
 import { getChatPromptResponse } from '../helpers/llmChain.js'
 import { ConversationHistory, IMessage } from '../../types/index.types.js'
 import { getConversationType } from '../../conversations/index.js'
-import { ZOOM_MEETING_URL_PROPERTY } from '../../conversations/eventAssistant.js'
+import {
+  ZOOM_MEETING_URL_PROPERTY,
+  TRANSCRIPT_CHANNEL,
+  CHAT_CHANNEL,
+  RESOURCES_CHANNEL,
+  MODERATOR_CHANNEL
+} from '../../conversations/eventAssistant.js'
 
 // Lazy imports to avoid a circular dependency: these modules load the agent
 // registry, which imports this file.
@@ -340,10 +346,15 @@ export function buildCalendarLink({ name, description, zoomLink, dateTime, durat
 }
 
 const DEFAULT_PARTICIPANT_TEMPLATE =
-  '{host}/assistant/?conversationId={conversationId}[&channel=transcript,{transcript_passcode}][&channel=chat,{chat_passcode}][&channel=resources,{resources_passcode}]'
+  `{host}/assistant/?conversationId={conversationId}` +
+  `[&channel=${TRANSCRIPT_CHANNEL},{${TRANSCRIPT_CHANNEL}_passcode}]` +
+  `[&channel=${CHAT_CHANNEL},{${CHAT_CHANNEL}_passcode}]` +
+  `[&channel=${RESOURCES_CHANNEL},{${RESOURCES_CHANNEL}_passcode}]`
 
 const DEFAULT_MODERATOR_TEMPLATE =
-  '{host}/moderator/?conversationId={conversationId}&channel=moderator,{moderator_passcode}[&channel=transcript,{transcript_passcode}]'
+  `{host}/moderator/?conversationId={conversationId}` +
+  `&channel=${MODERATOR_CHANNEL},{${MODERATOR_CHANNEL}_passcode}` +
+  `[&channel=${TRANSCRIPT_CHANNEL},{${TRANSCRIPT_CHANNEL}_passcode}]`
 
 interface ChannelLike {
   name?: string
@@ -394,7 +405,7 @@ export function buildEventLinks(
     if (channel.name && channel.passcode) {
       // Skip the resources passcode when the organizer didn't ask for a
       // resources section, so the bracket segment drops out of the URL.
-      if (channel.name === 'resources' && !includeResources) continue
+      if (channel.name === RESOURCES_CHANNEL && !includeResources) continue
       vars[`${channel.name}_passcode`] = channel.passcode
     }
   }

--- a/src/agents/eventSetup/fieldCollection.ts
+++ b/src/agents/eventSetup/fieldCollection.ts
@@ -38,16 +38,40 @@ export interface CollectedFields {
 
 export type RoundKey = 'round1' | 'round2' | 'round3' | 'round4' | 'round5' | 'confirmation' | 'complete'
 
-export const ROUND_PROMPTS: Record<Exclude<RoundKey, 'complete' | 'confirmation'>, string> = {
-  round1:
-    "Sure, let's get this event set up. To start, please share:\n• The event name\n• The date and time\n• The duration (in minutes)",
-  round2:
-    'Got it. Next:\n• A short description of the event\n• The Zoom link\n• Whether the event needs a *resources* channel for sharing files and links during the event (yes/no)',
-  round3: 'What topic should this event be under?',
-  round4:
-    'Who is speaking? For each speaker, share their name plus an optional bio and an optional alternate name (nickname or other name) if they go by one. Reply *skip* if there are no speakers yet.',
-  round5:
-    'And who is moderating? For each moderator, share their name plus an optional bio and an optional alternate name. Reply *skip* if there are no moderators yet.'
+const ROUND3_PROMPT = 'What topic should this event be under?'
+const ROUND4_PROMPT =
+  'Who is speaking? For each speaker, share their name plus an optional bio and an optional alternate name (nickname or other name) if they go by one. Reply *skip* if there are no speakers yet.'
+const ROUND5_PROMPT =
+  'And who is moderating? For each moderator, share their name plus an optional bio and an optional alternate name. Reply *skip* if there are no moderators yet.'
+
+/**
+ * Returns the prompt for the given round, listing only the fields that are
+ * still missing. For rounds with multiple fields, uses a friendly opener on
+ * first contact and a targeted "still need" message on re-prompts.
+ */
+export function getRoundPrompt(round: Exclude<RoundKey, 'complete' | 'confirmation'>, fields: CollectedFields): string {
+  if (round === 'round1') {
+    const missing: string[] = []
+    if (!fields.eventName) missing.push('• The event name')
+    if (!fields.dateTime) missing.push('• The date and time')
+    if (typeof fields.duration !== 'number') missing.push('• The duration (in minutes)')
+    const isFirstContact = !fields.eventName && !fields.dateTime && typeof fields.duration !== 'number'
+    const opener = isFirstContact ? "Sure, let's get this event set up. To start, please share:" : 'Still need:'
+    return `${opener}\n${missing.join('\n')}`
+  }
+  if (round === 'round2') {
+    const missing: string[] = []
+    if (!fields.description) missing.push('• A short description of the event')
+    if (!fields.zoomLink) missing.push('• The Zoom link')
+    if (typeof fields.hasResources !== 'boolean')
+      missing.push('• Whether the event needs a *resources* channel for sharing files and links (yes/no)')
+    const isFirstContact = !fields.description && !fields.zoomLink && typeof fields.hasResources !== 'boolean'
+    const opener = isFirstContact ? 'Got it. Next:' : 'Still need:'
+    return `${opener}\n${missing.join('\n')}`
+  }
+  if (round === 'round3') return ROUND3_PROMPT
+  if (round === 'round4') return ROUND4_PROMPT
+  return ROUND5_PROMPT
 }
 
 /**

--- a/src/conversations/eventAssistant.ts
+++ b/src/conversations/eventAssistant.ts
@@ -3,6 +3,8 @@ import adapterTypes from '../adapters/config.js'
 import { ConversationType, Direction } from '../types/index.types.js'
 import config from '../config/config.js'
 
+export const ZOOM_MEETING_URL_PROPERTY = 'zoomMeetingUrl' as const
+
 const eventAssistant: ConversationType = {
   // user-facing
   name: 'eventAssistant',

--- a/src/conversations/eventAssistant.ts
+++ b/src/conversations/eventAssistant.ts
@@ -5,6 +5,13 @@ import config from '../config/config.js'
 
 export const ZOOM_MEETING_URL_PROPERTY = 'zoomMeetingUrl' as const
 
+export const TRANSCRIPT_CHANNEL = 'transcript' as const
+export const PARTICIPANT_CHANNEL = 'participant' as const
+export const MODERATOR_CHANNEL = 'moderator' as const
+export const CHAT_CHANNEL = 'chat' as const
+export const IMAGE_GEN_CHANNEL = 'image-gen' as const
+export const RESOURCES_CHANNEL = 'resources' as const
+
 const eventAssistant: ConversationType = {
   // user-facing
   name: 'eventAssistant',
@@ -230,11 +237,11 @@ const eventAssistant: ConversationType = {
   ],
   enableDMs: ['agents'],
   channels: [
-    { name: 'transcript' },
-    { name: 'participant' },
-    { name: 'moderator' },
-    { name: 'chat' },
-    { name: 'image-gen' }
+    { name: TRANSCRIPT_CHANNEL },
+    { name: PARTICIPANT_CHANNEL },
+    { name: MODERATOR_CHANNEL },
+    { name: CHAT_CHANNEL },
+    { name: IMAGE_GEN_CHANNEL }
   ],
   adapters: {
     zoom: {
@@ -252,17 +259,17 @@ const eventAssistant: ConversationType = {
       ],
       chatChannels: [
         {
-          name: 'moderator',
+          name: MODERATOR_CHANNEL,
           direction: Direction.OUTGOING
         },
         {
-          name: 'chat',
+          name: CHAT_CHANNEL,
           direction: Direction.BOTH
         }
       ],
       audioChannels: [
         {
-          name: 'transcript',
+          name: TRANSCRIPT_CHANNEL,
           direction: Direction.INCOMING
         }
       ]
@@ -276,7 +283,7 @@ const eventAssistant: ConversationType = {
       },
       audioChannels: [
         {
-          name: 'transcript',
+          name: TRANSCRIPT_CHANNEL,
           direction: Direction.INCOMING
         }
       ]

--- a/src/conversations/eventSetup.ts
+++ b/src/conversations/eventSetup.ts
@@ -2,6 +2,8 @@ import { supportedModels } from '../agents/helpers/getModelChat.js'
 import { ConversationType, Direction } from '../types/index.types.js'
 import config from '../config/config.js'
 
+export const SETUP_CHANNEL_NAME = 'setup' as const
+
 const eventSetup: ConversationType = {
   name: 'eventSetup',
   label: 'Event Setup',
@@ -63,7 +65,7 @@ const eventSetup: ConversationType = {
       ]
     }
   ],
-  channels: [{ name: 'setup' }],
+  channels: [{ name: SETUP_CHANNEL_NAME }],
   adapters: {
     slack: {
       type: 'slack',
@@ -76,7 +78,7 @@ const eventSetup: ConversationType = {
       },
       chatChannels: [
         {
-          name: 'setup',
+          name: SETUP_CHANNEL_NAME,
           direction: Direction.BOTH
         }
       ]

--- a/tests/agents/eventSetup/eventSetup.agent.test.ts
+++ b/tests/agents/eventSetup/eventSetup.agent.test.ts
@@ -6,6 +6,7 @@ import { Agent, Channel } from '../../../src/models/index.js'
 import { AgentMessageActions, ConversationHistory } from '../../../src/types/index.types.js'
 import {
   getNextRound,
+  getRoundPrompt,
   lookupTopicByName,
   buildConfirmationPrompt,
   buildCalendarLink,
@@ -242,6 +243,45 @@ describe('eventSetup agent tests', () => {
           confirmed: true
         })
       ).toBe('complete')
+    })
+  })
+
+  describe('getRoundPrompt()', () => {
+    it('uses the friendly intro for round1 when no fields are collected yet', () => {
+      const prompt = getRoundPrompt('round1', {})
+      expect(prompt).toContain("let's get this event set up")
+      expect(prompt).toContain('event name')
+      expect(prompt).toContain('date and time')
+      expect(prompt).toContain('duration')
+    })
+
+    it('uses "Still need" and lists only missing fields when round1 is partially filled', () => {
+      const prompt = getRoundPrompt('round1', { eventName: 'My Event', dateTime: '2026-06-01T12:00:00Z' })
+      expect(prompt).toContain('Still need')
+      expect(prompt).toContain('duration')
+      expect(prompt).not.toContain('event name')
+      expect(prompt).not.toContain('date and time')
+    })
+
+    it('uses the friendly intro for round2 when no round2 fields are collected yet', () => {
+      const prompt = getRoundPrompt('round2', { eventName: 'X', dateTime: '2026-06-01T12:00:00Z', duration: 60 })
+      expect(prompt).toContain('Got it')
+      expect(prompt).toContain('description')
+      expect(prompt).toContain('Zoom link')
+      expect(prompt).toContain('resources')
+    })
+
+    it('uses "Still need" and lists only missing fields when round2 is partially filled', () => {
+      const prompt = getRoundPrompt('round2', {
+        eventName: 'X',
+        dateTime: '2026-06-01T12:00:00Z',
+        duration: 60,
+        description: 'A talk'
+      })
+      expect(prompt).toContain('Still need')
+      expect(prompt).toContain('Zoom link')
+      expect(prompt).toContain('resources')
+      expect(prompt).not.toContain('description')
     })
   })
 

--- a/tests/agents/eventSetup/eventSetup.agent.test.ts
+++ b/tests/agents/eventSetup/eventSetup.agent.test.ts
@@ -1,14 +1,26 @@
+import mongoose from 'mongoose'
 import setupAgentTest from '../../utils/setupAgentTest.js'
 import defaultAgentTypes from '../../../src/agents/index.js'
 import { createUser, createConversation, createPublicTopic, createMessage } from '../../utils/agentTestHelpers.js'
 import { Agent, Channel } from '../../../src/models/index.js'
 import { AgentMessageActions, ConversationHistory } from '../../../src/types/index.types.js'
+import {
+  getNextRound,
+  lookupTopicByName,
+  buildConfirmationPrompt,
+  buildCalendarLink,
+  buildEventLinks
+} from '../../../src/agents/eventSetup/fieldCollection.js'
+import { insertTopics, newPublicTopic, newPrivateTopic } from '../../fixtures/topic.fixture.js'
 
 jest.setTimeout(30000)
 
 const testConfig = setupAgentTest('eventSetup')
 
-const BOT_NAME = 'Event Setup Bot'
+// Single-word name on purpose: the fuzzy mention helpers in intentChecks.ts
+// compare word-by-word, so a multi-token name like 'Event Setup Bot' wouldn't
+// match.
+const BOT_NAME = 'Eventbot'
 
 describe('eventSetup agent tests', () => {
   let agent
@@ -79,6 +91,23 @@ describe('eventSetup agent tests', () => {
       expect(result.action).toBe(AgentMessageActions.CONTRIBUTE)
     })
 
+    it('returns CONTRIBUTE when bot name is misspelled (fuzzy match)', async () => {
+      const result = await evaluate('@Evntbat please help')
+      expect(result.action).toBe(AgentMessageActions.CONTRIBUTE)
+    })
+
+    it('normalizes a misspelled bot mention in the returned userMessage body', async () => {
+      const result = await evaluate('@Evntbat please help')
+      expect(result.userMessage.body).toContain(`@${BOT_NAME}`)
+    })
+
+    it('returns CONTRIBUTE when message is a thread reply (mid-flow continuation)', async () => {
+      const msg = await createMessage('It is at 3pm tomorrow', user1, conversation, ['setup'])
+      msg.parentMessage = new mongoose.Types.ObjectId()
+      const result = await defaultAgentTypes.eventSetup.evaluate.call(agent, msg)
+      expect(result.action).toBe(AgentMessageActions.CONTRIBUTE)
+    })
+
     it('returns OK when message has no setup intent', async () => {
       const result = await evaluate('Good morning everyone!')
       expect(result.action).toBe(AgentMessageActions.OK)
@@ -86,17 +115,6 @@ describe('eventSetup agent tests', () => {
   })
 
   describe('respond()', () => {
-    it('returns a placeholder response', async () => {
-      const msg = await createMessage('setup a new event', user1, conversation, ['setup'])
-      const history = buildHistory([])
-      const responses = await defaultAgentTypes.eventSetup.respond.call(agent, history, msg)
-
-      expect(responses).toHaveLength(1)
-      expect(responses[0].visible).toBe(true)
-      expect(responses[0].message).toBe('Event setup coming soon')
-      expect(responses[0].messageType).toBe('text')
-    })
-
     it('routes the response to the setup channel', async () => {
       const msg = await createMessage('setup a new event', user1, conversation, ['setup'])
       const history = buildHistory([])
@@ -104,6 +122,360 @@ describe('eventSetup agent tests', () => {
 
       const channelNames = responses[0].channels.map((c) => c.name)
       expect(channelNames).toContain('setup')
+    })
+
+    it('threads its reply under the organizer message (parent = root id)', async () => {
+      const msg = await createMessage('I want to set up a new event', user1, conversation, ['setup'])
+      msg._id = new mongoose.Types.ObjectId()
+      const responses = await defaultAgentTypes.eventSetup.respond.call(agent, buildHistory([]), msg)
+      expect(responses[0].parent?.toString()).toBe(msg._id.toString())
+    })
+
+    it('prompts for round 1 fields (name, date/time, duration) when nothing has been provided', async () => {
+      const msg = await createMessage('I want to set up an event', user1, conversation, ['setup'])
+      const responses = await defaultAgentTypes.eventSetup.respond.call(agent, buildHistory([]), msg)
+
+      expect(responses).toHaveLength(1)
+      const body = (responses[0].message as string).toLowerCase()
+      expect(body).toContain('name')
+      expect(body).toMatch(/date|time/)
+      expect(body).toMatch(/duration|minutes/)
+    })
+  })
+
+  describe('getNextRound() logic', () => {
+    it('returns round1 when nothing has been collected', () => {
+      expect(getNextRound({})).toBe('round1')
+    })
+
+    it('returns round1 until name + dateTime + duration are all present', () => {
+      expect(getNextRound({ eventName: 'X', dateTime: '2026-06-01T12:00:00Z' })).toBe('round1')
+      expect(getNextRound({ eventName: 'X', duration: 30 })).toBe('round1')
+    })
+
+    it('returns round2 once round 1 is complete', () => {
+      expect(getNextRound({ eventName: 'X', dateTime: '2026-06-01T12:00:00Z', duration: 30 })).toBe('round2')
+    })
+
+    it('stays on round2 until hasResources is answered', () => {
+      expect(
+        getNextRound({
+          eventName: 'X',
+          dateTime: '2026-06-01T12:00:00Z',
+          duration: 30,
+          description: 'a talk',
+          zoomLink: 'https://zoom.us/j/abc'
+        })
+      ).toBe('round2')
+    })
+
+    it('returns round3 once round 2 is complete', () => {
+      expect(
+        getNextRound({
+          eventName: 'X',
+          dateTime: '2026-06-01T12:00:00Z',
+          duration: 30,
+          description: 'a talk',
+          zoomLink: 'https://zoom.us/j/abc',
+          hasResources: false
+        })
+      ).toBe('round3')
+    })
+
+    it('returns round4 when topic is set but speakers are not (and not skipped)', () => {
+      expect(
+        getNextRound({
+          eventName: 'X',
+          dateTime: '2026-06-01T12:00:00Z',
+          duration: 30,
+          description: 'a talk',
+          zoomLink: 'https://zoom.us/j/abc',
+          hasResources: false,
+          topicName: 'AI'
+        })
+      ).toBe('round4')
+    })
+
+    it('skips round4 if skipSpeakers is true', () => {
+      expect(
+        getNextRound({
+          eventName: 'X',
+          dateTime: '2026-06-01T12:00:00Z',
+          duration: 30,
+          description: 'a talk',
+          zoomLink: 'https://zoom.us/j/abc',
+          hasResources: false,
+          topicName: 'AI',
+          skipSpeakers: true
+        })
+      ).toBe('round5')
+    })
+
+    it('returns confirmation when every field is set but the organizer has not confirmed', () => {
+      expect(
+        getNextRound({
+          eventName: 'X',
+          dateTime: '2026-06-01T12:00:00Z',
+          duration: 30,
+          description: 'a talk',
+          zoomLink: 'https://zoom.us/j/abc',
+          hasResources: false,
+          topicName: 'AI',
+          skipSpeakers: true,
+          skipModerators: true
+        })
+      ).toBe('confirmation')
+    })
+
+    it('returns complete only once confirmed is true', () => {
+      expect(
+        getNextRound({
+          eventName: 'X',
+          dateTime: '2026-06-01T12:00:00Z',
+          duration: 30,
+          description: 'a talk',
+          zoomLink: 'https://zoom.us/j/abc',
+          hasResources: false,
+          topicName: 'AI',
+          skipSpeakers: true,
+          skipModerators: true,
+          confirmed: true
+        })
+      ).toBe('complete')
+    })
+  })
+
+  describe('buildConfirmationPrompt()', () => {
+    const fullFields = {
+      eventName: 'Founders Q&A',
+      dateTime: '2026-05-22T20:00:00Z',
+      duration: 45,
+      description: 'Casual fundraising chat.',
+      zoomLink: 'https://zoom.us/j/abc',
+      topicName: 'Spring Demo Day',
+      speakers: [{ name: 'Maya Chen', bio: 'Founder of Stratoship', alternateName: 'Mei Chen' }],
+      moderators: [{ name: 'Priya Raman', bio: 'Northwind Capital' }]
+    }
+
+    it('shows a speaker alternate name alongside their primary name when present', () => {
+      const prompt = buildConfirmationPrompt(fullFields)
+      expect(prompt).toContain('Mei Chen')
+    })
+
+    it('formats dateTime as a human-readable string with the default timezone (Eastern)', () => {
+      // 2026-05-22T20:00:00Z is 4:00 PM EDT in America/New_York.
+      const prompt = buildConfirmationPrompt(fullFields)
+      expect(prompt).toMatch(/May 22, 2026 at 4:00 PM EDT/)
+    })
+
+    it('honors a timezone extracted from the organizer message', () => {
+      // Same instant, displayed in Pacific time.
+      const prompt = buildConfirmationPrompt({ ...fullFields, timeZone: 'America/Los_Angeles' })
+      expect(prompt).toMatch(/May 22, 2026 at 1:00 PM PDT/)
+    })
+
+    it('uses the resolved canonical topic name when one is provided', () => {
+      const prompt = buildConfirmationPrompt(
+        { ...fullFields, topicName: 'Setup Test' },
+        { resolvedTopicName: 'EventSetupTest' }
+      )
+      expect(prompt).toContain('EventSetupTest')
+      expect(prompt).not.toMatch(/Topic: Setup Test\b/)
+    })
+
+    it('shows a warning when the topic could not be matched', () => {
+      const prompt = buildConfirmationPrompt(
+        { ...fullFields, topicName: 'Made Up Topic' },
+        { topicWarning: 'I could not find this topic in Nextspace.' }
+      )
+      expect(prompt).toContain('Made Up Topic')
+      expect(prompt).toContain('I could not find this topic in Nextspace.')
+    })
+
+    it('includes every collected field in the summary', () => {
+      const prompt = buildConfirmationPrompt(fullFields)
+      expect(prompt).toContain('Founders Q&A')
+      expect(prompt).toContain('45')
+      expect(prompt).toContain('Casual fundraising chat.')
+      expect(prompt).toContain('https://zoom.us/j/abc')
+      expect(prompt).toContain('Spring Demo Day')
+      expect(prompt).toContain('Maya Chen')
+      expect(prompt).toContain('Priya Raman')
+    })
+
+    it('asks the organizer to reply confirm', () => {
+      const prompt = buildConfirmationPrompt(fullFields)
+      expect(prompt.toLowerCase()).toContain('confirm')
+    })
+
+    it('shows "none" when speakers were skipped', () => {
+      const prompt = buildConfirmationPrompt({ ...fullFields, speakers: [], skipSpeakers: true })
+      expect(prompt.toLowerCase()).toMatch(/speakers?:?\s*none/i)
+    })
+  })
+
+  describe('buildCalendarLink()', () => {
+    let savedBaseUrl: string | undefined
+    beforeEach(() => {
+      savedBaseUrl = process.env.CALENDAR_DEEPLINK_BASE_URL
+      delete process.env.CALENDAR_DEEPLINK_BASE_URL
+    })
+    afterEach(() => {
+      if (savedBaseUrl === undefined) delete process.env.CALENDAR_DEEPLINK_BASE_URL
+      else process.env.CALENDAR_DEEPLINK_BASE_URL = savedBaseUrl
+    })
+
+    it('returns an empty string when CALENDAR_DEEPLINK_BASE_URL is not set', () => {
+      const url = buildCalendarLink({
+        name: 'Founders Q&A',
+        zoomLink: 'https://zoom.us/j/abc',
+        dateTime: '2026-05-22T20:00:00Z',
+        duration: 45
+      })
+      expect(url).toBe('')
+    })
+
+    it('builds a deep link with subject, start, end, body, and location when the base URL is configured', () => {
+      process.env.CALENDAR_DEEPLINK_BASE_URL = 'https://calendar.example.com/compose'
+      const url = buildCalendarLink({
+        name: 'Founders Q&A',
+        description: 'A talk',
+        zoomLink: 'https://zoom.us/j/abc',
+        dateTime: '2026-05-22T20:00:00Z',
+        duration: 45
+      })
+      expect(url).toContain('https://calendar.example.com/compose')
+      expect(url).toContain('subject=Founders%20Q%26A')
+      expect(url).toContain('startdt=2026-05-22T20%3A00%3A00.000Z')
+      expect(url).toContain('enddt=2026-05-22T20%3A45%3A00.000Z')
+      expect(url).toContain('location=https%3A%2F%2Fzoom.us%2Fj%2Fabc')
+    })
+  })
+
+  describe('buildEventLinks()', () => {
+    const stubConversation = {
+      id: 'CONV123',
+      slug: 'founders-qa',
+      channels: [
+        { name: 'transcript', passcode: 'tr-pc' },
+        { name: 'chat', passcode: 'ch-pc' },
+        { name: 'moderator', passcode: 'mod-pc' },
+        { name: 'resources', passcode: 'res-pc' }
+      ]
+    }
+
+    afterEach(() => {
+      delete process.env.EVENT_PARTICIPANT_URL_TEMPLATE
+      delete process.env.EVENT_MODERATOR_URL_TEMPLATE
+    })
+
+    it('renders the nextspace-style default participant url with all optional channels filled in', () => {
+      const links = buildEventLinks(stubConversation, 'https://app.example.com')
+      expect(links.participantUrl).toBe(
+        'https://app.example.com/assistant/?conversationId=CONV123&channel=transcript,tr-pc&channel=chat,ch-pc&channel=resources,res-pc'
+      )
+    })
+
+    it('renders the nextspace-style default moderator url with the moderator passcode', () => {
+      const links = buildEventLinks(stubConversation, 'https://app.example.com')
+      expect(links.moderatorUrl).toBe(
+        'https://app.example.com/moderator/?conversationId=CONV123&channel=moderator,mod-pc&channel=transcript,tr-pc'
+      )
+    })
+
+    it('drops optional bracket segments when a referenced passcode is missing', () => {
+      const noChat = {
+        ...stubConversation,
+        channels: stubConversation.channels.filter((c) => c.name !== 'chat')
+      }
+      const links = buildEventLinks(noChat, 'https://app.example.com')
+      expect(links.participantUrl).not.toContain('chat,')
+      expect(links.participantUrl).toContain('transcript,tr-pc')
+      expect(links.participantUrl).toContain('resources,res-pc')
+    })
+
+    it('omits the resources channel segment when includeResources is false', () => {
+      const links = buildEventLinks(stubConversation, 'https://app.example.com', {
+        includeResources: false
+      })
+      expect(links.participantUrl).not.toContain('resources,')
+      expect(links.participantUrl).toContain('transcript,tr-pc')
+      expect(links.participantUrl).toContain('chat,ch-pc')
+    })
+
+    it('returns an empty moderatorUrl when the moderator channel has no passcode', () => {
+      const noMod = {
+        ...stubConversation,
+        channels: stubConversation.channels.filter((c) => c.name !== 'moderator')
+      }
+      const links = buildEventLinks(noMod, 'https://app.example.com')
+      expect(links.moderatorUrl).toBe('')
+    })
+
+    it('still emits a moderator link when the channel has a passcode regardless of moderator profiles', () => {
+      // The bot promised a moderator link whenever the event type supports
+      // it; collecting moderator profiles is independent.
+      const links = buildEventLinks(stubConversation, 'https://app.example.com')
+      expect(links.moderatorUrl).toContain('channel=moderator,mod-pc')
+    })
+
+    it('honors EVENT_PARTICIPANT_URL_TEMPLATE when set', () => {
+      process.env.EVENT_PARTICIPANT_URL_TEMPLATE = '{host}/join/{slug}?cid={conversationId}'
+      const links = buildEventLinks(stubConversation, 'https://other.example.com')
+      expect(links.participantUrl).toBe('https://other.example.com/join/founders-qa?cid=CONV123')
+    })
+  })
+
+  describe('lookupTopicByName()', () => {
+    beforeEach(async () => {
+      // Seed a deliberate mix of topic name styles plus a private decoy.
+      await insertTopics([
+        { ...newPublicTopic(), name: 'EventSetupTest', slug: 'eventsetuptest' },
+        { ...newPublicTopic(), name: 'Climate Tech', slug: 'climate-tech' },
+        { ...newPrivateTopic(), name: 'Private Secret Stuff', slug: 'private-secret-stuff' }
+      ])
+    })
+
+    it('finds an exact name match', async () => {
+      const result = await lookupTopicByName('EventSetupTest')
+      expect(result.match?.name).toBe('EventSetupTest')
+    })
+
+    it('matches a camelCase topic when the query has spaces (Event Setup Test → EventSetupTest)', async () => {
+      const result = await lookupTopicByName('Event Setup Test')
+      expect(result.match?.name).toBe('EventSetupTest')
+    })
+
+    it('is case-insensitive', async () => {
+      const result = await lookupTopicByName('event setup test')
+      expect(result.match?.name).toBe('EventSetupTest')
+    })
+
+    it('ignores hyphens and underscores when comparing', async () => {
+      const result = await lookupTopicByName('event-setup_test')
+      expect(result.match?.name).toBe('EventSetupTest')
+    })
+
+    it('matches a partial substring (LLM dropped the "Event" prefix)', async () => {
+      const result = await lookupTopicByName('Setup Test')
+      expect(result.match?.name).toBe('EventSetupTest')
+    })
+
+    it('returns null match when nothing matches', async () => {
+      const result = await lookupTopicByName('Totally Made Up Topic')
+      expect(result.match).toBeNull()
+      expect(result.options).toEqual([])
+    })
+
+    it('excludes private topics from results', async () => {
+      const result = await lookupTopicByName('Private Secret Stuff')
+      expect(result.match).toBeNull()
+    })
+
+    it('returns null match and empty options when the needle normalizes to empty', async () => {
+      const result = await lookupTopicByName('   ')
+      expect(result.match).toBeNull()
+      expect(result.options).toEqual([])
     })
   })
 })


### PR DESCRIPTION
## What is in this PR?

This adds the guided event setup flow to the Slack bot. An organizer messages the bot, and it asks for each field one at a time (event name, date/time, description, Zoom link, topic, speakers, moderators) in a Slack thread. Once everything is collected, it shows a confirmation summary. On confirm, it creates the event and posts the participant link, moderator link, Zoom link, and an "Add to Calendar" link.

When a round has multiple fields and the organizer only answers some of them, the bot asks specifically for what's still missing rather than repeating the whole prompt.

## Changes in the codebase

- New `fieldCollection.ts` handles the state machine: figuring out which field to ask for next, pulling structured data from the thread via LLM, building the confirmation summary, and generating the final reply with links
- Channel names and the Zoom property key are exported as typed constants from their respective conversation files so field collection can't silently drift out of sync with the conversation definition
- Features and platform names are derived at runtime from the eventAssistant conversation type rather than duplicated as hardcoded lists
- Participant and moderator URL structure is configurable via `EVENT_PARTICIPANT_URL_TEMPLATE` and `EVENT_MODERATOR_URL_TEMPLATE`. Optional URL segments (like passcode params) drop out automatically when the referenced value isn't set
- Calendar deeplink uses `CALENDAR_DEEPLINK_BASE_URL`. Leave it unset and the "Add to Calendar" link won't appear
- The moderator link is always included when the event type supports it, even if no moderator name or bio was provided
- Topic names are matched case/whitespace/hyphen-insensitively and resolved to the right canonical name at confirmation time
- Date/time is shown in human-readable format using `EVENT_DISPLAY_TIMEZONE`

## Documentation and automated tests

Did you:
- [x] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [x] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [x] update team documentation of any new or changed environment variables?

## Testing this PR

1. Add the new env vars to `.env`. The [Slack setup guide](docs/pages/platforms/slack.md) has the full list under "Event Setup Bot configuration". OR have Chelsea add you to the private Slack channel connected to a locally running instance. :) 
2. Message the event setup bot in Slack and walk through the prompts
3. Try answering only some fields in a round — the bot should ask for only what's missing, not repeat the whole prompt
4. Check the confirmation summary looks right, then confirm
5. Verify the final reply has a participant link, moderator link, Zoom link, and calendar link
6. Remove `CALENDAR_DEEPLINK_BASE_URL` and confirm the "Add to Calendar" line disappears

## Additional information

All the new env vars are optional. The bot works without them, links just won't appear for anything that's unset. Nothing is hardcoded.