### PR TITLE
DM moderator report to moderators in Zoom rather than sending to group chat

### DIFF
--- a/docs/pages/platforms/zoom.md
+++ b/docs/pages/platforms/zoom.md
@@ -98,13 +98,13 @@ Example setting data retention to four hours:
 
 ### Enabling Direct Messages
 
-If you wish to enable direct messages between agents and users, you must set the `enableDMs": ["agents"]` property during Conversation creation. You must also specify a `dmChannel` in the `Adapter` configuration for each agent that should receive DMs.
+If you wish to enable direct messages between agents and users, you must set the `"enableDMs": ["agents"]` property during Conversation creation. You must also specify a `dmChannel` in the `Adapter` configuration for each agent that should receive DMs.
 
 ```
 {
 "name": "Should plastic water bottles be banned?",
 "topicId": "{{defaultTopic}}",
-"enableDMs": ["agents"]
+"enableDMs": ["agents"],
 "channels": [ { "name": "transcript"}],
 "adapters": [ {"type": "zoom", "config" : {"meetingUrl": "{{ZOOM_MEETING_URL}}"},
     "dmChannels": [{"direct": true, "agent": "eventAssistant", "direction": "both"}],
@@ -113,3 +113,34 @@ If you wish to enable direct messages between agents and users, you must set the
 ```
 
 If you do not need transcription, remove the `transcript` channel from the configuration.
+
+#### Sending DMs to a Specific Set of Participants
+
+You can configure a DM channel to target a specific subset of participants using the `users` property. This is useful for sending moderator alerts or other outgoing messages to particular roles.
+
+The `users` property supports three modes:
+
+- **`"moderators"`** — targets participants whose Zoom display name fuzzy-matches a name in the conversation's `moderators` list. If no moderators are defined on the conversation, falls back to targeting the meeting host(s). This is the recommended mode for moderator alert channels.
+- **`"hosts"`** — targets only participants who joined as the Zoom host.
+- **Comma-separated names** — targets participants whose Zoom display name exactly matches one of the provided names, e.g. `"Alice Smith, Bob Jones"`.
+
+Targeted DM channels use `"direction": "outgoing"` since they are used for one-way delivery to specific participants, not for receiving messages.
+
+Example using `"moderators"` mode:
+
+```
+{
+"name": "Should plastic water bottles be banned?",
+"topicId": "{{defaultTopic}}",
+"enableDMs": ["agents"],
+"channels": [{"name": "transcript"}, {"name": "moderator"}],
+"adapters": [{"type": "zoom", "config": {"meetingUrl": "{{ZOOM_MEETING_URL}}"},
+    "dmChannels": [
+        {"direct": true, "agent": "eventAssistant", "direction": "both"},
+        {"name": "moderator", "direction": "outgoing", "users": "moderators"}
+    ],
+    "audioChannels": [{"name": "transcript"}]}]
+}
+```
+
+DM channel targeting is resolved at join time — when a participant joins (or updates their display name or host status), the engine checks whether they match the `users` criteria and registers them for that channel if so.

--- a/src/adapters/zoom.ts
+++ b/src/adapters/zoom.ts
@@ -54,7 +54,7 @@ async function deployMeetingBot() {
     },
     {
       type: 'webhook',
-      events: ['participant_events.join'],
+      events: ['participant_events.join', 'participant_events.update'],
       url: `${config.recall.endpointBaseUrl}/v1/webhooks/recall/join/?conversationId=${this.conversation._id}`
     }
   ]
