### PR TITLE
feat: hand Slack event setup off to a Nextspace form via signed link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,9 @@ JWT_ACCESS_EXPIRATION_MINUTES=30
 # Number of days after which a refresh token expires
 JWT_REFRESH_EXPIRATION_DAYS=30
 JWT_RESET_PASSWORD_EXPIRATION_MINUTES=120
+# Minutes a Slack-to-Nextspace event-setup handoff token stays valid.
+# Short by design: the token is meant to be clicked from Slack within an hour.
+# HANDOFF_TOKEN_EXPIRATION_MINUTES=60
 
 # SMTP configuration options for the email service
 # For testing, you can use a fake SMTP service like Ethereal: https://ethereal.email/create
@@ -69,7 +72,9 @@ SMTP_USERNAME=email-server-username
 SMTP_PASSWORD=email-server-password
 EMAIL_FROM=support@yourapp.com
 
-# This is used to build links for the reset password and channel archive emails
+# Public URL of the Nextspace frontend. Used to build links for password
+# reset emails, channel archive emails, and the Slack event-setup handoff
+# link the bot posts when an organizer asks to create an event.
 APP_HOST=http://localhost:3000
 
 #

--- a/docs/pages/platforms/slack.md
+++ b/docs/pages/platforms/slack.md
@@ -71,6 +71,136 @@ Example conversation body:
 
 6. Post a message to the Slack Channel. Any agents configured on the `Conversation` should receive and send messages on their typical channels.
 
+### Event Setup bot (Slack → Nextspace handoff)
+
+The `eventSetup` agent lets an organizer kick off a new Nextspace event from Slack. When the organizer mentions the bot or posts a setup-intent message (e.g. "create an event") in a designated Slack channel, the bot replies with a link to the Nextspace event-creation form. The link carries a signed handoff token (JWT) so the form knows which Slack user, team, channel, and thread the request came from. The form lives in Nextspace; this server only mints and verifies the token and runs the planner endpoint the form calls.
+
+A note on channel naming, because there are two different things both called "channel":
+
+- The **Slack channel** is the actual channel in your Slack workspace where organizers post setup requests. You can name your channel anything.
+- The **Nextspace channel role** is an internal label this codebase uses to describe what a channel is for. The `eventSetup` agent listens on a role literally named `setup`. Other agents listen on roles like `transcript` or `chat`. Operators do not need to rename these roles. They are part of the agent's contract, the same way every other agent in the codebase declares the role it serves.
+
+The Slack adapter bridges the two. In the Conversation you create below, `adapters[0].config.channel` says which Slack channel ID you want, and `adapters[0].chatChannels` maps that Slack channel into the `setup` role the agent listens on. So renaming your Slack channel never requires a code change, only an update to the Conversation config.
+
+#### Environment variables
+
+These are all that's needed for the event setup bot. No separate URL templates, calendar deeplink, or display timezone settings are needed. Those concerns moved to the Nextspace frontend.
+
+| Variable                           | Required        | Purpose                                                                                                                                                   |
+| ---------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `APP_HOST`                         | yes             | Public URL of the Nextspace frontend. The bot builds the handoff link as `${APP_HOST}/events/new?token=...`.                                              |
+| `JWT_SECRET`                       | yes             | Signs and verifies the handoff token. Must match between the Slack bot's process and any process that verifies the token (this same llm_engine instance). |
+| `HANDOFF_TOKEN_EXPIRATION_MINUTES` | no (default 60) | How long the link stays valid after the bot posts it. Short window is intentional.                                                                        |
+| `SLACK_SIGNING_SECRET`             | yes             | Verifies inbound Slack webhooks (general Slack requirement, not event-setup specific).                                                                    |
+| `SYSTEM_USERS`                     | recommended     | Include `event-setup-bot:serviceAccount` so the bot has an account to act under. See [Installing](../installing/index.md).                                |
+
+#### Slack-side setup
+
+**Prerequisite:** complete the *One Time Setup - Create the app in Slack* section at the top of this document first. That section walks through creating the LLM Engine Slack app, requesting bot scopes, installing the app into your workspace, configuring event subscriptions, and setting `SLACK_SIGNING_SECRET`. The steps below assume the app already exists in your workspace and is reachable from your LLM Engine server.
+
+The event setup bot has no additional Slack permissions beyond `chat:write` and the channel scopes already listed in the prerequisite section.
+
+To trigger the bot in a workspace:
+
+1. **Pick or create a Slack channel.** Name it whatever fits your team. This is the channel organizers will post in when they want to create an event.
+2. **Invite the LLM Engine app to that channel** so it can read messages and post replies. In Slack: open the channel, click the channel name to open settings, go to the *Integrations* tab, click *Add apps*, and select your LLM Engine app.
+3. **Look up the Slack identifiers you'll need for the Conversation config:**
+   - **Slack channel ID.** Open the channel in Slack, click the channel name, scroll to the bottom of the *About* panel. The ID looks like `C` followed by alphanumeric characters.
+   - **Slack workspace (team) ID.** Open the workspace in Slack on the web. The URL contains the workspace ID, which looks like `T` followed by alphanumeric characters.
+   - **Bot User OAuth Token.** In your Slack app configuration at api.slack.com, go to *OAuth & Permissions* and copy the *Bot* token (not the User token). It starts with `xoxb-`.
+4. **Create a Conversation** by POSTing to the admin API with the body below. Replace the four `<PLACEHOLDER>` values with the identifiers from step 3, your topic ID, and the name you want the bot to display in Slack.
+
+   ```json
+   {
+     "name": "Event Setup",
+     "topicId": "<NEXTSPACE_TOPIC_ID>",
+     "channels": [{ "name": "setup" }],
+     "agentTypes": ["eventSetup"],
+     "adapters": [
+       {
+         "type": "slack",
+         "config": {
+           "channel": "<SLACK_CHANNEL_ID>",
+           "workspace": "<SLACK_WORKSPACE_ID>",
+           "botToken": "<SLACK_BOT_TOKEN>",
+           "botName": "<BOT_DISPLAY_NAME>"
+         },
+         "chatChannels": [{ "name": "setup", "direction": "both" }]
+       }
+     ]
+   }
+   ```
+
+   `channels[0].name` and `chatChannels[0].name` both stay as `"setup"`. That value is the Nextspace channel role the agent listens on, not a Slack channel name. The Slack-side name is whatever you picked in step 1, and you reference it by ID in `adapters[0].config.channel`.
+
+5. **Post a setup request** in the Slack channel from step 1. Either mention the bot (e.g. `@<BOT_DISPLAY_NAME> create an event`) or use a setup-intent phrase like `create an event next Thursday`. The bot replies with the handoff link.
+
+##### One Slack app per LLM Engine server
+
+Before configuring multiple agents, know this constraint up front: a single LLM Engine server is bound to exactly one Slack app. The server verifies every inbound Slack webhook against the single `SLACK_SIGNING_SECRET` env var (see `src/handlers/slack.ts`), so webhooks from any other Slack app would fail signature verification and never reach an agent. There is no per-agent or per-Conversation signing secret.
+
+That single Slack app can host many Conversations across many Slack channels and workspaces. What it cannot do is appear as more than one bot identity in Slack. Every outbound post from this server uses the installed app's bot user, with the display name and avatar configured at install time on api.slack.com. The adapter does not override `username` or `icon_url` per message (see `src/adapters/slack/index.ts`).
+
+If you need agents to appear as visually distinct Slack users (e.g. Berkie posting as "Berkie" and Mason posting as "Mason"), you need a separate Slack app and a separate LLM Engine instance, each with its own signing secret and installed identity.
+
+##### Sharing a Slack channel between multiple agents
+
+A single Conversation can host more than one agent on the same channel binding. To put the event setup bot and another Nextspace agent (e.g. a moderator persona) into the same Slack channel, add both agent type names to the `agentTypes` array on the Conversation. They both attach to the `setup`-role channel binding declared in `chatChannels`.
+
+Each agent evaluates incoming messages independently against its own triggers, so the two do not interfere with each other. If only one agent's triggers match a given message (e.g. only the event-setup intent pattern fires on `create an event next Thursday`), only that agent responds. If both match, each gets a chance to respond.
+
+Because of the one-app-per-server constraint above, both agents appear in Slack under the same bot identity. The `agentConfig.botName` value on each agent definition is used for in-prompt addressing and trace metadata. It does not change what Slack displays.
+
+##### How users address individual agents in a shared channel
+
+Since every agent in the channel posts under the same Slack bot identity, the user cannot pick one out with a real Slack `@`-mention. Each agent resolves itself by inspecting the message body inside its own `evaluate()` function. The rules each agent applies fall into the categories below:
+
+1. **Typed name in the message text.** The user types the agent's name as plain text: `Berkie, set up an event` or `@Mason can you summarize`. Each agent's `evaluate()` looks for its own `agentConfig.botName` in the body, independently of the others. Two matching styles exist in the codebase:
+   - **Fuzzy** match via `matchBotMention()` in [src/agents/helpers/intentChecks.ts](src/agents/helpers/intentChecks.ts). It uses fuzzball with a 70% ratio threshold, so small typos like `Berki` or `Berkey` still resolve. Used by chatbot and eventHistorian.
+   - **Substring** match. The simplest form, used by `eventSetup`: `body.toLowerCase().includes('@' + botName.toLowerCase())` (see [src/agents/eventSetup/eventSetup.ts](src/agents/eventSetup/eventSetup.ts)).
+2. **Real Slack `@app` mention.** Slack's built-in mention (with the blue highlight) refers to the one bot user the app owns. The adapter rewrites that mention into the in-text token `@<botName>`, where `<botName>` is whatever is configured in `adapters[0].config.botName` (not the per-agent `agentConfig.botName`). So a Slack-level mention resolves to exactly one name. If that name matches an agent's `agentConfig.botName`, that agent fires; otherwise the message falls through to intent matching.
+3. **Intent keywords.** If the user names no agent at all, each agent falls back to whatever intent pattern its `evaluate()` declares. For event setup, this is the regex set in `SETUP_INTENT_PATTERNS` (matches `setup`, `create an event`, etc.). For other agents it might be different keywords or an LLM intent check.
+
+Worked examples for a Berkie + Mason channel:
+
+| User types | Berkie matches | Mason matches | Who responds |
+| --- | --- | --- | --- |
+| `Berkie, set up an event` | yes (typed name) | no | Berkie |
+| `Mason, summarize the discussion` | no | yes (typed name) | Mason |
+| `create an event next Thursday` | yes (intent keyword) | no | Berkie |
+| `@<adapter botName> hello` | depends on whether the adapter botName matches their `agentConfig.botName` | same | whoever matches |
+
+If you put two agents on one channel, their `evaluate()` functions have to be written so they don't both fire on the same message. The reliable way to keep them apart is to require a name match in the body before responding, and to make sure their intent keywords don't overlap. When both agents fire on the same input, both respond, which gets confusing fast for the user.
+
+#### Deploying to production
+
+When merging this change to production, do these in order:
+
+1. **Set `APP_HOST`** to the production Nextspace URL (e.g. `https://nextspace.example.org`). Without this the bot will post `localhost` links.
+2. **Confirm `JWT_SECRET` is set** in the production environment and is not the placeholder from `.env.example`. The handoff token is signed with this secret; a weak or default secret means anyone can forge a handoff.
+3. **(Optional) Set `HANDOFF_TOKEN_EXPIRATION_MINUTES`** if the default 60 minutes doesn't fit your workflow.
+4. **Restart the llm_engine service** so the new config is loaded.
+5. **Smoke test** by posting a setup request in the Slack channel the production Conversation is wired to, and confirming the bot replies with a link pointing at the production `APP_HOST`. Clicking the link should land on the Nextspace event-creation form. That part requires the matching Nextspace deploy with the frontend handler; track that separately.
+6. **Verify token rejection paths** by hand-crafting a request to `POST /v1/event-setup/plan` without a token and with a tampered token. Both should return 401.
+
+#### Local development
+
+1. Copy `.env.example` to `.env` and set `APP_HOST=http://localhost:3000`, `JWT_SECRET=<anything>`, `SLACK_SIGNING_SECRET=<your dev app secret>`.
+2. Run `yarn dev` (or your usual local script).
+3. Expose the local server with ngrok or similar, point your Slack dev app's Event Subscriptions URL at it.
+4. Create a dev Conversation following the steps above, pointing at a Slack channel in your dev workspace.
+5. Post a setup request in that Slack channel. The bot will reply with a `localhost:3000` link.
+6. Hit the planner endpoint directly with curl to iterate on the LLM prompt without the frontend:
+
+```bash
+curl -X POST http://localhost:3000/v1/event-setup/plan \
+  -H "X-Handoff-Token: <token from the bot's URL>" \
+  -H "Content-Type: application/json" \
+  -d '{"description":"AI ethics roundtable next Thursday at 3pm ET, online via Zoom"}'
+```
+
+### Direct messages
+
 If you wish to support DMs between users and agents, you must configure a separate Conversation for all DMs. **You can only have one such Conversation active at a time.** Private communication between a user and the Slack app happens on a dedicated channel (different for each user). Therefore, you must use the keyword 'direct' for channel name, to signal that the conversation should process all direct messages.
 
 Example conversation body:

