### PR TITLE
feat: do not send moderator report to Zoom chat in hybrid events

### DIFF
--- a/src/conversations/eventAssistant.ts
+++ b/src/conversations/eventAssistant.ts
@@ -235,6 +235,7 @@ const eventAssistant: ConversationType = {
     { name: 'image-gen' }
   ],
   adapters: {
+    // Fully remote: Zoom only — moderator DMs sent via Zoom
     zoom: {
       type: 'zoom',
       config: {
@@ -253,6 +254,33 @@ const eventAssistant: ConversationType = {
           name: 'moderator',
           direction: Direction.OUTGOING
         },
+        {
+          name: 'chat',
+          direction: Direction.BOTH
+        }
+      ],
+      audioChannels: [
+        {
+          name: 'transcript',
+          direction: Direction.INCOMING
+        }
+      ]
+    },
+    // Hybrid: Zoom + NextSpace — moderator DMs handled by NextSpace, not Zoom
+    'nextspace,zoom': {
+      type: 'zoom',
+      config: {
+        meetingUrl: '{{{properties.zoomMeetingUrl}}}',
+        botName: '{{properties.botName}}'
+      },
+      dmChannels: [
+        {
+          direct: true,
+          agent: 'eventAssistant',
+          direction: Direction.BOTH
+        }
+      ],
+      chatChannels: [
         {
           name: 'chat',
           direction: Direction.BOTH

--- a/src/conversations/resolver.ts
+++ b/src/conversations/resolver.ts
@@ -232,10 +232,14 @@ export default function resolveConversationType(
   for (const { name, config, enabled } of features) if (enabled) workingProperties[name] = config ?? true
 
   const adapterDefs = conversationType.adapters || {}
-  const matched = (platforms || []).map((p) => adapterDefs[p]).filter(Boolean)
+  const sortedKey = (platforms || []).slice().sort().join(',')
+  const exactMatch = adapterDefs[sortedKey]
+  const perPlatform = (platforms || []).map((p) => adapterDefs[p]).filter(Boolean)
   let adapters: unknown[] = []
-  if (matched.length > 0) {
-    adapters = matched.map((a) => resolvePropertyReferences(a, workingProperties))
+  if (exactMatch) {
+    adapters = [resolvePropertyReferences(exactMatch, workingProperties)]
+  } else if (perPlatform.length > 0) {
+    adapters = perPlatform.map((a) => resolvePropertyReferences(a, workingProperties))
   } else if (adapterDefs.default) {
     adapters = [resolvePropertyReferences(adapterDefs.default, workingProperties)]
   }

--- a/tests/conversations/resolver.test.ts
+++ b/tests/conversations/resolver.test.ts
@@ -296,6 +296,51 @@ describe('resolveConversationType', () => {
       const result = resolveConversationType({ platforms: ['web'] }, type)
       expect(result.adapters).toHaveLength(0)
     })
+
+    test('matches composite platform key over individual keys', () => {
+      const type: ConversationType = {
+        ...baseType,
+        properties: [],
+        adapters: {
+          zoom: { type: 'zoom', config: { variant: 'zoom-only' } },
+          'nextspace,zoom': { type: 'zoom', config: { variant: 'hybrid' } },
+          default: { type: 'web' }
+        }
+      }
+      const result = resolveConversationType({ platforms: ['zoom', 'nextspace'] }, type)
+      expect(result.adapters).toHaveLength(1)
+      expect(result.adapters[0]).toMatchObject({ config: { variant: 'hybrid' } })
+    })
+
+    test('composite key matches regardless of platform order', () => {
+      const type: ConversationType = {
+        ...baseType,
+        properties: [],
+        adapters: {
+          'nextspace,zoom': { type: 'zoom', config: { variant: 'hybrid' } },
+          default: { type: 'web' }
+        }
+      }
+      const result = resolveConversationType({ platforms: ['nextspace', 'zoom'] }, type)
+      expect(result.adapters).toHaveLength(1)
+      expect(result.adapters[0]).toMatchObject({ config: { variant: 'hybrid' } })
+    })
+
+    test('falls back to per-platform adapters when no composite key matches', () => {
+      const type: ConversationType = {
+        ...baseType,
+        properties: [],
+        adapters: {
+          zoom: { type: 'zoom' },
+          'nextspace,zoom': { type: 'zoom', config: { variant: 'hybrid' } }
+        }
+      }
+      // Only zoom platform — matches single 'zoom' key, not composite
+      const result = resolveConversationType({ platforms: ['zoom'] }, type)
+      expect(result.adapters).toHaveLength(1)
+      expect(result.adapters[0]).toMatchObject({ type: 'zoom' })
+      expect((result.adapters[0] as { config?: { variant?: string } }).config?.variant).toBeUndefined()
+    })
   })
 
   describe('passthrough fields', () => {


### PR DESCRIPTION


## What is in this PR?

hybrid events may involve projection of zoom mtg where sensitive reports could be viewed, use NS mod view only

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- Updates parsing conversation types to allow specific adapter configurations based on platforms chosen

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x] Create an EA conversation in Zoom only
- [x] Launch Zoom and DM /mod messages to Berkie
- [x] Ensure moderator report is sent to the group chat within 2-ish minutes
- [x] Create another EA conversation, selecting both NextSpace and Zoom
- [x] Launch Zoom and DM /mod messages to Berkie
- [x] Ensure moderator report is NOT sent to the group chat within 2-ish minutes
- [x] Ensure moderator messages are visible in NextSpace mod view
- [x]  Create an EA conversation in NextSpace only
- [x] Launch Zoom
- [x] Use NS participant view to send /mod messages
- [x] Ensure moderator report is NOT sent to the group chat within 2-ish minutes
- [x] Ensure moderator messages are visible in NextSpace mod view

## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
