### PR TITLE
refactor: extract channel and property name constants

### DIFF
--- a/src/conversations/eventAssistant.ts
+++ b/src/conversations/eventAssistant.ts
@@ -5,6 +5,12 @@ import config from '../config/config.js'
 
 export const ZOOM_MEETING_URL_PROPERTY = 'zoomMeetingUrl' as const
 
+export const TRANSCRIPT_CHANNEL = 'transcript' as const
+export const PARTICIPANT_CHANNEL = 'participant' as const
+export const MODERATOR_CHANNEL = 'moderator' as const
+export const CHAT_CHANNEL = 'chat' as const
+export const IMAGE_GEN_CHANNEL = 'image-gen' as const
+
 const eventAssistant: ConversationType = {
   // user-facing
   name: 'eventAssistant',
@@ -230,11 +236,11 @@ const eventAssistant: ConversationType = {
   ],
   enableDMs: ['agents'],
   channels: [
-    { name: 'transcript' },
-    { name: 'participant' },
-    { name: 'moderator' },
-    { name: 'chat' },
-    { name: 'image-gen' }
+    { name: TRANSCRIPT_CHANNEL },
+    { name: PARTICIPANT_CHANNEL },
+    { name: MODERATOR_CHANNEL },
+    { name: CHAT_CHANNEL },
+    { name: IMAGE_GEN_CHANNEL }
   ],
   adapters: {
     // Fully remote: Zoom only — moderator DMs sent via Zoom
@@ -258,13 +264,13 @@ const eventAssistant: ConversationType = {
       ],
       chatChannels: [
         {
-          name: 'chat',
+          name: CHAT_CHANNEL,
           direction: Direction.BOTH
         }
       ],
       audioChannels: [
         {
-          name: 'transcript',
+          name: TRANSCRIPT_CHANNEL,
           direction: Direction.INCOMING
         }
       ]
@@ -305,7 +311,7 @@ const eventAssistant: ConversationType = {
       },
       audioChannels: [
         {
-          name: 'transcript',
+          name: TRANSCRIPT_CHANNEL,
           direction: Direction.INCOMING
         }
       ]

--- a/src/conversations/eventAssistant.ts
+++ b/src/conversations/eventAssistant.ts
@@ -3,6 +3,8 @@ import adapterTypes from '../adapters/config.js'
 import { ConversationType, Direction } from '../types/index.types.js'
 import config from '../config/config.js'
 
+export const ZOOM_MEETING_URL_PROPERTY = 'zoomMeetingUrl' as const
+
 const eventAssistant: ConversationType = {
   // user-facing
   name: 'eventAssistant',
@@ -11,7 +13,7 @@ const eventAssistant: ConversationType = {
   platforms: adapterTypes,
   properties: [
     {
-      name: 'zoomMeetingUrl',
+      name: ZOOM_MEETING_URL_PROPERTY,
       label: 'Zoom Meeting URL',
       description: 'The zoom meeting link for transcription purposes',
       required: true,

--- a/src/conversations/eventSetup.ts
+++ b/src/conversations/eventSetup.ts
@@ -2,6 +2,8 @@ import { supportedModels } from '../agents/helpers/getModelChat.js'
 import { ConversationType, Direction } from '../types/index.types.js'
 import config from '../config/config.js'
 
+export const SETUP_CHANNEL_NAME = 'setup' as const
+
 const eventSetup: ConversationType = {
   name: 'eventSetup',
   label: 'Event Setup',
@@ -63,7 +65,7 @@ const eventSetup: ConversationType = {
       ]
     }
   ],
-  channels: [{ name: 'setup' }],
+  channels: [{ name: SETUP_CHANNEL_NAME }],
   adapters: {
     slack: {
       type: 'slack',
@@ -76,7 +78,7 @@ const eventSetup: ConversationType = {
       },
       chatChannels: [
         {
-          name: 'setup',
+          name: SETUP_CHANNEL_NAME,
           direction: Direction.BOTH
         }
       ]


### PR DESCRIPTION
## What is in this PR?

Replaces a handful of magic strings (channel names like `'transcript'` and `'moderator'`, plus the `'zoomMeetingUrl'` property name) with named constants in `src/conversations/eventAssistant.ts` and `src/conversations/eventSetup.ts`. If we rename one of these later, the change happens in one place instead of needing a grep-and-replace.

No behavior change.

## Changes in the codebase

- New `ZOOM_MEETING_URL_PROPERTY` constant; the `zoomMeetingUrl` property in `eventAssistant.ts` now references it.
- New `SETUP_CHANNEL_NAME` constant in `eventSetup.ts`.
- New channel-name constants in `eventAssistant.ts`: `TRANSCRIPT_CHANNEL`, `PARTICIPANT_CHANNEL`, `MODERATOR_CHANNEL`, `CHAT_CHANNEL`, `IMAGE_GEN_CHANNEL`.
- Scope is intentionally narrow: only the literals inside the same file are swapped over. Plenty of other call sites (`backChannel.ts`, various agents) still use string literals; that's a bigger sweep for another day.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages? No behavior change.
- [ ] document your changes as comments in the code? Use TSDoc format where appropriate. N/A.
- [ ] update the README and docs to be clear and easy to use for end users and developers? N/A.
- [ ] add and/or update automated tests? Pure refactor; existing tests cover behavior.
- [ ] update team documentation of any new or changed environment variables? None changed.

## Testing this PR

- [ ] `yarn test` stays green

## Additional information

Salvaged from #125 (closed). Companion to #139, which picks up the Block Kit plumbing.