--- a/docs/pages/platforms/slack.md
+++ b/docs/pages/platforms/slack.md
@@ -88,7 +88,7 @@ These are all that's needed for the event setup bot. No separate URL templates, 
 
 | Variable                           | Required        | Purpose                                                                                                                                                   |
 | ---------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `APP_HOST`                         | yes             | Public URL of the Nextspace frontend. The bot builds the handoff link as `${APP_HOST}/events/new?token=...`.                                              |
+| `APP_HOST`                         | yes             | Public URL of the Nextspace frontend. The bot builds the handoff link as `${APP_HOST}/events/new#token=...`. The token is placed in the URL fragment (after `#`) so browsers never send it to the Nextspace server, keeping it out of server access logs and Referer headers. |
 | `JWT_SECRET`                       | yes             | Signs and verifies the handoff token. Must match between the Slack bot's process and any process that verifies the token (this same llm_engine instance). |
 | `HANDOFF_TOKEN_EXPIRATION_MINUTES` | no (default 60) | How long the link stays valid after the bot posts it. Short window is intentional.                                                                        |
 | `SLACK_SIGNING_SECRET`             | yes             | Verifies inbound Slack webhooks (general Slack requirement, not event-setup specific).                                                                    |
@@ -190,11 +190,11 @@ When merging this change to production, do these in order:
 3. Expose the local server with ngrok or similar, point your Slack dev app's Event Subscriptions URL at it.
 4. Create a dev Conversation following the steps above, pointing at a Slack channel in your dev workspace.
 5. Post a setup request in that Slack channel. The bot will reply with a `localhost:3000` link.