@@ -400,6 +400,22 @@ export default {
     const botNames = bots.map((bot) => bot.config?.botName)
     botNames.push(defaultBotName)
     // Ignore if participant is one of the bots
+    if (!botNames.includes(participant.name)) {
+      const adapterUser: AdapterUser = {
+        username: participant.name,
+        dmConfig: { to: participant.id },
+        isHost: participant.is_host ?? false
+      }
+      return adapterUser
+    }
+  },
+  async participantUpdated(participant) {
+    if (!this.conversation.populated('adapters')) {
+      await this.conversation.populate('adapters')
+    }
+    const bots = this.conversation.adapters.filter((adapter) => adapter.type === 'zoom' && adapter.config?.botName)
+    const botNames = bots.map((bot) => bot.config?.botName)
+    botNames.push(defaultBotName)
     if (!botNames.includes(participant.name)) {
       const adapterUser: AdapterUser = {
         username: participant.name,

--- a/src/adapters/zoom.ts
+++ b/src/adapters/zoom.ts
@@ -401,7 +401,11 @@ export default {
     botNames.push(defaultBotName)
     // Ignore if participant is one of the bots
     if (!botNames.includes(participant.name)) {
-      const adapterUser: AdapterUser = { username: participant.name, dmConfig: { to: participant.id } }
+      const adapterUser: AdapterUser = {
+        username: participant.name,
+        dmConfig: { to: participant.id },
+        isHost: participant.is_host ?? false
+      }
       return adapterUser
     }
   },

--- a/src/conversations/eventAssistant.ts
+++ b/src/conversations/eventAssistant.ts
@@ -40,7 +40,7 @@ const eventAssistant: ConversationType = {
       required: false,
       type: 'number',
       default: 3
-    }
+    },
   ],
   /*
    * Each entry determines 3 things: the Features section in the event creation form,
@@ -247,13 +247,14 @@ const eventAssistant: ConversationType = {
           direct: true,
           agent: 'eventAssistant',
           direction: Direction.BOTH
+        },
+        {
+          name: 'moderator',
+          direction: Direction.OUTGOING,
+          users: 'moderators'
         }
       ],
       chatChannels: [
-        {
-          name: 'moderator',
-          direction: Direction.OUTGOING
-        },
         {
           name: 'chat',
           direction: Direction.BOTH

--- a/src/conversations/eventAssistant.ts
+++ b/src/conversations/eventAssistant.ts
@@ -40,7 +40,7 @@ const eventAssistant: ConversationType = {
       required: false,
       type: 'number',
       default: 3
-    },
+    }
   ],
   /*
    * Each entry determines 3 things: the Features section in the event creation form,

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -115,6 +115,7 @@ const supportedEvents = [
   'transcript.data',
   'participant_events.chat_message',
   'participant_events.join',
+  'participant_events.update',
   'bot.call_ended',
   'bot.in_call_recording',
   'bot.in_call_not_recording'
@@ -157,6 +158,8 @@ const handleEvent = async (req, _res) => {
     await webhookService.receiveMessage(zoomAdapter, req.body)
   } else if (event === 'participant_events.join') {
     await webhookService.participantJoined(zoomAdapter, req.body.data.data.participant)
+  } else if (event === 'participant_events.update') {
+    await webhookService.participantUpdated(zoomAdapter, req.body.data.data.participant)
   }
   _res.status(httpStatus.OK).send('ok')
 }

--- a/src/models/adapter.model.ts
+++ b/src/models/adapter.model.ts
@@ -40,6 +40,10 @@ const adapterChannelConfigSchema = new mongoose.Schema<AdapterChannelConfig>({
   config: {
     type: mongoose.Schema.Types.Mixed,
     default: undefined
+  },
+  users: {
+    type: mongoose.Schema.Types.Mixed,
+    required: false
   }
 })
 const adapterSchema = new mongoose.Schema<IAdapter, AdapterModel>(
@@ -200,8 +204,14 @@ adapterSchema.method('sendMessage', async function (message) {
         return
       }
       logger.debug(`Sending message with channel ${channelName} through adapter ${this._id}`)
-      const channelConfig = channel.direct ? channel.config[channelName] : channel.config
-      await adapterTypes[this.type].sendMessage.call(this, message, channelConfig)
+      if (channel.users) {
+        for (const dmConfig of Object.values(channel.config || {})) {
+          await adapterTypes[this.type].sendMessage.call(this, message, dmConfig)
+        }
+      } else {
+        const channelConfig = channel.direct ? channel.config[channelName] : channel.config
+        await adapterTypes[this.type].sendMessage.call(this, message, channelConfig)
+      }
     }
   }
 })

--- a/src/models/adapter.model.ts
+++ b/src/models/adapter.model.ts
@@ -11,6 +11,7 @@ export interface AdapterMethods {
   sendMessage(message: IMessage)
   validateBeforeUpdate()
   participantJoined(participant: Record<string, unknown>)
+  participantUpdated(participant: Record<string, unknown>)
 }
 
 interface AdapterStatics {
@@ -234,6 +235,18 @@ adapterSchema.method('participantJoined', async function (participant) {
     return
   }
   return await adapterTypes[this.type].participantJoined.call(this, participant)
+})
+
+adapterSchema.method('participantUpdated', async function (participant) {
+  if (!this.active) {
+    logger.warn(`Inactive adapter: ${this._id} received message`)
+    return
+  }
+  await populateConversation.call(this)
+  if (this.dmChannels?.length === 0 && this.chatChannels?.length === 0) {
+    return
+  }
+  return await adapterTypes[this.type].participantUpdated.call(this, participant)
 })
 
 adapterSchema.pre('validate', async function () {

--- a/src/services/webhook.service.ts
+++ b/src/services/webhook.service.ts
@@ -130,5 +130,12 @@ const participantJoined = async (adapter, participant) => {
   }
 }
 
-const webhookService = { receiveMessage, participantJoined }
+const participantUpdated = async (adapter, participant) => {
+  const adapterUser: AdapterUser = await adapter.participantUpdated(participant)
+  if (adapterUser) {
+    await getOrCreateUser(adapter, adapterUser)
+  }
+}
+
+const webhookService = { receiveMessage, participantJoined, participantUpdated }
 export default webhookService

--- a/src/services/webhook.service.ts
+++ b/src/services/webhook.service.ts
@@ -1,3 +1,4 @@
+import * as fuzzball from 'fuzzball'
 import { User } from '../models/index.js'
 import { AdapterMessage, AdapterUser } from '../types/adapter.types.js'
 import userService from './user.service.js'
@@ -32,6 +33,35 @@ async function getOrCreateUser(adapter, adapterUser) {
           config: {
             ...(dmChannelConfig.config || {}),
             [directChannelName]: adapterUser.dmConfig
+          }
+        }
+      }
+    }
+    if (dmChannelConfig.users && adapterUser.dmConfig) {
+      const moderators = adapter.conversation.moderators ?? []
+      const fuzzyMatchesModerator = moderators.some(
+        (mod) =>
+          fuzzball.ratio(adapterUser.username, mod.name) >= 70 ||
+          (mod.alternateName && fuzzball.ratio(adapterUser.username, mod.alternateName) >= 70)
+      )
+      let isTargeted: boolean
+      if (dmChannelConfig.users === 'moderators') {
+        isTargeted = moderators.length > 0 ? fuzzyMatchesModerator : adapterUser.isHost
+      } else if (dmChannelConfig.users === 'hosts') {
+        isTargeted = adapterUser.isHost
+      } else {
+        isTargeted = dmChannelConfig.users
+          .split(',')
+          .map((u) => u.trim())
+          .includes(adapterUser.username)
+      }
+      if (isTargeted && !dmChannelConfig.config?.[adapterUser.username]) {
+        channelsUpdated = true
+        return {
+          ...dmChannelConfig,
+          config: {
+            ...(dmChannelConfig.config || {}),
+            [adapterUser.username]: adapterUser.dmConfig
           }
         }
       }

--- a/src/types/adapter.types.ts
+++ b/src/types/adapter.types.ts
@@ -4,6 +4,7 @@ export interface AdapterUser {
   username: string
   pseudonym?: string
   dmConfig?: Record<string, unknown>
+  isHost?: boolean
 }
 
 export interface AdapterMessage<T> {

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -148,6 +148,7 @@ export interface AdapterChannelConfig {
   name?: string
   direction: Direction
   config?: Record<string, unknown>
+  users?: string
 }
 
 export interface IAdapter {

--- a/tests/adapters/zoom.adapter.test.ts
+++ b/tests/adapters/zoom.adapter.test.ts
@@ -2052,7 +2052,7 @@ describe('zoom adapter tests', () => {
               },
               {
                 type: 'webhook',
-                events: ['participant_events.join'],
+                events: ['participant_events.join', 'participant_events.update'],
                 url: `${config.recall.endpointBaseUrl}/v1/webhooks/recall/join/?conversationId=${conversation._id}`
               }
             ],
@@ -2130,7 +2130,7 @@ describe('zoom adapter tests', () => {
               },
               {
                 type: 'webhook',
-                events: ['participant_events.join'],
+                events: ['participant_events.join', 'participant_events.update'],
                 url: `${config.recall.endpointBaseUrl}/v1/webhooks/recall/join/?conversationId=${conversation._id}`
               }
             ],
@@ -2798,7 +2798,7 @@ describe('zoom adapter tests', () => {
       }
 
       const adapterUser = await adapter.participantJoined(participant)
-      expect(adapterUser).toEqual({ username: 'New Joiner', dmConfig: { to: 200 } })
+      expect(adapterUser).toEqual({ username: 'New Joiner', dmConfig: { to: 200 }, isHost: false })
     })
 
     it('does not configure direct channel when DMs are not enabled', async () => {

--- a/tests/services/webhook.service.test.ts
+++ b/tests/services/webhook.service.test.ts
@@ -38,7 +38,8 @@ const testAgentTypeSpecification = {
 // Create mock adapter type
 const mockAdapterType = {
   receiveMessage: jest.fn(),
-  participantJoined: jest.fn()
+  participantJoined: jest.fn(),
+  participantUpdated: jest.fn()
 }
 const testAdapterTypes = {
   test: mockAdapterType
@@ -92,6 +93,7 @@ describe('adapter service tests', () => {
     // Add mock methods to the adapter instance
     adapter.receiveMessage = mockAdapterType.receiveMessage
     adapter.participantJoined = mockAdapterType.participantJoined
+    adapter.participantUpdated = mockAdapterType.participantUpdated
 
     conversation.adapters.push(adapter)
     await conversation.save()
@@ -1008,6 +1010,115 @@ describe('adapter service tests', () => {
       expect(moderatorChannel!.config?.['Regular User']).toBeUndefined()
     })
 
+    describe('participantUpdated', () => {
+      it('adds participant to moderator channel when they become host and no moderators are defined', async () => {
+        await createConversation('Meeting with Host Promotion')
+        conversation.moderators = []
+        conversation.enableDMs = ['agents']
+        await conversation.save()
+
+        adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'moderators' }]
+        await adapter.save()
+
+        // Participant joins as non-host — not added to moderator channel
+        mockAdapterType.participantJoined.mockReturnValue({
+          username: 'Future Host',
+          dmConfig: { to: 720 },
+          isHost: false
+        })
+        await webhookService.participantJoined(adapter, { id: 720, name: 'Future Host', is_host: false, platform: 'test' })
+
+        let modifiedAdapter = await Adapter.findById(adapter._id)
+        expect(modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')?.config?.['Future Host']).toBeUndefined()
+
+        // Host status changes — now added to moderator channel
+        mockAdapterType.participantUpdated.mockReturnValue({
+          username: 'Future Host',
+          dmConfig: { to: 720 },
+          isHost: true
+        })
+        await webhookService.participantUpdated(adapter, { id: 720, name: 'Future Host', is_host: true, platform: 'test' })
+
+        modifiedAdapter = await Adapter.findById(adapter._id)
+        expect(modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')?.config?.['Future Host']).toEqual({
+          to: 720
+        })
+      })
+
+      it('adds participant to moderator channel when they rename to match a moderator', async () => {
+        await createConversation('Meeting with Rename to Moderator')
+        conversation.moderators = [{ name: 'Alice Smith' }]
+        conversation.enableDMs = ['agents']
+        await conversation.save()
+
+        adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'moderators' }]
+        await adapter.save()
+
+        // Participant joins with a non-matching name
+        mockAdapterType.participantJoined.mockReturnValue({
+          username: 'Unknown',
+          dmConfig: { to: 721 },
+          isHost: false
+        })
+        await webhookService.participantJoined(adapter, { id: 721, name: 'Unknown', is_host: false, platform: 'test' })
+
+        let modifiedAdapter = await Adapter.findById(adapter._id)
+        expect(modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')?.config?.Unknown).toBeUndefined()
+
+        // Participant renames to match moderator
+        mockAdapterType.participantUpdated.mockReturnValue({
+          username: 'Alice Smith',
+          dmConfig: { to: 721 },
+          isHost: false
+        })
+        await webhookService.participantUpdated(adapter, { id: 721, name: 'Alice Smith', is_host: false, platform: 'test' })
+
+        modifiedAdapter = await Adapter.findById(adapter._id)
+        expect(modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')?.config?.['Alice Smith']).toEqual({
+          to: 721
+        })
+      })
+
+      it('does not add participant to moderator channel when update does not match criteria', async () => {
+        await createConversation('Meeting with Non-Matching Update')
+        conversation.moderators = [{ name: 'Alice Smith' }]
+        conversation.enableDMs = ['agents']
+        await conversation.save()
+
+        adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'moderators' }]
+        await adapter.save()
+
+        mockAdapterType.participantUpdated.mockReturnValue({
+          username: 'Carol Williams',
+          dmConfig: { to: 722 },
+          isHost: false
+        })
+        await webhookService.participantUpdated(adapter, {
+          id: 722,
+          name: 'Carol Williams',
+          is_host: false,
+          platform: 'test'
+        })
+
+        const modifiedAdapter = await Adapter.findById(adapter._id)
+        expect(modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')?.config?.['Carol Williams']).toBeUndefined()
+      })
+
+      it('does not process participantUpdated when adapter type returns null', async () => {
+        await createConversation('Meeting with Bot Update')
+        conversation.enableDMs = ['agents']
+        await conversation.save()
+
+        adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'moderators' }]
+        await adapter.save()
+
+        mockAdapterType.participantUpdated.mockReturnValue(null)
+        await webhookService.participantUpdated(adapter, { id: 723, name: 'LLM Engine', is_host: true, platform: 'test' })
+
+        const modifiedAdapter = await Adapter.findById(adapter._id)
+        expect(modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')?.config).toBeUndefined()
+      })
+    })
 
     it('does not process participantJoined when adapter type returns null', async () => {
       await createConversation('Meeting with Bot Participant')

--- a/tests/services/webhook.service.test.ts
+++ b/tests/services/webhook.service.test.ts
@@ -785,6 +785,230 @@ describe('adapter service tests', () => {
       expect(dmChannel!.config![`direct-${user!._id}-${agent._id}`]).toEqual({ to: 500 })
     })
 
+    it('stores dmConfig on users channel when host joins and users is "hosts"', async () => {
+      await createConversation('Meeting with Host DMs')
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'hosts' }]
+      await adapter.save()
+
+      const participant = { id: 700, name: 'Host User', is_host: true, platform: 'test' }
+
+      mockAdapterType.participantJoined.mockReturnValue({
+        username: 'Host User',
+        dmConfig: { to: 700 },
+        isHost: true
+      })
+
+      await webhookService.participantJoined(adapter, participant)
+
+      const modifiedAdapter = await Adapter.findById(adapter._id)
+      const moderatorChannel = modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')
+      expect(moderatorChannel!.config!['Host User']).toEqual({ to: 700 })
+    })
+
+    it('does not store dmConfig on users channel when non-host joins and users is "hosts"', async () => {
+      await createConversation('Meeting with Non-Host')
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'hosts' }]
+      await adapter.save()
+
+      const participant = { id: 701, name: 'Regular User', is_host: false, platform: 'test' }
+
+      mockAdapterType.participantJoined.mockReturnValue({
+        username: 'Regular User',
+        dmConfig: { to: 701 },
+        isHost: false
+      })
+
+      await webhookService.participantJoined(adapter, participant)
+
+      const modifiedAdapter = await Adapter.findById(adapter._id)
+      const moderatorChannel = modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')
+      expect(moderatorChannel!.config?.['Regular User']).toBeUndefined()
+    })
+
+    it('stores dmConfig on users channel when username matches comma-separated list', async () => {
+      await createConversation('Meeting with Named Moderators')
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'Alice Smith, Bob Jones' }]
+      await adapter.save()
+
+      mockAdapterType.participantJoined.mockReturnValue({
+        username: 'Alice Smith',
+        dmConfig: { to: 702 },
+        isHost: false
+      })
+
+      await webhookService.participantJoined(adapter, { id: 702, name: 'Alice Smith', is_host: false, platform: 'test' })
+
+      const modifiedAdapter = await Adapter.findById(adapter._id)
+      const moderatorChannel = modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')
+      expect(moderatorChannel!.config!['Alice Smith']).toEqual({ to: 702 })
+    })
+
+    it('does not store dmConfig on users channel when username is not in comma-separated list', async () => {
+      await createConversation('Meeting with Named Moderators Exclusion')
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'Alice Smith, Bob Jones' }]
+      await adapter.save()
+
+      mockAdapterType.participantJoined.mockReturnValue({
+        username: 'Carol Williams',
+        dmConfig: { to: 703 },
+        isHost: false
+      })
+
+      await webhookService.participantJoined(adapter, { id: 703, name: 'Carol Williams', is_host: false, platform: 'test' })
+
+      const modifiedAdapter = await Adapter.findById(adapter._id)
+      const moderatorChannel = modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')
+      expect(moderatorChannel!.config?.['Carol Williams']).toBeUndefined()
+    })
+
+    it('does not duplicate dmConfig on users channel when same host rejoins', async () => {
+      await createConversation('Meeting with Rejoining Host')
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'hosts' }]
+      await adapter.save()
+
+      mockAdapterType.participantJoined.mockReturnValue({
+        username: 'Rejoining Host',
+        dmConfig: { to: 704 },
+        isHost: true
+      })
+
+      await webhookService.participantJoined(adapter, { id: 704, name: 'Rejoining Host', is_host: true, platform: 'test' })
+      await webhookService.participantJoined(adapter, { id: 704, name: 'Rejoining Host', is_host: true, platform: 'test' })
+
+      expect(mockAdapterType.participantJoined).toHaveBeenCalledTimes(2)
+
+      const modifiedAdapter = await Adapter.findById(adapter._id)
+      const moderatorChannel = modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')
+      expect(Object.keys(moderatorChannel!.config!)).toHaveLength(1)
+      expect(moderatorChannel!.config!['Rejoining Host']).toEqual({ to: 704 })
+    })
+
+    it('stores dmConfig on users channel when participant fuzzy matches a moderator name and users is "moderators"', async () => {
+      await createConversation('Meeting with Moderator DMs')
+      conversation.moderators = [{ name: 'Alice Smith' }]
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'moderators' }]
+      await adapter.save()
+
+      mockAdapterType.participantJoined.mockReturnValue({
+        username: 'Alice Smith',
+        dmConfig: { to: 710 },
+        isHost: false
+      })
+
+      await webhookService.participantJoined(adapter, { id: 710, name: 'Alice Smith', is_host: false, platform: 'test' })
+
+      const modifiedAdapter = await Adapter.findById(adapter._id)
+      const moderatorChannel = modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')
+      expect(moderatorChannel!.config!['Alice Smith']).toEqual({ to: 710 })
+    })
+
+    it('stores dmConfig when participant fuzzy matches moderator alternateName and users is "moderators"', async () => {
+      await createConversation('Meeting with Moderator Alternate Name')
+      conversation.moderators = [{ name: 'Alice Smith', alternateName: 'Dr. Alice' }]
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'moderators' }]
+      await adapter.save()
+
+      mockAdapterType.participantJoined.mockReturnValue({
+        username: 'Dr. Alice',
+        dmConfig: { to: 711 },
+        isHost: false
+      })
+
+      await webhookService.participantJoined(adapter, { id: 711, name: 'Dr. Alice', is_host: false, platform: 'test' })
+
+      const modifiedAdapter = await Adapter.findById(adapter._id)
+      const moderatorChannel = modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')
+      expect(moderatorChannel!.config!['Dr. Alice']).toEqual({ to: 711 })
+    })
+
+    it('does not store dmConfig when participant does not match any moderator and users is "moderators"', async () => {
+      await createConversation('Meeting with Moderator Exclusion')
+      conversation.moderators = [{ name: 'Alice Smith' }]
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'moderators' }]
+      await adapter.save()
+
+      mockAdapterType.participantJoined.mockReturnValue({
+        username: 'Carol Williams',
+        dmConfig: { to: 712 },
+        isHost: false
+      })
+
+      await webhookService.participantJoined(adapter, { id: 712, name: 'Carol Williams', is_host: false, platform: 'test' })
+
+      const modifiedAdapter = await Adapter.findById(adapter._id)
+      const moderatorChannel = modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')
+      expect(moderatorChannel!.config?.['Carol Williams']).toBeUndefined()
+    })
+
+    it('falls back to host targeting when users is "moderators" and no moderators are defined', async () => {
+      await createConversation('Meeting with Moderators Fallback to Host')
+      conversation.moderators = []
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'moderators' }]
+      await adapter.save()
+
+      mockAdapterType.participantJoined.mockReturnValue({
+        username: 'Host User',
+        dmConfig: { to: 713 },
+        isHost: true
+      })
+
+      await webhookService.participantJoined(adapter, { id: 713, name: 'Host User', is_host: true, platform: 'test' })
+
+      const modifiedAdapter = await Adapter.findById(adapter._id)
+      const moderatorChannel = modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')
+      expect(moderatorChannel!.config!['Host User']).toEqual({ to: 713 })
+    })
+
+    it('does not store dmConfig for non-host when users is "moderators" and no moderators are defined', async () => {
+      await createConversation('Meeting with Moderators Fallback Non-Host')
+      conversation.moderators = []
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      adapter.dmChannels = [{ name: 'moderator', direction: Direction.OUTGOING, users: 'moderators' }]
+      await adapter.save()
+
+      mockAdapterType.participantJoined.mockReturnValue({
+        username: 'Regular User',
+        dmConfig: { to: 714 },
+        isHost: false
+      })
+
+      await webhookService.participantJoined(adapter, { id: 714, name: 'Regular User', is_host: false, platform: 'test' })
+
+      const modifiedAdapter = await Adapter.findById(adapter._id)
+      const moderatorChannel = modifiedAdapter?.dmChannels?.find((c) => c.name === 'moderator')
+      expect(moderatorChannel!.config?.['Regular User']).toBeUndefined()
+    })
+
+
     it('does not process participantJoined when adapter type returns null', async () => {
       await createConversation('Meeting with Bot Participant')
       conversation.enableDMs = ['agents']


### PR DESCRIPTION
## What is in this PR?

When using EA in Zoom, the moderator report should not be visible to all participants in the group chat. Instead, this PR adds support for sending Zoom DMs to a group of people on a channel (in this case, the moderator channel). In the default EA conversation, the zoom adapter will now fuzzy match Zoom display names to the names of the conversation moderators if provided on event creation, else will fallback to sending the report to all Zoom hosts.

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- feat: send moderator msgs only to hosts or moderators in Zoom (see new section in zoom.md for info on how this works)
support routing msgs on a channel to DM of specified participants
- feat: update Zoom participant username and host status on change event
listen for recall participant_events.update to catch changes in display name and host status


## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [x] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [x] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

(note multi-participant testing in Zoom was already done)
- [x] Introduces 2 new env vars for the summarization model, defaults to Claude Haiku
- [x] Create an EA event with moderator support in Zoom, do not specify any moderators on event creation
- [x] Wait a bit before launching Zoom to ensure Berkie comes in first (this tests the new participant updated support b/c Berkie will be host until you arrive)
- [x] In Zoom DM to Berkie, send some /mod commands
- [x] Ensure the moderator report comes only to you (the host) via DM and not to the group chat
- [x] Create another EA event and name yourself as the Moderator (note this has to be a 70% match with your Zoom display name)
- [x] Launch Zoom immediately
- [x] In Zoom DM to Berkie, send some /mod commands
- [x] Ensure the moderator report comes only to you via DM and not to the group chat
- [x] Change your Zoom display name to something very different (right click on the participant list)
- [x] Send some more /mod commands in DM to Berkie
- [x] Wait 2 minutes (or check server logs to see when mod report prepared). You should NOT receive the mod report at all.




## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