-6. Hit the planner endpoint directly with curl to iterate on the LLM prompt without the frontend:
+6. Hit the planner endpoint directly with curl to iterate on the LLM prompt without the frontend. The token is the part of the bot's URL after `#token=`:
 
 ```bash
 curl -X POST http://localhost:3000/v1/event-setup/plan \
-  -H "X-Handoff-Token: <token from the bot's URL>" \
+  -H "X-Handoff-Token: <token from the # fragment of the bot's URL>" \
   -H "Content-Type: application/json" \
   -d '{"description":"AI ethics roundtable next Thursday at 3pm ET, online via Zoom"}'
 ```

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -21,7 +21,9 @@ async function findThreadParent(conversationId, threadTs) {
 async function receiveGroupChatMessage(event) {
   const msg: AdapterMessage<string> = {
     message: normalizeBotMention(event.text, this.config.botUserId, this.config.botName),
-    source: { type: 'slack', id: event.ts },
+    /* Store Slack identity in source so it survives DB persistence.
+       The user field is only used for auth lookup and is not saved. */
+    source: { type: 'slack', id: event.ts, userId: event.user, teamId: event.team, channelId: event.channel },
     channels: this.chatChannels,
     user: { username: `${event.team}-${event.user}`, pseudonym: event.user }
   }

--- a/src/agents/eventSetup/eventSetup.ts
+++ b/src/agents/eventSetup/eventSetup.ts
@@ -48,7 +48,12 @@ export default verify({
 
   async respond(_conversationHistory: ConversationHistory, userMessage) {
     const setupChannel = this.conversation.channels.find((channel) => channel.name === 'setup')
-    const parentMessageId = userMessage.parentMessage
+    /* If the organizer's message is already a reply in an existing thread,
+       keep our response in that same thread. Otherwise use the organizer's
+       own message as the parent so the Slack adapter starts a new thread
+       under it; without this our reply would land in the main channel
+       instead of threading under what the user typed. */
+    const parentMessageId = userMessage.parentMessage || userMessage._id
 
     /* The handoff token has to carry enough Slack context that the form
        can post back into the right thread later. The Slack adapter packs

--- a/src/agents/eventSetup/eventSetup.ts
+++ b/src/agents/eventSetup/eventSetup.ts
@@ -109,16 +109,21 @@ export default verify({
        different adapter — and signing a token with empty Slack fields
        would just produce a broken link. In that case we drop the token
        and fall back to the bare URL. */
-    const username = userMessage.user?.username ?? ''
-    const dashIndex = username.indexOf('-')
-    const slackChannelId = userMessage.channels?.[0]?.name ?? ''
-    const slackThreadTs = userMessage.source?.id ?? ''
+    /* Read Slack identity from source — that's the only field that survives
+       DB round-trip. The adapter stores userId/teamId/channelId there so they
+       are available here even after the message is persisted and reloaded. */
+    const slackUserId = (userMessage.source?.userId as string) ?? ''
+    const slackTeamId = (userMessage.source?.teamId as string) ?? ''
+    const slackChannelId = (userMessage.source?.channelId as string) ?? ''
+    const slackThreadTs = (userMessage.source?.id as string) ?? ''
     const hasFullSlackContext =
-      userMessage.source?.type === 'slack' && dashIndex > 0 && slackChannelId !== '' && slackThreadTs !== ''
+      userMessage.source?.type === 'slack' &&
+      slackUserId !== '' &&
+      slackTeamId !== '' &&
+      slackChannelId !== '' &&
+      slackThreadTs !== ''
 
     if (hasFullSlackContext) {
-      const slackTeamId = username.slice(0, dashIndex)
-      const slackUserId = username.slice(dashIndex + 1)
       const token = mintHandoffToken({ slackUserId, slackTeamId, slackChannelId, slackThreadTs })
       /* The token goes in the URL fragment (after #) rather than the query
          string (after ?). Browsers never send fragments to the server, so

--- a/src/agents/eventSetup/eventSetup.ts
+++ b/src/agents/eventSetup/eventSetup.ts
@@ -1,10 +1,47 @@
 import verify from '../helpers/verify.js'
 import { AgentMessageActions, ConversationHistory } from '../../types/index.types.js'
-import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
+import { defaultLLMModel, defaultLLMPlatform, getModelChat } from '../helpers/getModelChat.js'
 import { mintHandoffToken } from '../../services/handoffToken.service.js'
+import { checkEventSetupIntent } from './intentCheck.js'
 import config from '../../config/config.js'
 
-const SETUP_INTENT_PATTERNS = [/\bsetup\b/i, /\bcreate event\b/i, /\bcreate an? event\b/i, /\bnew event\b/i]
+/*
+ * Builds the Slack Block Kit payload for the event setup reply.
+ *
+ * Exported as a pure function so it can be unit-tested without needing to
+ * invoke the full respond() pipeline (which requires a live LLM for the
+ * intent check). Called from respond() when full Slack context is available.
+ *
+ * The url is expected to contain the handoff token in the URL fragment
+ * (e.g. /events/new#token=...) — see respond() for why fragment over query
+ * string.
+ */
+export function buildEventSetupBlocks(slackUserId: string, url: string): object[] {
+  return [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        /* <@USER_ID> is Slack's mrkdwn syntax for a user mention — Slack
+           renders it as the person's display name with a highlight. */
+        text: `Hey <@${slackUserId}>! I can help with that in Nextspace. Click the button below and we can get your event set up.`
+      }
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: "Let's Go", emoji: false },
+          url,
+          /* action_id lets the slackInteraction handler route button-click
+             events back to this agent if we need to handle them later. */
+          action_id: 'open_event_setup_form'
+        }
+      ]
+    }
+  ]
+}
 
 export default verify({
   name: 'Event Setup',
@@ -24,29 +61,35 @@ export default verify({
   ragCollectionName: undefined,
   defaultConversationHistorySettings: { count: 50, channels: ['setup'] },
 
+  /* Channel-level filtering happens upstream in AgentEvaluationService
+     (only messages on the 'setup' channel reach this agent), so we mark
+     every message in that channel as a contribution and defer the actual
+     "should the bot respond?" decision to checkEventSetupIntent inside
+     respond(). This matches the pattern used by chatbot and
+     eventHistorian. */
   async evaluate(userMessage) {
-    const body = userMessage?.body ?? ''
-    const hasBotMention = body.toLowerCase().includes(`@${this.agentConfig.botName}`.toLowerCase())
-    const hasSetupIntent = SETUP_INTENT_PATTERNS.some((pattern) => pattern.test(body))
-
-    if (hasBotMention || hasSetupIntent) {
-      return {
-        userMessage,
-        action: AgentMessageActions.CONTRIBUTE,
-        userContributionVisible: true,
-        suggestion: undefined
-      }
-    }
-
     return {
       userMessage,
-      action: AgentMessageActions.OK,
+      action: AgentMessageActions.CONTRIBUTE,
       userContributionVisible: true,
       suggestion: undefined
     }
   },
 
-  async respond(_conversationHistory: ConversationHistory, userMessage) {
+  async respond(
+    _conversationHistory: ConversationHistory,
+    userMessage,
+    /* Optional seam for testing: pass a stub to skip the LLM call.
+       Production code omits this argument and gets the real intent check. */
+    _checkIntent: (llm: unknown, botName: string, msg: unknown) => Promise<boolean> = checkEventSetupIntent
+  ) {
+    /* Ask the LLM whether the user's message is actually a request to
+       set up an event. If not (casual chatter, off-topic, generic
+       greetings), bail out without posting the link. */
+    const llm = await getModelChat(config.classificationLLMPlatform, config.classificationLLMModel)
+    const isSetupIntent = await _checkIntent(llm, this.agentConfig.botName, userMessage)
+    if (!isSetupIntent) return []
+
     const setupChannel = this.conversation.channels.find((channel) => channel.name === 'setup')
     /* If the organizer's message is already a reply in an existing thread,
        keep our response in that same thread. Otherwise use the organizer's
@@ -65,7 +108,7 @@ export default verify({
        Slack — most likely a test message routed through this agent by a
        different adapter — and signing a token with empty Slack fields
        would just produce a broken link. In that case we drop the token
-       and send the bare URL instead. */
+       and fall back to the bare URL. */
     const username = userMessage.user?.username ?? ''
     const dashIndex = username.indexOf('-')
     const slackChannelId = userMessage.channels?.[0]?.name ?? ''
@@ -73,32 +116,42 @@ export default verify({
     const hasFullSlackContext =
       userMessage.source?.type === 'slack' && dashIndex > 0 && slackChannelId !== '' && slackThreadTs !== ''
 
-    let message: string
     if (hasFullSlackContext) {
       const slackTeamId = username.slice(0, dashIndex)
       const slackUserId = username.slice(dashIndex + 1)
       const token = mintHandoffToken({ slackUserId, slackTeamId, slackChannelId, slackThreadTs })
-      /* The token is placed in the URL fragment (after #) rather than the
-         query string (after ?) on purpose. Browsers do not send URL
-         fragments to servers, so the Nextspace server never sees the
-         token in its access logs and the token cannot leak via Referer
-         headers on third-party resources the form page might load. The
-         frontend reads the token from window.location.hash on the client
-         side. */
+      /* The token goes in the URL fragment (after #) rather than the query
+         string (after ?). Browsers never send fragments to the server, so
+         the Nextspace server never sees the token in its access logs and the
+         token can't leak via the Referer header. The frontend reads it from
+         window.location.hash on the client side. */
       const url = `${config.appHost}/events/new#token=${encodeURIComponent(token)}`
-      message = `Let's set up your event! Open the form here: ${url}`
-    } else {
-      /* Reached when Slack context is missing or partial — see the guard
-         above. The organizer still gets a working link to the event form,
-         they just have to authenticate themselves on the Nextspace side
-         instead of arriving pre-identified from Slack. */
-      message = `Let's set up your event! Open Nextspace to continue: ${config.appHost}/events/new`
+      /* The blocks array is the interactive Block Kit UI (section + button).
+         The message field is plain-text fallback for push notifications and
+         screen readers; Slack requires it whenever blocks are present.
+         We use the base URL without the token here so the token doesn't end
+         up in push notifications, the DB transcript, or Slack's message
+         history. The token only needs to live in the button URL. */
+      return [
+        {
+          visible: true,
+          message: `Let's set up your event! Open Nextspace: ${config.appHost}/events/new`,
+          messageType: 'text',
+          channels: setupChannel ? [setupChannel] : [],
+          parent: parentMessageId,
+          blocks: buildEventSetupBlocks(slackUserId, url)
+        }
+      ]
     }
 
+    /* Reached when Slack context is missing or partial — see the guard above.
+       The organizer still gets a link to the event form; they just have to
+       authenticate on the Nextspace side instead of arriving pre-identified
+       from Slack. No Block Kit blocks here since we're not on Slack. */
     return [
       {
         visible: true,
-        message,
+        message: `Let's set up your event! Open Nextspace to continue: ${config.appHost}/events/new`,
         messageType: 'text',
         channels: setupChannel ? [setupChannel] : [],
         parent: parentMessageId

--- a/src/agents/eventSetup/eventSetup.ts
+++ b/src/agents/eventSetup/eventSetup.ts
@@ -1,6 +1,8 @@
 import verify from '../helpers/verify.js'
 import { AgentMessageActions, ConversationHistory } from '../../types/index.types.js'
 import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
+import { mintHandoffToken } from '../../services/handoffToken.service.js'
+import config from '../../config/config.js'
 
 const SETUP_INTENT_PATTERNS = [/\bsetup\b/i, /\bcreate event\b/i, /\bcreate an? event\b/i, /\bnew event\b/i]
 
@@ -48,10 +50,43 @@ export default verify({
     const setupChannel = this.conversation.channels.find((channel) => channel.name === 'setup')
     const parentMessageId = userMessage.parentMessage
 
+    /* The handoff token has to carry enough Slack context that the form
+       can post back into the right thread later. The Slack adapter packs
+       that context across the userMessage like this:
+         user.username  = `${teamId}-${userId}`  (no dashes in either ID)
+         channels[0].name = Slack channel ID
+         source.id      = timestamp of the originating message (the thread)
+       If any of those are missing we are not actually being invoked from
+       Slack — most likely a test message routed through this agent by a
+       different adapter — and signing a token with empty Slack fields
+       would just produce a broken link. In that case we drop the token
+       and send the bare URL instead. */
+    const username = userMessage.user?.username ?? ''
+    const dashIndex = username.indexOf('-')
+    const slackChannelId = userMessage.channels?.[0]?.name ?? ''
+    const slackThreadTs = userMessage.source?.id ?? ''
+    const hasFullSlackContext =
+      userMessage.source?.type === 'slack' && dashIndex > 0 && slackChannelId !== '' && slackThreadTs !== ''
+
+    let message: string
+    if (hasFullSlackContext) {
+      const slackTeamId = username.slice(0, dashIndex)
+      const slackUserId = username.slice(dashIndex + 1)
+      const token = mintHandoffToken({ slackUserId, slackTeamId, slackChannelId, slackThreadTs })
+      const url = `${config.appHost}/events/new?token=${encodeURIComponent(token)}`
+      message = `Let's set up your event! Open the form here: ${url}`
+    } else {
+      /* Reached when Slack context is missing or partial — see the guard
+         above. The organizer still gets a working link to the event form,
+         they just have to authenticate themselves on the Nextspace side
+         instead of arriving pre-identified from Slack. */
+      message = `Let's set up your event! Open Nextspace to continue: ${config.appHost}/events/new`
+    }
+
     return [
       {
         visible: true,
-        message: 'Event setup coming soon',
+        message,
         messageType: 'text',
         channels: setupChannel ? [setupChannel] : [],
         parent: parentMessageId

--- a/src/agents/eventSetup/eventSetup.ts
+++ b/src/agents/eventSetup/eventSetup.ts
@@ -78,7 +78,14 @@ export default verify({
       const slackTeamId = username.slice(0, dashIndex)
       const slackUserId = username.slice(dashIndex + 1)
       const token = mintHandoffToken({ slackUserId, slackTeamId, slackChannelId, slackThreadTs })
-      const url = `${config.appHost}/events/new?token=${encodeURIComponent(token)}`
+      /* The token is placed in the URL fragment (after #) rather than the
+         query string (after ?) on purpose. Browsers do not send URL
+         fragments to servers, so the Nextspace server never sees the
+         token in its access logs and the token cannot leak via Referer
+         headers on third-party resources the form page might load. The
+         frontend reads the token from window.location.hash on the client
+         side. */
+      const url = `${config.appHost}/events/new#token=${encodeURIComponent(token)}`
       message = `Let's set up your event! Open the form here: ${url}`
     } else {
       /* Reached when Slack context is missing or partial — see the guard

--- a/src/agents/eventSetup/intentCheck.ts
+++ b/src/agents/eventSetup/intentCheck.ts
@@ -1,0 +1,66 @@
+/*
+ * Decides whether a Slack message in the event setup channel is asking
+ * the bot to help create a new event.
+ *
+ * The setup channel is single-purpose, so the bar is "is the user
+ * expressing intent to plan, create, set up, or schedule an event?"
+ * rather than the more general "is this directed at the bot?" check used
+ * by chatbot and eventHistorian. We avoid posting the handoff link in
+ * response to casual chatter ("hey berkie, you alive?") or off-topic
+ * conversation in the channel.
+ *
+ * Short-circuits with a fuzzy bot-name match before calling the LLM. If
+ * the user named the bot in the message text, that's treated as setup
+ * intent in this channel. The LLM call only fires when no name was
+ * mentioned, which keeps cost down for routine traffic.
+ *
+ * If the LLM call fails for any reason, we err on the side of NOT
+ * posting the link. Better to miss a setup request than to post links
+ * into the middle of unrelated conversation.
+ */
+
+import { z } from 'zod'
+import { getChatPromptResponse } from '../helpers/llmChain.js'
+import { matchBotMention } from '../helpers/intentChecks.js'
+import logger from '../../config/logger.js'
+
+const intentSchema = z.object({ intended_for_setup: z.boolean() })
+
+const SYSTEM_PROMPT = `You are evaluating whether a Slack message is asking an event-setup assistant to help create a new event.
+
+Match (intended_for_setup: true) when the user is expressing intent to:
+- create, set up, plan, or schedule a new event
+- propose an event topic, panel, talk, or discussion
+- kick off the process of organizing something new
+
+Do NOT match (intended_for_setup: false) for:
+- casual chatter or greetings ("hey", "good morning")
+- questions about existing events ("when is Tuesday's panel?")
+- generic questions to the bot ("are you online?", "what time is it?")
+- statements that mention an event without asking to create one
+
+When in doubt, default to false.
+
+Respond with a single JSON object: {{ "intended_for_setup": true }} or {{ "intended_for_setup": false }}`
+
+export async function checkEventSetupIntent(llm, botName, userMessage): Promise<boolean> {
+  const words = userMessage?.body?.trim().split(/\s+/) ?? []
+  if (matchBotMention(words, botName)) return true
+
+  try {
+    const response = await getChatPromptResponse(
+      llm,
+      SYSTEM_PROMPT,
+      'Message: {question}',
+      { question: userMessage?.body },
+      [],
+      intentSchema
+    )
+    return response?.intended_for_setup === true
+  } catch (err) {
+    logger.error(`event-setup intent check failed: ${(err as Error).message}`)
+    return false
+  }
+}
+
+export default { checkEventSetupIntent }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -27,6 +27,9 @@ const envVarsSchema = Joi.object()
     JWT_RESET_PASSWORD_EXPIRATION_MINUTES: Joi.number()
       .default(120)
       .description('minutes after which a password reset token expires'),
+    HANDOFF_TOKEN_EXPIRATION_MINUTES: Joi.number()
+      .default(60)
+      .description('minutes after which a Slack-to-Nextspace event-setup handoff token expires'),
     AUTH_TOKEN_SECRET: Joi.string().description('secret used to encrypt generated passwords'),
     SMTP_HOST: Joi.string().description('server that will send the emails'),
     SMTP_PORT: Joi.number().description('port to connect to the email server'),
@@ -148,7 +151,8 @@ const config = {
     accessExpirationMinutes: envVars.JWT_ACCESS_EXPIRATION_MINUTES,
     refreshExpirationDays: envVars.JWT_REFRESH_EXPIRATION_DAYS,
     resetPasswordExpirationMinutes: envVars.JWT_RESET_PASSWORD_EXPIRATION_MINUTES,
-    verifyEmailExpirationMinutes: undefined
+    verifyEmailExpirationMinutes: undefined,
+    handoffExpirationMinutes: envVars.HANDOFF_TOKEN_EXPIRATION_MINUTES
   },
   email: {
     smtp: {

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -3,7 +3,8 @@ const tokenTypes = {
   REFRESH: 'refresh',
   RESET_PASSWORD: 'resetPassword',
   VERIFY_EMAIL: 'verifyEmail',
-  ARCHIVE_TOPIC: 'archiveTopic'
+  ARCHIVE_TOPIC: 'archiveTopic',
+  SLACK_HANDOFF: 'slackHandoff'
 }
 
 export default tokenTypes

--- a/src/controllers/eventSetup.controller.ts
+++ b/src/controllers/eventSetup.controller.ts
@@ -1,0 +1,18 @@
+import catchAsync from '../utils/catchAsync.js'
+import { planEventSetup } from '../services/eventSetup/planner.service.js'
+import logger from '../config/logger.js'
+
+const plan = catchAsync(async (req, res) => {
+  /* If something goes wrong with a specific request, we want to be able
+     to trace it back to the originating Slack user and to the specific
+     handoff token. Logging jti and slackUserId gives us both without
+     ever putting the raw signed token into the logs. */
+  logger.info(
+    `event-setup plan jti=${req.handoff?.jti} slackUserId=${req.handoff?.slackUserId} descriptionLength=${req.body.description?.length}`
+  )
+
+  const result = await planEventSetup({ description: req.body.description })
+  res.send(result)
+})
+
+export default { plan }

--- a/src/middlewares/handoffAuth.ts
+++ b/src/middlewares/handoffAuth.ts
@@ -1,0 +1,45 @@
+/*
+ * Gates the event-setup endpoints behind a valid handoff token.
+ *
+ * The token is the one the Slack bot embedded in the link the organizer
+ * clicked to reach the event-creation form. It carries the originating
+ * Slack context (user, team, channel, thread timestamp) so later handlers
+ * can post the confirmation back into the same Slack thread.
+ *
+ * The handoff token is the ONLY authorization on these endpoints. There
+ * is deliberately no Nextspace user session check because the organizer
+ * may not be logged into Nextspace at all — they arrive directly from a
+ * Slack click. So any failure path (no token, bad signature, wrong type,
+ * expired) has to return 401.
+ *
+ * On success, the verified Slack context is attached to req.handoff so
+ * the route handler can use it.
+ */
+
+import httpStatus from 'http-status'
+import ApiError from '../utils/ApiError.js'
+import { verifyHandoffToken, VerifiedHandoff } from '../services/handoffToken.service.js'
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      handoff?: VerifiedHandoff
+    }
+  }
+}
+
+const handoffAuth = (req, res, next) => {
+  const token = req.header('x-handoff-token')
+  if (!token) {
+    return next(new ApiError(httpStatus.UNAUTHORIZED, 'Missing handoff token'))
+  }
+  try {
+    req.handoff = verifyHandoffToken(token)
+    return next()
+  } catch {
+    return next(new ApiError(httpStatus.UNAUTHORIZED, 'Invalid handoff token'))
+  }
+}
+
+export default handoffAuth

--- a/src/models/message.model.ts
+++ b/src/models/message.model.ts
@@ -121,6 +121,13 @@ const messageSchema = new mongoose.Schema<IMessage, MessageModel>(
     },
     prompt: {
       type: promptSchema
+    },
+    /* Adapter-specific rich content (e.g. Slack Block Kit blocks array).
+       Stored as Mixed so any valid block structure can round-trip without
+       needing a schema per platform. The Slack adapter reads this field
+       when forwarding the message to chat.postMessage. */
+    blocks: {
+      type: mongoose.SchemaTypes.Mixed
     }
   },
   {

--- a/src/routes/v1/eventSetup.route.ts
+++ b/src/routes/v1/eventSetup.route.ts
@@ -1,0 +1,11 @@
+import express from 'express'
+import validate from '../../middlewares/validate.js'
+import handoffAuth from '../../middlewares/handoffAuth.js'
+import eventSetupController from '../../controllers/eventSetup.controller.js'
+import eventSetupValidation from '../../validations/eventSetup.validation.js'
+
+const router = express.Router()
+
+router.post('/plan', handoffAuth, validate(eventSetupValidation.plan), eventSetupController.plan)
+
+export default router

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -14,6 +14,7 @@ import webhooksRoute from './webhooks.route.js'
 import experimentsRoute from './experiments.route.js'
 import healthRoute from './health.route.js'
 import openApiRoute from './openapi.route.js'
+import eventSetupRoute from './eventSetup.route.js'
 // import exportRoute from './export.route.js'
 
 const router = express.Router()
@@ -69,6 +70,10 @@ const defaultRoutes = [
   {
     path: '/openapi.json',
     route: openApiRoute
+  },
+  {
+    path: '/event-setup',
+    route: eventSetupRoute
   }
   // {
   //   path: '/export',

--- a/src/services/eventSetup/planSchema.ts
+++ b/src/services/eventSetup/planSchema.ts
@@ -1,0 +1,120 @@
+/*
+ * Defines what the LLM planner is allowed to return when interpreting an
+ * organizer's free-form description of an event.
+ *
+ * The agentic event-creation form sends the description here once, up
+ * front, and uses the response to:
+ *   - prefill fields the LLM could extract from the description
+ *   - hide form sections that obviously do not apply (skippedSections)
+ *   - turn on optional features the LLM thinks fit (featureDecisions)
+ *   - ask clarifying questions instead of showing the form when the
+ *     description is too vague (tooVague + clarifyingQuestions)
+ *   - order the remaining steps the form walks through (steps)
+ *
+ * Using Zod here forces the LLM into structured output. Anything the
+ * LLM is not confident about is omitted rather than guessed.
+ *
+ * The field-extraction half of this schema (ExtractedFieldsSchema) is
+ * kept manually in sync with the Conversation model
+ * (src/models/conversation.model.ts), which is the canonical event
+ * record. When that model gains a new user-supplied field, decide
+ * whether the LLM should try to extract it and add it below.
+ *
+ * If a second Zod consumer ever appears in the codebase (e.g. a Zod
+ * port of the conversation Joi validator), pull ExtractedFieldsSchema
+ * into a shared eventFieldsSchema module so both consumers can .pick()
+ * from it instead of drifting.
+ */
+
+import { z } from 'zod'
+
+const speakerSchema = z.object({
+  name: z.string(),
+  bio: z.string(),
+  alternateName: z.string().optional().describe('Nickname or stage name the speaker also goes by')
+})
+
+export const ExtractedFieldsSchema = z.object({
+  eventName: z.string().optional(),
+  dateTime: z.string().optional().describe('ISO 8601 datetime string'),
+  duration: z.number().optional().describe('Duration in minutes'),
+  description: z.string().optional(),
+  zoomLink: z.string().optional(),
+  topicName: z.string().optional(),
+  speakers: z.array(speakerSchema).optional(),
+  moderators: z.array(speakerSchema).optional(),
+  timeZone: z
+    .string()
+    .optional()
+    .describe(
+      'IANA timezone (e.g. America/New_York) inferred from any timezone the organizer mentioned, like ET, Eastern, PST, or GMT+1'
+    )
+})
+
+export const StepHintSchema = z.object({
+  key: z.string().describe('Stable identifier for the step, e.g. "schedule", "speakers", "resources"'),
+  prompt: z.string().describe('User-facing prompt or question for this step'),
+  fields: z.array(z.string()).describe('Names of the fields this step asks the organizer to fill')
+})
+
+/* The set of form sections the LLM is allowed to hide. These IDs are
+   the same keys the form uses to render section groups, so the LLM
+   cannot make up a section that the UI does not know how to handle. */
+const SKIPPABLE_SECTION_IDS = ['basic', 'when', 'where', 'who', 'res', 'feat'] as const
+
+export const SkippedSectionSchema = z.object({
+  id: z.enum(SKIPPABLE_SECTION_IDS).describe('Section identifier matching the form\'s section renderer keys'),
+  label: z.string().describe('Human-readable section name (e.g. "Speakers", "Resources")'),
+  reason: z.string().describe('Brief plain-language explanation of why this section was hidden')
+})
+
+/* The event features the LLM is allowed to recommend turning on or off.
+   Held as a fixed enum so the LLM cannot suggest a feature the UI does
+   not actually render a toggle for. */
+const FEATURE_IDS = ['transcription', 'backChannel', 'resourcesChannel', 'modAgent', 'qaAssistant'] as const
+
+export const FeatureDecisionSchema = z.object({
+  id: z.enum(FEATURE_IDS).describe('Feature identifier'),
+  label: z.string().describe('Human-readable feature name'),
+  enabled: z.boolean().describe('Whether the feature should be on for this event'),
+  reason: z.string().describe('Brief plain-language explanation of the choice'),
+  byAgent: z
+    .boolean()
+    .describe('True if Mason actively chose this value; false if it matches the default and Mason did not weigh in'),
+  byDefault: z.boolean().describe('What this feature would be if Mason did nothing — the system default')
+})
+
+export const EventSetupPlanSchema = z.object({
+  extracted: ExtractedFieldsSchema.describe('Fields plausibly inferable from the description, omitted if unknown'),
+  tooVague: z
+    .boolean()
+    .describe(
+      'True if the description does not contain enough signal to interpret confidently — e.g. "not sure yet", a single-sentence vague intent'
+    ),
+  confidence: z
+    .enum(['high', 'medium', 'low'])
+    .describe('Overall interpretation confidence — informs whether the form falls back to clarifying questions'),
+  clarifyingQuestions: z
+    .array(z.string())
+    .optional()
+    .describe('When tooVague is true, 2-4 short questions to ask the organizer next'),
+  steps: z
+    .array(StepHintSchema)
+    .describe('Recommended ordered sequence of steps for the rest of the form, with per-step copy hints'),
+  skippedSections: z
+    .array(SkippedSectionSchema)
+    .describe(
+      'Sections the form should hide because they do not apply to this event (e.g. skip "where" for online-only). Empty array if nothing to skip.'
+    ),
+  featureDecisions: z
+    .array(FeatureDecisionSchema)
+    .describe(
+      'Feature toggles Mason has an opinion about for this event. Sparse: include ONLY features where Mason actively chose a value based on signal in the description. Absent features mean Mason had no opinion and the system default applies. Empty array is fine.'
+    )
+})
+
+export type EventSetupPlan = z.infer<typeof EventSetupPlanSchema>
+export type ExtractedFields = z.infer<typeof ExtractedFieldsSchema>
+export type Speaker = z.infer<typeof speakerSchema>
+export type SkippedSection = z.infer<typeof SkippedSectionSchema>
+export type FeatureDecision = z.infer<typeof FeatureDecisionSchema>

--- a/src/services/eventSetup/planner.service.ts
+++ b/src/services/eventSetup/planner.service.ts
@@ -1,0 +1,123 @@
+/*
+ * The LLM call that powers the agentic event-creation form.
+ *
+ * When an organizer opens the form they type a free-form description of
+ * the event they want to create ("AI ethics roundtable next Thursday at
+ * 3pm ET, online via Zoom..."). This service takes that description and
+ * asks the LLM to:
+ *   - extract every field it can spot (eventName, dateTime, speakers, ...)
+ *   - judge whether the description is too vague to interpret confidently
+ *   - recommend the next steps the form should walk the organizer through
+ *   - decide which form sections obviously do not apply and can be hidden
+ *   - suggest feature toggles for the event (transcription, Q&A, ...)
+ *
+ * The shape of the response is enforced by EventSetupPlanSchema (Zod) so
+ * the form receives something it can render directly.
+ *
+ * If the LLM call fails for any reason (rate limit, malformed output, ...)
+ * we fall back to a minimal plan with tooVague=true. The form then shows
+ * the organizer clarifying questions instead of erroring out, which is a
+ * degraded but still-usable experience.
+ *
+ * The timezone, ISO-date, and topicName-preservation rules in the prompt
+ * have been tuned over many iterations and are load-bearing. Be careful
+ * editing them.
+ */
+
+import { getChatPromptResponse } from '../../agents/helpers/llmChain.js'
+import { getModelChat } from '../../agents/helpers/getModelChat.js'
+import config from '../../config/config.js'
+import logger from '../../config/logger.js'
+import { EventSetupPlan, EventSetupPlanSchema } from './planSchema.js'
+
+const SYSTEM_PROMPT = `You help an organizer set up an event in Nextspace. The organizer has written a free-form description of what they already know about the event in a web form. Your job is to (a) extract any structured fields you can, (b) judge whether the description is too vague to interpret confidently, (c) recommend the next steps for the rest of the form, (d) decide which form sections can be skipped entirely, and (e) recommend feature toggles.
+
+Today's date (for resolving relative dates like "tomorrow"): {today}
+
+Extraction rules:
+- Extract every field that appears in the description. Leave a field undefined only if it has never been mentioned. Do NOT guess or invent details.
+- For dateTime, return ISO 8601 in UTC (always end with Z). Resolve relative dates from "today" above.
+- If the organizer mentions a timezone (e.g. "5pm ET", "6:30 Pacific", "14:00 GMT+1"), use that timezone to compute the UTC dateTime, AND set timeZone to the matching IANA name (e.g. America/New_York for ET/Eastern, America/Los_Angeles for PT/Pacific, Europe/London for GMT/BST, etc.). If no timezone is mentioned, leave timeZone undefined.
+- duration is in minutes.
+- speakers and moderators are arrays of {{name, bio, alternateName?}}. Include a speaker or moderator entry as soon as a name is provided, even if the bio is missing — set bio to an empty string in that case. Capture alternateName only when the organizer gives an explicit alias such as "also goes by", "aka", "nickname", or "stage name"; leave it undefined otherwise.
+- topicName must be the EXACT text the organizer typed when naming the topic or series. Do not shorten, paraphrase, drop leading words, normalize casing, or "clean up" the value — preserve it character-for-character (you may trim surrounding whitespace).
+
+Planner-meta rules:
+- Set tooVague=true ONLY if the description has no concrete signal at all (e.g. "not sure yet", "an event of some kind", or a single empty greeting). Otherwise tooVague=false.
+- confidence reflects how much of the description is structured information vs. handwave. high = several fields extractable plus clear intent; medium = a few fields, some ambiguity; low = mostly vague, one or two extractable hints.
+- When tooVague is true, propose 2-4 short clarifying questions in clarifyingQuestions covering the highest-value unknowns (typically: what the event is about, when it is, who it's for, modality).
+- Steps recommend the remaining ordered sequence the form should walk through. Each step has a stable key (e.g. "schedule", "speakers", "resources"), a short user-facing prompt, and the field names it covers. Skip steps for fields you've already extracted with confidence. Order steps most-natural-first.
+
+Section-skipping rules — populate skippedSections with sections the form should HIDE because they obviously do not apply:
+- Section IDs are exactly: "basic" (event name/series), "when" (date/time), "where" (modality/Zoom link/venue), "who" (speakers), "res" (resources/readings), "feat" (event features).
+- Only skip when the description gives you confident evidence. Examples: an online-only event with a Zoom link → DO NOT skip "where" (the Zoom link still lives there), but a one-person solo update may justify skipping "who". A casual social hour may justify skipping "res".
+- Each entry: {{ id, label, reason }}. label is the human-readable section name. reason is one short sentence the organizer would understand.
+- When unsure, leave the section out of skippedSections — the form will show it. Empty array is the right answer if nothing is obviously skippable.
+
+Feature-decision rules — populate featureDecisions with toggle recommendations:
+- Feature IDs are exactly: "transcription" (live event transcript), "backChannel" (moderator-only insights from participant comments), "resourcesChannel" (separate channel for sharing readings), "modAgent" (AI moderator agent), "qaAssistant" (participant Q&A assistant).
+- System defaults: qaAssistant ON, transcription OFF, backChannel OFF, resourcesChannel OFF, modAgent OFF.
+- Only set byAgent=true when you actively chose a non-default value based on signal in the description. Examples that warrant byAgent=true: a workshop with assigned readings → enable resourcesChannel; a hybrid event with attendees joining remotely → enable transcription; an on-the-record panel → enable transcription. If you have no opinion on a feature, omit it from featureDecisions entirely.
+- Each entry: {{ id, label, enabled, reason, byAgent, byDefault }}. byDefault is the system default value for that feature.
+- Empty array is the right answer if you have no feature opinions.
+
+Return ONLY valid JSON matching the response schema.`
+
+const USER_PROMPT = `Organizer description:
+{description}`
+
+export interface PlanEventSetupInput {
+  description: string
+  /* Today's date gets baked into the system prompt so the LLM can resolve
+     relative dates like "next Thursday". Tests pass a fixed date here so
+     they get deterministic prompts; production code leaves it undefined
+     and the service uses new Date(). */
+  today?: Date
+}
+
+/* The form needs SOMETHING back from this service to render — a 500
+   would just leave the organizer staring at an empty form. So when the
+   LLM call fails we return a minimal valid plan that flags tooVague and
+   includes generic clarifying questions. The form treats that the same
+   as a description it could not interpret, which is the closest thing
+   to a useful degraded experience. */
+const fallbackPlan = (): EventSetupPlan => ({
+  extracted: {},
+  tooVague: true,
+  confidence: 'low',
+  clarifyingQuestions: [
+    'What is the event about?',
+    'When does it happen?',
+    'Who is it for?',
+    'Is it online, in person, or both?'
+  ],
+  steps: [],
+  skippedSections: [],
+  featureDecisions: []
+})
+
+export const planEventSetup = async ({
+  description,
+  today = new Date()
+}: PlanEventSetupInput): Promise<EventSetupPlan> => {
+  const llm = await getModelChat(config.classificationLLMPlatform, config.classificationLLMModel)
+  try {
+    const result = (await getChatPromptResponse(
+      llm,
+      SYSTEM_PROMPT,
+      USER_PROMPT,
+      {
+        description,
+        today: today.toISOString().split('T')[0]
+      },
+      [],
+      EventSetupPlanSchema
+    )) as EventSetupPlan
+    return result ?? fallbackPlan()
+  } catch (err) {
+    logger.error(`event-setup planEventSetup failed: ${(err as Error).message}`)
+    return fallbackPlan()
+  }
+}
+
+export default { planEventSetup }

--- a/src/services/handoffToken.service.ts
+++ b/src/services/handoffToken.service.ts
@@ -1,0 +1,74 @@
+/*
+ * Issues the signed link the Slack bot sends to an organizer who asks to
+ * create an event, and validates that link when the organizer clicks
+ * through to the Nextspace event-creation form.
+ *
+ * The link looks like https://nextspace.example/events/new?token=<jwt>.
+ * The token carries the originating Slack context (user, team, channel,
+ * thread timestamp) so once the event is created we know which Slack
+ * thread to post the confirmation back into.
+ *
+ * The token has to be unforgeable because the form trusts whatever it
+ * says about Slack identity. We sign it with the same JWT secret used
+ * elsewhere in the server, and tag every token with type='slackHandoff'
+ * so a leaked auth-session JWT cannot be replayed here (and vice versa).
+ * Tokens expire after HANDOFF_TOKEN_EXPIRATION_MINUTES because the link
+ * is meant to be clicked within the hour, not saved for later.
+ *
+ * Verification is stateless: signature + type + expiry, no DB lookup.
+ * Each token includes a random jti so we can add a revocation blacklist
+ * later if we ever need to invalidate a token before it expires; that
+ * blacklist does not exist yet.
+ */
+
+import jwt from 'jsonwebtoken'
+import { randomUUID } from 'node:crypto'
+import moment from 'moment'
+import config from '../config/config.js'
+import tokenTypes from '../config/tokens.js'
+
+export interface SlackHandoffContext {
+  slackUserId: string
+  slackTeamId: string
+  slackChannelId: string
+  slackThreadTs: string
+}
+
+export interface VerifiedHandoff extends SlackHandoffContext {
+  jti: string
+}
+
+interface HandoffPayload extends SlackHandoffContext {
+  jti: string
+  type: string
+  iat: number
+  exp: number
+}
+
+export const mintHandoffToken = (context: SlackHandoffContext): string => {
+  const expires = moment().add(config.jwt.handoffExpirationMinutes, 'minutes')
+  const payload = {
+    ...context,
+    jti: randomUUID(),
+    type: tokenTypes.SLACK_HANDOFF,
+    iat: moment().unix(),
+    exp: expires.unix()
+  }
+  return jwt.sign(payload, config.jwt.secret)
+}
+
+export const verifyHandoffToken = (token: string): VerifiedHandoff => {
+  const payload = jwt.verify(token, config.jwt.secret) as HandoffPayload
+  if (payload.type !== tokenTypes.SLACK_HANDOFF) {
+    throw new Error('Invalid token type for handoff')
+  }
+  return {
+    slackUserId: payload.slackUserId,
+    slackTeamId: payload.slackTeamId,
+    slackChannelId: payload.slackChannelId,
+    slackThreadTs: payload.slackThreadTs,
+    jti: payload.jti
+  }
+}
+
+export default { mintHandoffToken, verifyHandoffToken }

--- a/src/services/handoffToken.service.ts
+++ b/src/services/handoffToken.service.ts
@@ -54,11 +54,17 @@ export const mintHandoffToken = (context: SlackHandoffContext): string => {
     iat: moment().unix(),
     exp: expires.unix()
   }
-  return jwt.sign(payload, config.jwt.secret)
+  /* Pin to HS256 so the algorithm can't be negotiated from the token header.
+     Some jsonwebtoken versions accept 'none' or asymmetric algorithms without
+     this, which would let an attacker bypass signature verification. */
+  return jwt.sign(payload, config.jwt.secret, { algorithm: 'HS256' })
 }
 
 export const verifyHandoffToken = (token: string): VerifiedHandoff => {
-  const payload = jwt.verify(token, config.jwt.secret) as HandoffPayload
+  /* Explicit algorithm allowlist: rejects tokens signed with anything else,
+     including 'none'. The type check below is a second layer so an
+     access-session JWT can't be replayed against this endpoint. */
+  const payload = jwt.verify(token, config.jwt.secret, { algorithms: ['HS256'] }) as HandoffPayload
   if (payload.type !== tokenTypes.SLACK_HANDOFF) {
     throw new Error('Invalid token type for handoff')
   }

--- a/src/services/message.service.ts
+++ b/src/services/message.service.ts
@@ -83,7 +83,8 @@ const createMessage = async (messageBody, user, conversation) => {
     // TODO control this more carefully
     fromAgent: !!messageBody.fromAgent,
     source: messageBody.source,
-    channels: messageBody.channels?.map((c) => c.name)
+    channels: messageBody.channels?.map((c) => c.name),
+    ...(messageBody.blocks !== undefined && { blocks: messageBody.blocks })
   })
 
   message.parseOutput = messageBody.parseOutput

--- a/src/services/message.service.ts
+++ b/src/services/message.service.ts
@@ -408,7 +408,10 @@ export const agentResponseToMessageData = (response, agent) => ({
   channels: response.channels,
   parseOutput: agent.parseOutput,
   ...(response.replyFormat !== undefined && { prompt: response.replyFormat }),
-  ...(response.parent !== undefined && { parentMessage: response.parent })
+  ...(response.parent !== undefined && { parentMessage: response.parent }),
+  /* Pass adapter-specific blocks (e.g. Slack Block Kit) through to the
+     message so the adapter can include them in the outbound API call. */
+  ...(response.blocks !== undefined && { blocks: response.blocks })
 })
 
 const messageService = {

--- a/src/types/adapter.types.ts
+++ b/src/types/adapter.types.ts
@@ -12,7 +12,7 @@ export interface AdapterMessage<T> {
   channels: AdapterChannelConfig[]
   messageType?: string
   user: AdapterUser
-  source: { type: string; id?: string }
+  source: { type: string; id?: string; [key: string]: unknown }
   createdAt?: Date
   parentMessage?: string
   /** Adapter-specific rich content blocks (e.g. Slack Block Kit). Typed as unknown[] to keep this interface platform-agnostic. */

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -94,7 +94,7 @@ export interface IMessage {
   owner?: IBaseUser
   body: string | Record<string, unknown>
   bodyType?: string
-  source?: { type: string; id?: string }
+  source?: { type: string; id?: string; [key: string]: unknown }
   channels?: string[]
   conversation: IConversation
   fromAgent: boolean

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -113,6 +113,10 @@ export interface IMessage {
   updatedAt?: Date
   replyCount?: number
   prompt?: MessagePrompt
+  /* Adapter-specific rich content (e.g. Slack Block Kit). Persisted so the
+     Slack adapter can read it when forwarding the message to Slack's API.
+     Kept as unknown[] to avoid platform-specific types in the shared model. */
+  blocks?: unknown[]
 }
 
 export interface IFollower {
@@ -422,6 +426,10 @@ export interface AgentResponse<T> {
   replyFormat?: MessagePrompt
   parent?: mongoose.Types.ObjectId
   pause?: number
+  /* Adapter-specific rich content (e.g. Slack Block Kit). Kept as unknown[]
+     here to avoid pulling platform-specific types into the shared interface.
+     The Slack adapter reads this field when sending a message. */
+  blocks?: unknown[]
 }
 
 export interface ConversationHistorySettings {

--- a/src/validations/eventSetup.validation.ts
+++ b/src/validations/eventSetup.validation.ts
@@ -1,0 +1,11 @@
+import Joi from 'joi'
+
+const MAX_DESCRIPTION_LENGTH = 4000
+
+const plan = {
+  body: Joi.object().keys({
+    description: Joi.string().min(1).max(MAX_DESCRIPTION_LENGTH).required()
+  })
+}
+
+export default { plan }

--- a/tests/adapters/slack.adapter.test.ts
+++ b/tests/adapters/slack.adapter.test.ts
@@ -406,7 +406,13 @@ describe('slack adapter tests', () => {
       expect(msgs).toEqual([
         {
           message: 'Hello from Slack!',
-          source: { type: 'slack', id: slackEvent.ts },
+          source: {
+            type: 'slack',
+            id: slackEvent.ts,
+            userId: slackEvent.user,
+            teamId: slackEvent.team,
+            channelId: slackEvent.channel
+          },
           channels: adapter.chatChannels,
           user: { username: `${slackEvent.team}-${slackEvent.user}`, pseudonym: slackEvent.user }
         }
@@ -430,7 +436,13 @@ describe('slack adapter tests', () => {
       expect(msgs).toEqual([
         {
           message: 'Hello <@U123456> and <#C789012|general>! Check out <https://example.com|this link>',
-          source: { type: 'slack', id: slackEvent.ts },
+          source: {
+            type: 'slack',
+            id: slackEvent.ts,
+            userId: slackEvent.user,
+            teamId: slackEvent.team,
+            channelId: slackEvent.channel
+          },
           channels: adapter.chatChannels,
           user: { username: `${slackEvent.team}-${slackEvent.user}`, pseudonym: slackEvent.user }
         }

--- a/tests/agents/eventSetup/eventSetup.agent.test.ts
+++ b/tests/agents/eventSetup/eventSetup.agent.test.ts
@@ -6,6 +6,10 @@ import { AgentMessageActions, ConversationHistory } from '../../../src/types/ind
 import { verifyHandoffToken } from '../../../src/services/handoffToken.service.js'
 import config from '../../../src/config/config.js'
 
+type Block = Record<string, unknown>
+type ActionElement = { type: string; text: { text: string }; url: string }
+type ActionsBlock = { type: 'actions'; elements: ActionElement[] }
+
 jest.setTimeout(30000)
 
 const testConfig = setupAgentTest('eventSetup')
@@ -58,32 +62,18 @@ describe('eventSetup agent tests', () => {
   }
 
   describe('evaluate()', () => {
-    it('returns CONTRIBUTE when message contains "setup"', async () => {
-      const result = await evaluate('I want to setup a new event')
-      expect(result.action).toBe(AgentMessageActions.CONTRIBUTE)
-    })
+    /* evaluate() always returns CONTRIBUTE for any message on the setup
+       channel. The "should the bot actually reply?" decision is deferred to
+       checkEventSetupIntent inside respond(), which uses an LLM. This
+       matches the pattern used by chatbot and eventHistorian: evaluate marks
+       every message as a contribution so the agent is considered for
+       respond(), then respond() decides whether to post. */
+    it('returns CONTRIBUTE for any message on the setup channel', async () => {
+      const setupMsg = await evaluate('I want to setup a new event')
+      expect(setupMsg.action).toBe(AgentMessageActions.CONTRIBUTE)
 
-    it('returns CONTRIBUTE when message contains "create event" or "create an event"', async () => {
-      const withoutArticle = await evaluate('Can you create event for next Thursday?')
-      expect(withoutArticle.action).toBe(AgentMessageActions.CONTRIBUTE)
-
-      const withArticle = await evaluate('Can you create an event for next Thursday?')
-      expect(withArticle.action).toBe(AgentMessageActions.CONTRIBUTE)
-    })
-
-    it('returns CONTRIBUTE when message contains "new event"', async () => {
-      const result = await evaluate('Let us kick off a new event about AI')
-      expect(result.action).toBe(AgentMessageActions.CONTRIBUTE)
-    })
-
-    it('returns CONTRIBUTE when message is a direct @mention', async () => {
-      const result = await evaluate(`@${BOT_NAME} can you help me?`)
-      expect(result.action).toBe(AgentMessageActions.CONTRIBUTE)
-    })
-
-    it('returns OK when message has no setup intent', async () => {
-      const result = await evaluate('Good morning everyone!')
-      expect(result.action).toBe(AgentMessageActions.OK)
+      const casualMsg = await evaluate('Good morning everyone!')
+      expect(casualMsg.action).toBe(AgentMessageActions.CONTRIBUTE)
     })
   })
 
@@ -100,7 +90,7 @@ describe('eventSetup agent tests', () => {
     }
     /* eslint-enable no-param-reassign */
 
-    it('returns a Nextspace handoff URL with a verifiable token', async () => {
+    it("returns a Block Kit response with a Let's Go button carrying a verifiable token", async () => {
       const msg = await createMessage('setup a new event', user1, conversation, ['setup'])
       asSlackMessage(msg)
       const history = buildHistory([])
@@ -109,12 +99,17 @@ describe('eventSetup agent tests', () => {
       expect(responses).toHaveLength(1)
       expect(responses[0].visible).toBe(true)
       expect(responses[0].messageType).toBe('text')
-      /* Token lives in the URL fragment so it never reaches the server's
-         access logs. See eventSetup.ts for the reasoning. */
-      expect(responses[0].message).toContain(`${config.appHost}/events/new#token=`)
 
-      const match = responses[0].message.match(/#token=([A-Za-z0-9._-]+)/)
-      const token = decodeURIComponent(match[1])
+      /* The token lives in the button URL (inside blocks), not in the
+         fallback message text. URL fragment keeps it out of server logs. */
+      const { blocks } = responses[0]
+      expect(blocks).toBeDefined()
+      const actionsBlock = (blocks as Block[]).find((b): b is ActionsBlock => b.type === 'actions') as ActionsBlock
+      const buttonUrl: string = actionsBlock.elements[0].url
+      expect(buttonUrl).toContain(`${config.appHost}/events/new#token=`)
+
+      const match = buttonUrl.match(/#token=([A-Za-z0-9._-]+)/)
+      const token = decodeURIComponent(match![1])
       const verified = verifyHandoffToken(token)
       expect(verified.slackUserId).toBe('U456DEF')
     })

--- a/tests/agents/eventSetup/eventSetup.agent.test.ts
+++ b/tests/agents/eventSetup/eventSetup.agent.test.ts
@@ -3,6 +3,8 @@ import defaultAgentTypes from '../../../src/agents/index.js'
 import { createUser, createConversation, createPublicTopic, createMessage } from '../../utils/agentTestHelpers.js'
 import { Agent, Channel } from '../../../src/models/index.js'
 import { AgentMessageActions, ConversationHistory } from '../../../src/types/index.types.js'
+import { verifyHandoffToken } from '../../../src/services/handoffToken.service.js'
+import config from '../../../src/config/config.js'
 
 jest.setTimeout(30000)
 
@@ -86,19 +88,38 @@ describe('eventSetup agent tests', () => {
   })
 
   describe('respond()', () => {
-    it('returns a placeholder response', async () => {
+    /* The DB-backed createMessage helper does not set source.type='slack',
+       so to exercise the Slack-handoff branch we attach a Slack-shaped envelope
+       to the message before calling respond. */
+    /* eslint-disable no-param-reassign */
+    function asSlackMessage(msg, { teamId = 'T123ABC', userId = 'U456DEF', channelId = 'C789GHI' } = {}) {
+      msg.source = { type: 'slack', id: '1700000000.000100' }
+      msg.user = { username: `${teamId}-${userId}`, pseudonym: userId }
+      msg.channels = [{ name: channelId }]
+      return msg
+    }
+    /* eslint-enable no-param-reassign */
+
+    it('returns a Nextspace handoff URL with a verifiable token', async () => {
       const msg = await createMessage('setup a new event', user1, conversation, ['setup'])
+      asSlackMessage(msg)
       const history = buildHistory([])
       const responses = await defaultAgentTypes.eventSetup.respond.call(agent, history, msg)
 
       expect(responses).toHaveLength(1)
       expect(responses[0].visible).toBe(true)
-      expect(responses[0].message).toBe('Event setup coming soon')
       expect(responses[0].messageType).toBe('text')
+      expect(responses[0].message).toContain(`${config.appHost}/events/new?token=`)
+
+      const match = responses[0].message.match(/token=([A-Za-z0-9._-]+)/)
+      const token = decodeURIComponent(match[1])
+      const verified = verifyHandoffToken(token)
+      expect(verified.slackUserId).toBe('U456DEF')
     })
 
     it('routes the response to the setup channel', async () => {
       const msg = await createMessage('setup a new event', user1, conversation, ['setup'])
+      asSlackMessage(msg)
       const history = buildHistory([])
       const responses = await defaultAgentTypes.eventSetup.respond.call(agent, history, msg)
 

--- a/tests/agents/eventSetup/eventSetup.agent.test.ts
+++ b/tests/agents/eventSetup/eventSetup.agent.test.ts
@@ -109,9 +109,11 @@ describe('eventSetup agent tests', () => {
       expect(responses).toHaveLength(1)
       expect(responses[0].visible).toBe(true)
       expect(responses[0].messageType).toBe('text')
-      expect(responses[0].message).toContain(`${config.appHost}/events/new?token=`)
+      /* Token lives in the URL fragment so it never reaches the server's
+         access logs. See eventSetup.ts for the reasoning. */
+      expect(responses[0].message).toContain(`${config.appHost}/events/new#token=`)
 
-      const match = responses[0].message.match(/token=([A-Za-z0-9._-]+)/)
+      const match = responses[0].message.match(/#token=([A-Za-z0-9._-]+)/)
       const token = decodeURIComponent(match[1])
       const verified = verifyHandoffToken(token)
       expect(verified.slackUserId).toBe('U456DEF')

--- a/tests/agents/eventSetup/eventSetup.agent.test.ts
+++ b/tests/agents/eventSetup/eventSetup.agent.test.ts
@@ -83,9 +83,10 @@ describe('eventSetup agent tests', () => {
        to the message before calling respond. */
     /* eslint-disable no-param-reassign */
     function asSlackMessage(msg, { teamId = 'T123ABC', userId = 'U456DEF', channelId = 'C789GHI' } = {}) {
-      msg.source = { type: 'slack', id: '1700000000.000100' }
-      msg.user = { username: `${teamId}-${userId}`, pseudonym: userId }
-      msg.channels = [{ name: channelId }]
+      /* Slack identity goes in source — that's what survives the DB
+         round-trip. The adapter stores these fields there so respond()
+         can read them from the persisted message. */
+      msg.source = { type: 'slack', id: '1700000000.000100', userId, teamId, channelId }
       return msg
     }
     /* eslint-enable no-param-reassign */

--- a/tests/integration/eventSetup.test.ts
+++ b/tests/integration/eventSetup.test.ts
@@ -1,0 +1,134 @@
+import { jest } from '@jest/globals'
+import httpStatus from 'http-status'
+import jwt from 'jsonwebtoken'
+import request from 'supertest'
+
+import setupIntTest from '../utils/setupIntTest.js'
+import { mintHandoffToken } from '../../src/services/handoffToken.service.js'
+import config from '../../src/config/config.js'
+import tokenTypes from '../../src/config/tokens.js'
+import type { EventSetupPlan } from '../../src/services/eventSetup/planSchema.js'
+
+/* Mock the planner service before importing the app. The LLM call is
+   nondeterministic. For plumbing tests we just need a stable response. */
+const mockPlan = jest.fn<(input: { description: string }) => Promise<EventSetupPlan>>()
+
+jest.unstable_mockModule('../src/services/eventSetup/planner.service.js', () => ({
+  planEventSetup: mockPlan,
+  default: { planEventSetup: mockPlan }
+}))
+
+jest.mock('agenda')
+
+const { default: app } = await import('../../src/app.js')
+
+jest.setTimeout(30000)
+setupIntTest()
+
+const slackContext = {
+  slackUserId: 'U123ABC',
+  slackTeamId: 'T456DEF',
+  slackChannelId: 'C789GHI',
+  slackThreadTs: '1700000000.000100'
+}
+
+const mockResponse: EventSetupPlan = {
+  extracted: {
+    eventName: 'AI Ethics Roundtable',
+    dateTime: '2026-05-28T19:00:00.000Z',
+    timeZone: 'America/New_York',
+    zoomLink: 'https://zoom.example/j/123'
+  },
+  tooVague: false,
+  confidence: 'high',
+  steps: [
+    { key: 'duration', prompt: 'How long is it?', fields: ['duration'] },
+    { key: 'speakers', prompt: 'Who is presenting?', fields: ['speakers'] }
+  ],
+  skippedSections: [{ id: 'res', label: 'Resources', reason: 'No readings mentioned for this event.' }],
+  featureDecisions: [
+    {
+      id: 'transcription',
+      label: 'Live transcription',
+      enabled: true,
+      reason: 'Hybrid panel — remote attendees benefit from a live transcript.',
+      byAgent: true,
+      byDefault: false
+    }
+  ]
+}
+
+describe('POST /v1/event-setup/plan', () => {
+  beforeEach(() => {
+    mockPlan.mockReset()
+    mockPlan.mockResolvedValue(mockResponse)
+  })
+
+  test('returns 401 when no handoff token is provided', async () => {
+    const res = await request(app)
+      .post('/v1/event-setup/plan')
+      .send({ description: 'A casual roundtable on AI ethics next Thursday at 3pm ET.' })
+
+    expect(res.status).toBe(httpStatus.UNAUTHORIZED)
+    expect(mockPlan).not.toHaveBeenCalled()
+  })
+
+  test('returns 401 when the handoff token is malformed', async () => {
+    const res = await request(app)
+      .post('/v1/event-setup/plan')
+      .set('X-Handoff-Token', 'not-a-real-jwt')
+      .send({ description: 'A casual roundtable.' })
+
+    expect(res.status).toBe(httpStatus.UNAUTHORIZED)
+    expect(mockPlan).not.toHaveBeenCalled()
+  })
+
+  test('returns 401 when the token is signed with the wrong type claim', async () => {
+    /* Sign a JWT with the same secret but type=access. A leaked auth token
+       must not be replayable as a handoff token. */
+    const wrongTypeToken = jwt.sign(
+      { ...slackContext, type: tokenTypes.ACCESS, exp: Math.floor(Date.now() / 1000) + 3600 },
+      config.jwt.secret
+    )
+
+    const res = await request(app)
+      .post('/v1/event-setup/plan')
+      .set('X-Handoff-Token', wrongTypeToken)
+      .send({ description: 'A casual roundtable.' })
+
+    expect(res.status).toBe(httpStatus.UNAUTHORIZED)
+    expect(mockPlan).not.toHaveBeenCalled()
+  })
+
+  test('returns 400 when description is missing', async () => {
+    const token = mintHandoffToken(slackContext)
+    const res = await request(app).post('/v1/event-setup/plan').set('X-Handoff-Token', token).send({})
+
+    expect(res.status).toBe(httpStatus.BAD_REQUEST)
+    expect(mockPlan).not.toHaveBeenCalled()
+  })
+
+  test('returns 400 when description exceeds the length cap', async () => {
+    const token = mintHandoffToken(slackContext)
+    const tooLong = 'a'.repeat(4001)
+    const res = await request(app).post('/v1/event-setup/plan').set('X-Handoff-Token', token).send({ description: tooLong })
+
+    expect(res.status).toBe(httpStatus.BAD_REQUEST)
+    expect(mockPlan).not.toHaveBeenCalled()
+  })
+
+  test('returns 200 with the planner output when token + body are valid', async () => {
+    const token = mintHandoffToken(slackContext)
+    const res = await request(app)
+      .post('/v1/event-setup/plan')
+      .set('X-Handoff-Token', token)
+      .send({ description: 'Casual AI ethics roundtable, online via Zoom, next Thursday.' })
+
+    expect(res.status).toBe(httpStatus.OK)
+    expect(res.body).toEqual(mockResponse)
+    expect(mockPlan).toHaveBeenCalledTimes(1)
+    expect(mockPlan).toHaveBeenCalledWith({
+      description: 'Casual AI ethics roundtable, online via Zoom, next Thursday.'
+    })
+  })
+})

--- a/tests/unit/agents/eventSetupRespond.test.ts
+++ b/tests/unit/agents/eventSetupRespond.test.ts
@@ -1,0 +1,82 @@
+import eventSetup from '../../../src/agents/eventSetup/eventSetup.js'
+import { verifyHandoffToken } from '../../../src/services/handoffToken.service.js'
+import config from '../../../src/config/config.js'
+
+/* The event-setup respond() function is unit-testable without a DB: it only
+   reads this.conversation.channels and the userMessage shape. We mock both. */
+function buildContext() {
+  return {
+    conversation: {
+      channels: [{ name: 'setup' }, { name: 'general' }]
+    }
+  }
+}
+
+function buildSlackMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    body: 'setup a new event',
+    source: { type: 'slack', id: '1700000000.000100' },
+    user: { username: 'T123ABC-U456DEF', pseudonym: 'U456DEF' },
+    channels: [{ name: 'C789GHI' }],
+    parentMessage: undefined,
+    ...overrides
+  }
+}
+
+describe('eventSetup respond()', () => {
+  test('returns a single message routed to the setup channel', async () => {
+    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, buildSlackMessage())
+
+    expect(responses).toHaveLength(1)
+    expect(responses[0].visible).toBe(true)
+    expect(responses[0].messageType).toBe('text')
+    expect(responses[0].channels.map((c) => c.name)).toContain('setup')
+  })
+
+  test('Slack-origin message: posts a Nextspace handoff URL with a verifiable token', async () => {
+    const msg = buildSlackMessage()
+    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg)
+
+    const text: string = responses[0].message
+    /* The URL we tell the organizer to open must point at the configured
+       Nextspace host and include the handoff token as a query param. */
+    expect(text).toContain(`${config.appHost}/events/new?token=`)
+
+    const match = text.match(/token=([A-Za-z0-9._-]+)/)
+    expect(match).not.toBeNull()
+    const token = decodeURIComponent(match![1])
+
+    const verified = verifyHandoffToken(token)
+    expect(verified.slackUserId).toBe('U456DEF')
+    expect(verified.slackTeamId).toBe('T123ABC')
+    expect(verified.slackChannelId).toBe('C789GHI')
+    expect(verified.slackThreadTs).toBe('1700000000.000100')
+  })
+
+  test('non-Slack origin: falls back to a generic Nextspace URL without a token', async () => {
+    const msg = buildSlackMessage({
+      source: { type: 'web', id: 'abc' },
+      user: { username: 'alice', pseudonym: 'alice' }
+    })
+    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg)
+
+    const text: string = responses[0].message
+    expect(text).toContain(`${config.appHost}/events/new`)
+    expect(text).not.toMatch(/token=/)
+  })
+
+  test.each([
+    ['user is missing entirely', { user: undefined }],
+    ['username has no dash separator', { user: { username: 'alice', pseudonym: 'alice' } }],
+    ['username is empty string', { user: { username: '', pseudonym: '' } }],
+    ['channels array is empty', { channels: [] }],
+    ['source.id is missing', { source: { type: 'slack' } }]
+  ])('Slack origin but %s: falls back without minting a token', async (_label, override) => {
+    const msg = buildSlackMessage(override)
+    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg)
+
+    const text: string = responses[0].message
+    expect(text).toContain(`${config.appHost}/events/new`)
+    expect(text).not.toMatch(/token=/)
+  })
+})

--- a/tests/unit/agents/eventSetupRespond.test.ts
+++ b/tests/unit/agents/eventSetupRespond.test.ts
@@ -14,6 +14,7 @@ function buildContext() {
 
 function buildSlackMessage(overrides: Record<string, unknown> = {}) {
   return {
+    _id: 'user-msg-id-001',
     body: 'setup a new event',
     source: { type: 'slack', id: '1700000000.000100' },
     user: { username: 'T123ABC-U456DEF', pseudonym: 'U456DEF' },
@@ -51,6 +52,26 @@ describe('eventSetup respond()', () => {
     expect(verified.slackTeamId).toBe('T123ABC')
     expect(verified.slackChannelId).toBe('C789GHI')
     expect(verified.slackThreadTs).toBe('1700000000.000100')
+  })
+
+  test('threads the reply under the user message when the user posted at top level', async () => {
+    /* If the organizer's message itself has no parent, the bot's reply
+       should start a new thread under that message rather than landing
+       back in the main channel. The Slack adapter does this by setting
+       thread_ts to the parent message's source.id, so we need to set our
+       response's parent to the user's own _id when no existing thread
+       exists. */
+    const msg = buildSlackMessage({ parentMessage: undefined })
+    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg)
+
+    expect(responses[0].parent).toBe('user-msg-id-001')
+  })
+
+  test('preserves an existing thread when the user message is already a reply', async () => {
+    const msg = buildSlackMessage({ parentMessage: 'existing-thread-root-id' })
+    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg)
+
+    expect(responses[0].parent).toBe('existing-thread-root-id')
   })
 
   test('non-Slack origin: falls back to a generic Nextspace URL without a token', async () => {

--- a/tests/unit/agents/eventSetupRespond.test.ts
+++ b/tests/unit/agents/eventSetupRespond.test.ts
@@ -39,11 +39,15 @@ describe('eventSetup respond()', () => {
     const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg)
 
     const text: string = responses[0].message
-    /* The URL we tell the organizer to open must point at the configured
-       Nextspace host and include the handoff token as a query param. */
-    expect(text).toContain(`${config.appHost}/events/new?token=`)
+    /* The token must be in the URL fragment (after #), not the query
+       string (after ?). Browsers do not send URL fragments to servers,
+       so this keeps the token out of Nextspace's server access logs and
+       out of the Referer header on any third-party resource the form
+       page loads. */
+    expect(text).toContain(`${config.appHost}/events/new#token=`)
+    expect(text).not.toContain(`${config.appHost}/events/new?token=`)
 
-    const match = text.match(/token=([A-Za-z0-9._-]+)/)
+    const match = text.match(/#token=([A-Za-z0-9._-]+)/)
     expect(match).not.toBeNull()
     const token = decodeURIComponent(match![1])
 

--- a/tests/unit/agents/eventSetupRespond.test.ts
+++ b/tests/unit/agents/eventSetupRespond.test.ts
@@ -22,9 +22,9 @@ function buildSlackMessage(overrides: Record<string, unknown> = {}) {
   return {
     _id: 'user-msg-id-001',
     body: 'setup a new event',
-    source: { type: 'slack', id: '1700000000.000100' },
-    user: { username: 'T123ABC-U456DEF', pseudonym: 'U456DEF' },
-    channels: [{ name: 'C789GHI' }],
+    /* Slack identity lives in source — these fields survive DB persistence
+       (unlike the transient user field, which is dropped after auth lookup). */
+    source: { type: 'slack', id: '1700000000.000100', userId: 'U456DEF', teamId: 'T123ABC', channelId: 'C789GHI' },
     parentMessage: undefined,
     ...overrides
   }
@@ -141,10 +141,7 @@ describe('eventSetup respond()', () => {
   })
 
   test('non-Slack origin: falls back to a text-only message with the Nextspace URL, no blocks', async () => {
-    const msg = buildSlackMessage({
-      source: { type: 'web', id: 'abc' },
-      user: { username: 'alice', pseudonym: 'alice' }
-    })
+    const msg = buildSlackMessage({ source: { type: 'web', id: 'abc' } })
     const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg, alwaysSetupIntent)
 
     const text: string = responses[0].message
@@ -156,12 +153,12 @@ describe('eventSetup respond()', () => {
   })
 
   test.each([
-    ['user is missing entirely', { user: undefined }],
-    ['username has no dash separator', { user: { username: 'alice', pseudonym: 'alice' } }],
-    ['username is empty string', { user: { username: '', pseudonym: '' } }],
-    ['channels array is empty', { channels: [] }],
-    ['source.id is missing', { source: { type: 'slack' } }]
-  ])('Slack origin but %s: falls back to text-only message without blocks', async (_label, override) => {
+    ['source.userId is missing', { source: { type: 'slack', id: '1700000000.000100', teamId: 'T123ABC', channelId: 'C789GHI' } }],
+    ['source.teamId is missing', { source: { type: 'slack', id: '1700000000.000100', userId: 'U456DEF', channelId: 'C789GHI' } }],
+    ['source.channelId is missing', { source: { type: 'slack', id: '1700000000.000100', userId: 'U456DEF', teamId: 'T123ABC' } }],
+    ['source.id (thread ts) is missing', { source: { type: 'slack', userId: 'U456DEF', teamId: 'T123ABC', channelId: 'C789GHI' } }],
+    ['source.type is not slack', { source: { type: 'web', id: '1700000000.000100', userId: 'U456DEF', teamId: 'T123ABC', channelId: 'C789GHI' } }]
+  ])('Slack context but %s: falls back to text-only message without blocks', async (_label, override) => {
     const msg = buildSlackMessage(override)
     const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg, alwaysSetupIntent)
 

--- a/tests/unit/agents/eventSetupRespond.test.ts
+++ b/tests/unit/agents/eventSetupRespond.test.ts
@@ -1,11 +1,17 @@
-import eventSetup from '../../../src/agents/eventSetup/eventSetup.js'
+import eventSetup, { buildEventSetupBlocks } from '../../../src/agents/eventSetup/eventSetup.js'
 import { verifyHandoffToken } from '../../../src/services/handoffToken.service.js'
 import config from '../../../src/config/config.js'
 
-/* The event-setup respond() function is unit-testable without a DB: it only
-   reads this.conversation.channels and the userMessage shape. We mock both. */
+/* respond() accepts an optional third argument for the intent check function.
+   Passing a stub here means these unit tests never touch a real LLM. The
+   intent check itself has dedicated tests in intentCheck.test.ts. */
+const alwaysSetupIntent = async () => true
+
+/* respond() is unit-testable without a DB: it only reads
+   this.conversation.channels and the userMessage shape. */
 function buildContext() {
   return {
+    agentConfig: { botName: 'Event Setup Bot' },
     conversation: {
       channels: [{ name: 'setup' }, { name: 'general' }]
     }
@@ -24,30 +30,77 @@ function buildSlackMessage(overrides: Record<string, unknown> = {}) {
   }
 }
 
+/* Helper types for Block Kit shapes returned by buildEventSetupBlocks */
+type Block = Record<string, unknown>
+type ActionElement = { type: string; text: { text: string }; url: string }
+type ActionsBlock = { type: 'actions'; elements: ActionElement[] }
+type SectionBlock = { type: 'section'; text: { type: string; text: string } }
+
+/* ─── buildEventSetupBlocks (pure function) ───────────────────────────────── */
+
+describe('buildEventSetupBlocks()', () => {
+  const url = 'https://nextspace.example.org/events/new#token=abc123'
+
+  test('returns a section block with a mrkdwn user mention', () => {
+    const blocks = buildEventSetupBlocks('U456DEF', url)
+    const section = blocks.find((b): b is SectionBlock => (b as Block).type === 'section') as SectionBlock
+    expect(section).toBeDefined()
+    expect(section.text.type).toBe('mrkdwn')
+    /* Slack renders <@USER_ID> as the user's display name */
+    expect(section.text.text).toContain('<@U456DEF>')
+  })
+
+  test("returns an actions block with a Let's Go button", () => {
+    const blocks = buildEventSetupBlocks('U456DEF', url)
+    const actions = blocks.find((b): b is ActionsBlock => (b as Block).type === 'actions') as ActionsBlock
+    expect(actions).toBeDefined()
+    expect(actions.elements[0].type).toBe('button')
+    expect(actions.elements[0].text.text).toBe("Let's Go")
+  })
+
+  test('button url matches the provided url exactly', () => {
+    const blocks = buildEventSetupBlocks('U456DEF', url)
+    const actions = blocks.find((b): b is ActionsBlock => (b as Block).type === 'actions') as ActionsBlock
+    expect(actions.elements[0].url).toBe(url)
+  })
+})
+
+/* ─── respond() ──────────────────────────────────────────────────────────── */
+
 describe('eventSetup respond()', () => {
   test('returns a single message routed to the setup channel', async () => {
-    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, buildSlackMessage())
+    const responses = await eventSetup.respond.call(
+      buildContext(),
+      { messages: [] },
+      buildSlackMessage(),
+      alwaysSetupIntent
+    )
 
     expect(responses).toHaveLength(1)
     expect(responses[0].visible).toBe(true)
     expect(responses[0].messageType).toBe('text')
-    expect(responses[0].channels.map((c) => c.name)).toContain('setup')
+    expect(responses[0].channels.map((c: { name: string }) => c.name)).toContain('setup')
   })
 
-  test('Slack-origin message: posts a Nextspace handoff URL with a verifiable token', async () => {
+  test('Slack-origin message: Block Kit button carries a verifiable token in the URL fragment', async () => {
     const msg = buildSlackMessage()
-    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg)
+    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg, alwaysSetupIntent)
 
-    const text: string = responses[0].message
-    /* The token must be in the URL fragment (after #), not the query
-       string (after ?). Browsers do not send URL fragments to servers,
-       so this keeps the token out of Nextspace's server access logs and
-       out of the Referer header on any third-party resource the form
-       page loads. */
-    expect(text).toContain(`${config.appHost}/events/new#token=`)
-    expect(text).not.toContain(`${config.appHost}/events/new?token=`)
+    /* The token lives in the button URL (inside blocks), not in the fallback
+       message text. Browsers never send URL fragments to servers, so placing
+       the token after # keeps it out of Nextspace's access logs and Referer
+       headers on any third-party resources the form page loads. The fallback
+       text is for push notifications and accessibility — it does not need the
+       token. */
+    const { blocks } = responses[0]
+    expect(blocks).toBeDefined()
+    const actionsBlock = (blocks as Block[]).find((b): b is ActionsBlock => b.type === 'actions') as ActionsBlock
+    expect(actionsBlock).toBeDefined()
+    const buttonUrl: string = actionsBlock.elements[0].url
+    expect(buttonUrl).toContain(`${config.appHost}/events/new#token=`)
+    expect(buttonUrl).not.toContain(`${config.appHost}/events/new?token=`)
 
-    const match = text.match(/#token=([A-Za-z0-9._-]+)/)
+    const match = buttonUrl.match(/#token=([A-Za-z0-9._-]+)/)
     expect(match).not.toBeNull()
     const token = decodeURIComponent(match![1])
 
@@ -58,36 +111,48 @@ describe('eventSetup respond()', () => {
     expect(verified.slackThreadTs).toBe('1700000000.000100')
   })
 
+  test('Slack-origin message: Block Kit section greets the user by Slack mention', async () => {
+    const msg = buildSlackMessage()
+    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg, alwaysSetupIntent)
+
+    const { blocks } = responses[0]
+    const sectionBlock = (blocks as Block[]).find((b): b is SectionBlock => b.type === 'section') as SectionBlock
+    expect(sectionBlock).toBeDefined()
+    /* Slack renders <@U456DEF> as the user's display name in the UI */
+    expect(sectionBlock.text.text).toContain('<@U456DEF>')
+  })
+
   test('threads the reply under the user message when the user posted at top level', async () => {
-    /* If the organizer's message itself has no parent, the bot's reply
-       should start a new thread under that message rather than landing
-       back in the main channel. The Slack adapter does this by setting
-       thread_ts to the parent message's source.id, so we need to set our
-       response's parent to the user's own _id when no existing thread
-       exists. */
+    /* If the organizer's message has no parent thread, the bot's reply should
+       start a new thread under that message. The Slack adapter sets thread_ts
+       to the parent message's source.id, so the response parent needs to be
+       the user's own _id when no existing thread exists. */
     const msg = buildSlackMessage({ parentMessage: undefined })
-    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg)
+    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg, alwaysSetupIntent)
 
     expect(responses[0].parent).toBe('user-msg-id-001')
   })
 
   test('preserves an existing thread when the user message is already a reply', async () => {
     const msg = buildSlackMessage({ parentMessage: 'existing-thread-root-id' })
-    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg)
+    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg, alwaysSetupIntent)
 
     expect(responses[0].parent).toBe('existing-thread-root-id')
   })
 
-  test('non-Slack origin: falls back to a generic Nextspace URL without a token', async () => {
+  test('non-Slack origin: falls back to a text-only message with the Nextspace URL, no blocks', async () => {
     const msg = buildSlackMessage({
       source: { type: 'web', id: 'abc' },
       user: { username: 'alice', pseudonym: 'alice' }
     })
-    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg)
+    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg, alwaysSetupIntent)
 
     const text: string = responses[0].message
     expect(text).toContain(`${config.appHost}/events/new`)
     expect(text).not.toMatch(/token=/)
+    /* No Block Kit blocks for non-Slack messages — other adapters don't
+       understand Slack's block format. */
+    expect(responses[0].blocks).toBeUndefined()
   })
 
   test.each([
@@ -96,12 +161,13 @@ describe('eventSetup respond()', () => {
     ['username is empty string', { user: { username: '', pseudonym: '' } }],
     ['channels array is empty', { channels: [] }],
     ['source.id is missing', { source: { type: 'slack' } }]
-  ])('Slack origin but %s: falls back without minting a token', async (_label, override) => {
+  ])('Slack origin but %s: falls back to text-only message without blocks', async (_label, override) => {
     const msg = buildSlackMessage(override)
-    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg)
+    const responses = await eventSetup.respond.call(buildContext(), { messages: [] }, msg, alwaysSetupIntent)
 
     const text: string = responses[0].message
     expect(text).toContain(`${config.appHost}/events/new`)
     expect(text).not.toMatch(/token=/)
+    expect(responses[0].blocks).toBeUndefined()
   })
 })

--- a/tests/unit/services/handoffToken.service.test.ts
+++ b/tests/unit/services/handoffToken.service.test.ts
@@ -1,0 +1,69 @@
+import jwt from 'jsonwebtoken'
+import config from '../../../src/config/config.js'
+import tokenTypes from '../../../src/config/tokens.js'
+import { mintHandoffToken, verifyHandoffToken } from '../../../src/services/handoffToken.service.js'
+
+describe('handoffToken service', () => {
+  const context = {
+    slackUserId: 'U123ABC',
+    slackTeamId: 'T456DEF',
+    slackChannelId: 'C789GHI',
+    slackThreadTs: '1700000000.000100'
+  }
+
+  test('roundtrips Slack context through mint + verify', () => {
+    const token = mintHandoffToken(context)
+    const verified = verifyHandoffToken(token)
+
+    expect(verified.slackUserId).toBe(context.slackUserId)
+    expect(verified.slackTeamId).toBe(context.slackTeamId)
+    expect(verified.slackChannelId).toBe(context.slackChannelId)
+    expect(verified.slackThreadTs).toBe(context.slackThreadTs)
+  })
+
+  test('mints a unique jti on each call', () => {
+    const decoded1 = jwt.decode(mintHandoffToken(context)) as { jti?: string }
+    const decoded2 = jwt.decode(mintHandoffToken(context)) as { jti?: string }
+
+    expect(decoded1.jti).toBeTruthy()
+    expect(decoded1.jti).not.toBe(decoded2.jti)
+  })
+
+  test('rejects a token signed with a different type claim (cross-context replay)', () => {
+    /* Sign a valid JWT against the same secret but with the access-token
+       type. Verifier must refuse: signature alone is not sufficient. */
+    const wrongTypeToken = jwt.sign(
+      {
+        ...context,
+        type: tokenTypes.ACCESS,
+        exp: Math.floor(Date.now() / 1000) + 3600
+      },
+      config.jwt.secret
+    )
+
+    expect(() => verifyHandoffToken(wrongTypeToken)).toThrow(/type/i)
+  })
+
+  test('rejects an expired token', () => {
+    const expiredToken = jwt.sign(
+      {
+        ...context,
+        type: tokenTypes.SLACK_HANDOFF,
+        exp: Math.floor(Date.now() / 1000) - 60
+      },
+      config.jwt.secret
+    )
+
+    expect(() => verifyHandoffToken(expiredToken)).toThrow()
+  })
+
+  test('rejects a tampered token', () => {
+    const token = mintHandoffToken(context)
+    /* Flip the final signature character to invalidate the HMAC. */
+    const lastChar = token.slice(-1)
+    const swap = lastChar === 'A' ? 'B' : 'A'
+    const tampered = token.slice(0, -1) + swap
+
+    expect(() => verifyHandoffToken(tampered)).toThrow()
+  })
+})


### PR DESCRIPTION
## What is in this PR?

Wires an event-setup bot that runs in Slack and sends the organizer to a dedicated event-creation form in Nextspace. When an organizer asks the bot to set up an event, the bot now replies with a signed link that carries enough Slack context (user, team, channel, thread timestamp) for the form to post the eventual confirmation back into the right Slack thread. This provides a smoother UX and reduces the maintenance overhead for two separate forms in different clients that do the same thing. 

## Changes in the codebase

- New token service that signs the bot's link and verifies it when the form calls back.
- The Slack bot now replies with that link (as a threaded reply on the user's message) instead of running a form in Slack. The token sits in the URL fragment (`#token=...`) so it never reaches the Nextspace server.
- New endpoint `POST /v1/event-setup/plan`. The form sends the organizer's description to it, and the LLM returns a structured plan the form can render.
- Updated Slack platform docs.

## Security notes

The bot posts a signed link in Slack. The signature stops anyone from forging tokens. The link itself is visible to everyone in that Slack channel, and the URL persists in the organizer's browser history. A 60-minute expiry and the token's narrow scope (an LLM call, no data writes) limit the damage someone could do, and the type claim prevents it from being swapped for a different kind of login token.

Putting the token in the URL fragment (after `#`) instead of the query string means browsers never send it to any server, so it stays out of Nextspace's server access logs and the Referer headers on third-party resources the form page might load.

As a follow-up: on the frontend, we plan to strip the token from the URL with `history.replaceState()` after the form reads it, so it doesn't stay in browser history.

## Documentation and automated testing

Did you:
- [x] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [x] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [x] update team documentation of any new or changed environment variables?

## Testing this PR

- [x] Ask Chelsea to add you to the channel with the bot. Ask the bot to set up an event. It should reply in a thread with a link. Click the link (note: the frontend is not wired up yet so you will see a 404 for now).
- [ ] Remove the token  (`#token=<VALUE>`) in that link or change it, it should return a 401

## Additional information

A matching frontend PR will land on `cj/agentic-event-form` in the nextspace repo. Until that ships, the link the bot posts will 404 in the browser. The backend is still fully testable via curl.

New env var: `HANDOFF_TOKEN_EXPIRATION_MINUTES` (default 60).