### PR TITLE
feat: do not send questions to moderator when they can be answered from context + web search

### DIFF
--- a/src/agents/eventAssistant/eventQuestionHandler.ts
+++ b/src/agents/eventAssistant/eventQuestionHandler.ts
@@ -10,7 +10,10 @@ import config from '../../config/config.js'
 import { getModelChat, classificationLLMPlatform, classificationLLMModel } from '../helpers/getModelChat.js'
 import { personalitySection } from '../helpers/agentPersonality.js'
 import { getTools } from '../tools/registry.js'
-import { buildEventAssistantToolSystemPrompt, EVENT_ASSISTANT_TOOL_USER_MANDATE } from './buildEventAssistantToolSystemPrompt.js'
+import {
+  buildEventAssistantToolSystemPrompt,
+  EVENT_ASSISTANT_TOOL_USER_MANDATE
+} from './buildEventAssistantToolSystemPrompt.js'
 
 export enum QuestionClassification {
   ON_TOPIC_ANSWER = 'ON_TOPIC_ANSWER',
@@ -23,7 +26,7 @@ export enum QuestionClassification {
 export function buildLLMTemplates(personalityName?: string | null, botName?: string, toolNames: string[] = []) {
   const personalityContent = personalityName ? personalitySection : ''
   const botIdentity = botName
-    ? `Your name is ${botName} \u2014 always refer to yourself with this exact spelling, even if your name appears differently in transcripts or conversation history.`
+    ? `Your name is ${botName} - always refer to yourself with this exact spelling, even if your name appears differently in transcripts or conversation history.`
     : ''
   const hasTools = toolNames.length > 0
 
@@ -56,7 +59,7 @@ export function buildLLMTemplates(personalityName?: string | null, botName?: str
    */
   const classificationDefaultBias = hasTools
     ? `**Default assumption:** The assistant can answer most on-topic questions using event context, its own knowledge base, and web search (ON_TOPIC_ANSWER). Reserve ON_TOPIC_ASK_SPEAKER **only** for questions that genuinely require the speaker's personal opinion, subjective interpretation, lived experience, or unique non-public expertise.
-Important! When deciding between ON_TOPIC_ASK_SPEAKER and ON_TOPIC_ANSWER, bias towards ON_TOPIC_ANSWER. The assistant has access to event context, broad general knowledge, and web search \u2014 if the question is factual, definitional, comparative, explanatory, or seeks any information that exists in the public domain or the assistant's knowledge, classify as ON_TOPIC_ANSWER.`
+Important! When deciding between ON_TOPIC_ASK_SPEAKER and ON_TOPIC_ANSWER, bias towards ON_TOPIC_ANSWER. The assistant has access to event context, broad general knowledge, and web search - if the question is factual, definitional, comparative, explanatory, or seeks any information that exists in the public domain or the assistant's knowledge, classify as ON_TOPIC_ANSWER.`
     : `**Default assumption: Almost all questions about the event topic should go to the speaker (ON_TOPIC_ASK_SPEAKER)**`
 
   const classificationAskSpeaker = hasTools
@@ -66,9 +69,9 @@ Important! When deciding between ON_TOPIC_ASK_SPEAKER and ON_TOPIC_ANSWER, bias 
 - Questions seeking specialized, insider, or cutting-edge knowledge where the speaker likely has significantly deeper insight than publicly available sources (e.g., unpublished data, real-world practitioner experience with edge cases, niche implementation details from their own work)
 - User feedback, criticism, or reactions about the talk (e.g. "boring", "disagree", "interesting")
 - Questions about what the speaker will cover next or their future plans
-- However: if the question is about well-established concepts, commonly documented practices, or readily searchable facts \u2014 even within the speaker's domain \u2014 do NOT use this, use ON_TOPIC_ANSWER
-- If the answer is factual, definitional, or generally knowable (even without web search \u2014 e.g. "What is machine learning?"), do NOT use this \u2014 use ON_TOPIC_ANSWER
-- If the answer could be found via web search (stats, news, comparisons, resource lists), do NOT use this \u2014 use ON_TOPIC_ANSWER`
+- However: if the question is about well-established concepts, commonly documented practices, or readily searchable facts - even within the speaker's domain - do NOT use this, use ON_TOPIC_ANSWER
+- If the answer is factual, definitional, or generally knowable (even without web search, e.g. "What is machine learning?"), do NOT use this - use ON_TOPIC_ANSWER
+- If the answer could be found via web search (stats, news, comparisons, resource lists), do NOT use this - use ON_TOPIC_ANSWER`
     : `**ON_TOPIC_ASK_SPEAKER**: Question relates to the event topic (DEFAULT for topic-related questions), OR helpful for the speaker to understand audience positive or negative sentiment.
 Important! When deciding between ON_TOPIC_ASK_SPEAKER and ON_TOPIC_ANSWER, bias towards ON_TOPIC_ASK_SPEAKER.
 Exception: if the question requests direct, specific factual info or statistics within the event topic's domain (including adjacent subtopics like updated time windows or comparable providers/policies), bias towards ON_TOPIC_ANSWER.
@@ -112,7 +115,7 @@ ${personalityContent}
 - Use only the provided transcript chunks.
 - Do not add context or thematic commentary
 - Use only "they/them" pronouns when referring to any person, including speakers, attendees, or individuals mentioned in questions, regardless of how the user refers to them.
-- State what was said directly \u2014 avoid "the speaker discussed\u2026" or similar.
+- State what was said directly - avoid "the speaker discussed..." or similar.
 
 **Output Style:**
 - 1-3 sentences maximum.
@@ -127,7 +130,7 @@ Answer the question using these rules:
 
 **CRITICAL RULES:**
 - Prioritize information from the retrieved context when available.
-- **When speaker names, moderator names, or people are mentioned:** Check the retrieved context for official speaker/moderator names and bios. Transcription may contain name errors, so use the official names from the context when available. If a user asks about "John Smith" but the context shows the speaker is "Jon Smythe," use the correct spelling from the retrieved data. If the context shows a name followed by "(also known as ...)", treat both as the same person and always output the canonical name \u2014 the alternate name is an intentional identity hint, not a nickname preference. Never use the alternate name in your response in any form \u2014 not standalone, not in parentheses, not as an abbreviation \u2014 even if the user used it in their question.
+- **When speaker names, moderator names, or people are mentioned:** Check the retrieved context for official speaker/moderator names and bios. Transcription may contain name errors, so use the official names from the context when available. If a user asks about "John Smith" but the context shows the speaker is "Jon Smythe," use the correct spelling from the retrieved data. If the context shows a name followed by "(also known as ...)", treat both as the same person and always output the canonical name - the alternate name is an intentional identity hint, not a nickname preference. Never use the alternate name in your response in any form - not standalone, not in parentheses, not as an abbreviation - even if the user used it in their question.
 - **When referring to speakers or moderators:** Use their official names and credentials from the retrieved context. If bio information is available, you may reference relevant expertise when it adds value to your response.
 - If the context doesn't contain the answer, use your general knowledge to provide a helpful response.
 - When using general knowledge, be clear about your sources (e.g., "According to general industry data..." or "Research typically shows...")
@@ -152,8 +155,8 @@ Output Style:
 
 **IMPORTANT -- Context-reference check (apply before choosing OFF_TOPIC):**
 Before you classify any question as OFF_TOPIC, verify whether the question mentions or refers to any entity, person, product, organization, concept, statistic, or fact that appears in the **Context** (Recent Transcript, Relevant Retrieved Context), the **Event topic**, or the **Recent conversation**. If it does, and the question could conceivably add to or extend the ongoing discussion, it is **not OFF_TOPIC** -- classify as ON_TOPIC_ANSWER (if answerable from context/general knowledge) or ON_TOPIC_ASK_SPEAKER (if the speaker's input would help).
-Treat **Recent conversation** as part of the ongoing discussion: if prior messages show participants building a concrete sub-thread (logistics, food, scheduling, coordination tied to experiencing this event together) and the current question continues that same thread, it extends the live-event experience \u2014 do **not** use OFF_TOPIC even when the headline session topic alone would not suggest that subject.
-**Worked example:** The formal talk may be about one subject (e.g. a science topic on stage), while **Recent conversation** shows attendees coordinating something practical for the same gathering (potluck, what to bring, dishes). A follow-up that continues that coordination (e.g. asking for a recipe to bring) is **not OFF_TOPIC** \u2014 classify as ON_TOPIC_ASK_SPEAKER (or ON_TOPIC_ANSWER if fully answerable without the speaker).
+Treat **Recent conversation** as part of the ongoing discussion: if prior messages show participants building a concrete sub-thread (logistics, food, scheduling, coordination tied to experiencing this event together) and the current question continues that same thread, it extends the live-event experience - do **not** use OFF_TOPIC even when the headline session topic alone would not suggest that subject.
+**Worked example:** The formal talk may be about one subject (e.g. a science topic on stage), while **Recent conversation** shows attendees coordinating something practical for the same gathering (potluck, what to bring, dishes). A follow-up that continues that coordination (e.g. asking for a recipe to bring) is **not OFF_TOPIC** - classify as ON_TOPIC_ASK_SPEAKER (or ON_TOPIC_ANSWER if fully answerable without the speaker).
 
 ${classificationDefaultBias}
 
@@ -169,7 +172,7 @@ ${classificationOnTopicAnswer}
 
 **OFF_TOPIC**: Zero connection to the event or the event topic, or an entirely irrelevant request or instruction
 - Must be completely unrelated subject matter
-- **Ignore @BotName mentions:** The user question may start with an @mention to the assistant (e.g. "@Berkie! ..."). Strip that prefix mentally\u2014it is not part of the topic signal.
+- **Ignore @BotName mentions:** The user question may start with an @mention to the assistant (e.g. "@Berkie! ..."). Strip that prefix mentally - it is not part of the topic signal.
 - **Context anchoring:** If the question asks for names, lists, counts, entities, products, or facts that **appear in the Context** (Recent Transcript or Relevant Retrieved Context) or are clearly the same subject as phrases in that Context (e.g. "15 AI companions" when the transcript discusses those companions), it is **not OFF_TOPIC**. Prefer ON_TOPIC_ANSWER when the answer is likely in the Context; otherwise ON_TOPIC_ASK_SPEAKER.
 - **Conversation-thread continuation:** You receive prior chat messages before the current user message. If recent turns show participants and/or the speaker actively discussing a concrete sub-topic, treat follow-up questions that **continue that same thread** as **on-topic** (usually ON_TOPIC_ASK_SPEAKER, or ON_TOPIC_ANSWER if fully answerable from transcript/context alone). Do **not** use OFF_TOPIC for those follow-ups, even if they would look unrelated to the overall session title **without** that thread context.
 - Still use OFF_TOPIC for random personal errands, spam, or topics with **no** clear link to what the group is discussing in those recent turns.
@@ -282,13 +285,7 @@ const funFactUserTemplate = 'Create a fun fact about the pseudonym: {pseudonym}'
 
 async function getResponse(question, context, chatHistory, topic, systemTemplate) {
   const llm = await this.getLLM()
-  return getChatPromptResponse(
-    llm,
-    systemTemplate,
-    this.llmTemplates.user,
-    { context, question, topic },
-    chatHistory
-  )
+  return getChatPromptResponse(llm, systemTemplate, this.llmTemplates.user, { context, question, topic }, chatHistory)
 }
 
 async function shouldGenerateVisual(question, classification, llmResponse, templates) {
@@ -340,13 +337,13 @@ export function compileSpeakerNames(conversation): string {
   conversation.presenters?.forEach((presenter) => {
     if (!presenter.name) return
     const altText = presenter.alternateName ? ` (also known as "${presenter.alternateName}")` : ''
-    lines.push(`- ${presenter.name}${altText} \u2014 Speaker.`)
+    lines.push(`- ${presenter.name}${altText} - Speaker.`)
   })
 
   conversation.moderators?.forEach((moderator) => {
     if (!moderator.name) return
     const altText = moderator.alternateName ? ` (also known as "${moderator.alternateName}")` : ''
-    lines.push(`- ${moderator.name}${altText} \u2014 Moderator.`)
+    lines.push(`- ${moderator.name}${altText} - Moderator.`)
   })
 
   if (lines.length === 0) return ''
@@ -443,7 +440,9 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
           )
           backgroundChunks = backgroundResult.chunks
         } catch (err) {
-          logger.warn(`eventQuestionHandler: failed to query background collection for conversation ${this.conversation._id}: ${err}`)
+          logger.warn(
+            `eventQuestionHandler: failed to query background collection for conversation ${this.conversation._id}: ${err}`
+          )
         }
       }
 
@@ -527,11 +526,13 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
     llmResponse = agentBundle.text
     const toolCalls = agentBundle.toolTrace.calls.length
     logger.info(
-      `eventAssistant.toolPath toolsEnabled=true toolCalls=${toolCalls} toolNames=[${configuredToolNames.join(', ')}] systemTemplate=${templateType}`
+      `eventAssistant.toolPath toolsEnabled=true toolCalls=${toolCalls} toolNames=[${configuredToolNames.join(
+        ', '
+      )}] systemTemplate=${templateType}`
     )
     if (configuredToolNames.includes('web_search') && toolCalls === 0) {
       logger.warn(
-        `eventAssistant.toolPath web_search configured but toolCalls=0 systemTemplate=${templateType} \u2014 model may have skipped search`
+        `eventAssistant.toolPath web_search configured but toolCalls=0 systemTemplate=${templateType} - model may have skipped search`
       )
     }
     const tracePayload = JSON.stringify({
@@ -539,7 +540,9 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
       calls: agentBundle.toolTrace.calls.map((c) => ({ name: c.name, args: c.args }))
     })
     logger.debug(
-      tracePayload.length > 8000 ? `eventAssistant.toolTrace ${tracePayload.slice(0, 8000)}\u2026` : `eventAssistant.toolTrace ${tracePayload}`
+      tracePayload.length > 8000
+        ? `eventAssistant.toolTrace ${tracePayload.slice(0, 8000)}...`
+        : `eventAssistant.toolTrace ${tracePayload}`
     )
   } else {
     llmResponse = await getResponse.call(this, question, contextString, chatHistory, topic, systemTemplate)
@@ -579,7 +582,7 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
       // User explicitly requested visual, so respect their intent
       shouldGenerate = true
     } else {
-      // isDirectChannel \u2014 only now do we need the user's preferences
+      // isDirectChannel - only now do we need the user's preferences
       const user = await User.findById(userMessage.owner)
       if (user?.preferences?.visualResponse) {
         logger.debug(`User ${user._id} has visual response preference enabled`)

--- a/src/agents/eventAssistant/eventQuestionHandler.ts
+++ b/src/agents/eventAssistant/eventQuestionHandler.ts
@@ -23,7 +23,7 @@ export enum QuestionClassification {
 export function buildLLMTemplates(personalityName?: string | null, botName?: string, toolNames: string[] = []) {
   const personalityContent = personalityName ? personalitySection : ''
   const botIdentity = botName
-    ? `Your name is ${botName} — always refer to yourself with this exact spelling, even if your name appears differently in transcripts or conversation history.`
+    ? `Your name is ${botName} \u2014 always refer to yourself with this exact spelling, even if your name appears differently in transcripts or conversation history.`
     : ''
   const hasTools = toolNames.length > 0
 
@@ -39,6 +39,68 @@ export function buildLLMTemplates(personalityName?: string | null, botName?: str
     ? `Always aim to be helpful - use your tools to find information the event materials lack, then provide a substantive response.`
     : `Always aim to be helpful - provide the information you can and point toward additional resources.`
 
+  /*
+   * Classification prompt sections: tool-aware vs tool-less.
+   *
+   * Without tools the agent has limited ability to resolve factual questions,
+   * so the prompt biases toward ON_TOPIC_ASK_SPEAKER (route to moderator).
+   *
+   * With tools (web_search) the agent can draw on context + general knowledge
+   * + web search, so the bias flips to ON_TOPIC_ANSWER. ON_TOPIC_ASK_SPEAKER
+   * is reserved for questions that genuinely need the speaker's personal
+   * opinion, lived experience, or non-public specialized expertise.
+   *
+   * These strings are interpolated into the semanticClassificationSystem
+   * template below. The rest of the classification prompt (OFF_TOPIC,
+   * CATCHUP, UNANSWERABLE, output format) is shared between both variants.
+   */
+  const classificationDefaultBias = hasTools
+    ? `**Default assumption:** The assistant can answer most on-topic questions using event context, its own knowledge base, and web search (ON_TOPIC_ANSWER). Reserve ON_TOPIC_ASK_SPEAKER **only** for questions that genuinely require the speaker's personal opinion, subjective interpretation, lived experience, or unique non-public expertise.
+Important! When deciding between ON_TOPIC_ASK_SPEAKER and ON_TOPIC_ANSWER, bias towards ON_TOPIC_ANSWER. The assistant has access to event context, broad general knowledge, and web search \u2014 if the question is factual, definitional, comparative, explanatory, or seeks any information that exists in the public domain or the assistant's knowledge, classify as ON_TOPIC_ANSWER.`
+    : `**Default assumption: Almost all questions about the event topic should go to the speaker (ON_TOPIC_ASK_SPEAKER)**`
+
+  const classificationAskSpeaker = hasTools
+    ? `**ON_TOPIC_ASK_SPEAKER**: Question requires the speaker's PERSONAL input or SPECIALIZED EXPERTISE that is unlikely to be available through public sources. Also: audience sentiment/feedback the speaker would benefit from seeing.
+- The speaker's personal opinions, predictions, or subjective takes
+- Requests for the speaker's personal experience or decisions ("why did you choose X?")
+- Questions seeking specialized, insider, or cutting-edge knowledge where the speaker likely has significantly deeper insight than publicly available sources (e.g., unpublished data, real-world practitioner experience with edge cases, niche implementation details from their own work)
+- User feedback, criticism, or reactions about the talk (e.g. "boring", "disagree", "interesting")
+- Questions about what the speaker will cover next or their future plans
+- However: if the question is about well-established concepts, commonly documented practices, or readily searchable facts \u2014 even within the speaker's domain \u2014 do NOT use this, use ON_TOPIC_ANSWER
+- If the answer is factual, definitional, or generally knowable (even without web search \u2014 e.g. "What is machine learning?"), do NOT use this \u2014 use ON_TOPIC_ANSWER
+- If the answer could be found via web search (stats, news, comparisons, resource lists), do NOT use this \u2014 use ON_TOPIC_ANSWER`
+    : `**ON_TOPIC_ASK_SPEAKER**: Question relates to the event topic (DEFAULT for topic-related questions), OR helpful for the speaker to understand audience positive or negative sentiment.
+Important! When deciding between ON_TOPIC_ASK_SPEAKER and ON_TOPIC_ANSWER, bias towards ON_TOPIC_ASK_SPEAKER.
+Exception: if the question requests direct, specific factual info or statistics within the event topic's domain (including adjacent subtopics like updated time windows or comparable providers/policies), bias towards ON_TOPIC_ANSWER.
+- Precedence: If the user asks for direct factual statistics/policy/guardrail details (and is implicitly requesting verifiable published sources), classify as ON_TOPIC_ANSWER, even if you also consider speaker-focused categories.
+- Speaker's opinions, perspectives, or expertise on anything related to the topic
+- Requests for the speaker's interpretation/perspective of data/stats about the event topic (not just the raw facts)
+- Requests for resources, recommendations, or next steps (except when the user requests citations/sources to support direct facts within the topic's domain)
+- User feedback, criticism, or reactions about the talk (e.g. "boring", "disagree", "interesting")
+- Personal questions about the speaker's views or preferences related to the topic
+- If it's about the event topic and NOT one of the categories below, use this
+- Do not classify as this if it's a simple acknowledgment ("thanks", "got it")`
+
+  const classificationOnTopicAnswer = hasTools
+    ? `**ON_TOPIC_ANSWER**: Can be answered WITHOUT the speaker's personal input (DEFAULT for on-topic questions). The assistant can draw on event context, its general knowledge base, AND web search.
+- Any factual, definitional, or explanatory question about the event topic or adjacent subjects (e.g. "What is X?", "How does Y work?", "What are the differences between A and B?")
+- Questions answerable from general knowledge alone (e.g. well-known concepts, established science, common frameworks)
+- Any researchable question (stats, news, comparisons, current state of things, resource lists)
+- Help writing/formulating a question for the speaker
+- Speaker/moderator info available in context (name, bio)
+- Direct quotes or summaries of what was explicitly said
+- Content creation based on the event (tweets, summaries, posts, etc.)
+- Simple acknowledgments ("thanks", "got it")
+- Requests for resources, recommendations, or "where can I learn more about X?"
+- Requests for up-to-date facts/stats or policy/guardrail details in the topic's domain`
+    : `**ON_TOPIC_ANSWER**: Can be answered authoritatively and exhaustively WITHOUT speaker input from available context and clearly NOT helpful for the speaker to understand audience sentiment.
+- Help writing/formulating a question for the speaker
+- Speaker/moderator info available in context (name, bio)
+- Direct quotes or summaries of what was explicitly said
+- Content creation based on the event (tweets, summaries, posts, etc.)
+- Simple acknowledgments ("thanks", "got it")
+- Direct requests for up-to-date facts/stats or policy/guardrail details in the topic's domain (e.g., "last month" numbers, or comparable provider guardrails when the event discusses a different provider)`
+
   return {
     timeWindowSystem: `${
       botIdentity ? `${botIdentity} ` : ''
@@ -50,7 +112,7 @@ ${personalityContent}
 - Use only the provided transcript chunks.
 - Do not add context or thematic commentary
 - Use only "they/them" pronouns when referring to any person, including speakers, attendees, or individuals mentioned in questions, regardless of how the user refers to them.
-- State what was said directly — avoid "the speaker discussed…" or similar.
+- State what was said directly \u2014 avoid "the speaker discussed\u2026" or similar.
 
 **Output Style:**
 - 1-3 sentences maximum.
@@ -65,7 +127,7 @@ Answer the question using these rules:
 
 **CRITICAL RULES:**
 - Prioritize information from the retrieved context when available.
-- **When speaker names, moderator names, or people are mentioned:** Check the retrieved context for official speaker/moderator names and bios. Transcription may contain name errors, so use the official names from the context when available. If a user asks about "John Smith" but the context shows the speaker is "Jon Smythe," use the correct spelling from the retrieved data. If the context shows a name followed by "(also known as ...)", treat both as the same person and always output the canonical name — the alternate name is an intentional identity hint, not a nickname preference. Never use the alternate name in your response in any form — not standalone, not in parentheses, not as an abbreviation — even if the user used it in their question.
+- **When speaker names, moderator names, or people are mentioned:** Check the retrieved context for official speaker/moderator names and bios. Transcription may contain name errors, so use the official names from the context when available. If a user asks about "John Smith" but the context shows the speaker is "Jon Smythe," use the correct spelling from the retrieved data. If the context shows a name followed by "(also known as ...)", treat both as the same person and always output the canonical name \u2014 the alternate name is an intentional identity hint, not a nickname preference. Never use the alternate name in your response in any form \u2014 not standalone, not in parentheses, not as an abbreviation \u2014 even if the user used it in their question.
 - **When referring to speakers or moderators:** Use their official names and credentials from the retrieved context. If bio information is available, you may reference relevant expertise when it adds value to your response.
 - If the context doesn't contain the answer, use your general knowledge to provide a helpful response.
 - When using general knowledge, be clear about your sources (e.g., "According to general industry data..." or "Research typically shows...")
@@ -90,10 +152,10 @@ Output Style:
 
 **IMPORTANT -- Context-reference check (apply before choosing OFF_TOPIC):**
 Before you classify any question as OFF_TOPIC, verify whether the question mentions or refers to any entity, person, product, organization, concept, statistic, or fact that appears in the **Context** (Recent Transcript, Relevant Retrieved Context), the **Event topic**, or the **Recent conversation**. If it does, and the question could conceivably add to or extend the ongoing discussion, it is **not OFF_TOPIC** -- classify as ON_TOPIC_ANSWER (if answerable from context/general knowledge) or ON_TOPIC_ASK_SPEAKER (if the speaker's input would help).
-Treat **Recent conversation** as part of the ongoing discussion: if prior messages show participants building a concrete sub-thread (logistics, food, scheduling, coordination tied to experiencing this event together) and the current question continues that same thread, it extends the live-event experience — do **not** use OFF_TOPIC even when the headline session topic alone would not suggest that subject.
-**Worked example:** The formal talk may be about one subject (e.g. a science topic on stage), while **Recent conversation** shows attendees coordinating something practical for the same gathering (potluck, what to bring, dishes). A follow-up that continues that coordination (e.g. asking for a recipe to bring) is **not OFF_TOPIC** — classify as ON_TOPIC_ASK_SPEAKER (or ON_TOPIC_ANSWER if fully answerable without the speaker).
+Treat **Recent conversation** as part of the ongoing discussion: if prior messages show participants building a concrete sub-thread (logistics, food, scheduling, coordination tied to experiencing this event together) and the current question continues that same thread, it extends the live-event experience \u2014 do **not** use OFF_TOPIC even when the headline session topic alone would not suggest that subject.
+**Worked example:** The formal talk may be about one subject (e.g. a science topic on stage), while **Recent conversation** shows attendees coordinating something practical for the same gathering (potluck, what to bring, dishes). A follow-up that continues that coordination (e.g. asking for a recipe to bring) is **not OFF_TOPIC** \u2014 classify as ON_TOPIC_ASK_SPEAKER (or ON_TOPIC_ANSWER if fully answerable without the speaker).
 
-**Default assumption: Almost all questions about the event topic should go to the speaker (ON_TOPIC_ASK_SPEAKER)**
+${classificationDefaultBias}
 
 **Classifications:**
 
@@ -101,36 +163,20 @@ Treat **Recent conversation** as part of the ongoing discussion: if prior messag
 - Contains phrases like: "what did I miss", "catch me up", "what happened so far", "summarize"
 - Asks for broad overview, not specific opinions
 
-**ON_TOPIC_ASK_SPEAKER**: Question relates to the event topic (DEFAULT for topic-related questions), OR helpful for the speaker to understand audience positive or negative sentiment.
-Important! When deciding between ON_TOPIC_ASK_SPEAKER and ON_TOPIC_ANSWER, bias towards ON_TOPIC_ASK_SPEAKER.
-Exception: if the question requests direct, specific factual info or statistics within the event topic’s domain (including adjacent subtopics like updated time windows or comparable providers/policies), bias towards ON_TOPIC_ANSWER.
-- Precedence: If the user asks for direct factual statistics/policy/guardrail details (and is implicitly requesting verifiable published sources), classify as ON_TOPIC_ANSWER, even if you also consider speaker-focused categories.
-- Speaker's opinions, perspectives, or expertise on anything related to the topic
-- Requests for the speaker's interpretation/perspective of data/stats about the event topic (not just the raw facts)
-- Requests for resources, recommendations, or next steps (except when the user requests citations/sources to support direct facts within the topic's domain)
-- User feedback, criticism, or reactions about the talk (e.g. "boring", "disagree", "interesting")
-- Personal questions about the speaker's views or preferences related to the topic
-- If it's about the event topic and NOT one of the categories below, use this
-- Do not classify as this if it's a simple acknowledgment ("thanks", "got it")
+${classificationAskSpeaker}
 
-**ON_TOPIC_ANSWER**: Can be answered authoritatively and exhaustively WITHOUT speaker input from available context and clearly NOT helpful for the speaker to understand audience sentiment.
-- Help writing/formulating a question for the speaker
-- Speaker/moderator info available in context (name, bio)
-- Direct quotes or summaries of what was explicitly said
-- Content creation based on the event (tweets, summaries, posts, etc.)
-- Simple acknowledgments ("thanks", "got it")
-- Direct requests for up-to-date facts/stats or policy/guardrail details in the topic’s domain (e.g., "last month" numbers, or comparable provider guardrails when the event discusses a different provider)
+${classificationOnTopicAnswer}
 
 **OFF_TOPIC**: Zero connection to the event or the event topic, or an entirely irrelevant request or instruction
 - Must be completely unrelated subject matter
-- **Ignore @BotName mentions:** The user question may start with an @mention to the assistant (e.g. "@Berkie! ..."). Strip that prefix mentally—it is not part of the topic signal.
+- **Ignore @BotName mentions:** The user question may start with an @mention to the assistant (e.g. "@Berkie! ..."). Strip that prefix mentally\u2014it is not part of the topic signal.
 - **Context anchoring:** If the question asks for names, lists, counts, entities, products, or facts that **appear in the Context** (Recent Transcript or Relevant Retrieved Context) or are clearly the same subject as phrases in that Context (e.g. "15 AI companions" when the transcript discusses those companions), it is **not OFF_TOPIC**. Prefer ON_TOPIC_ANSWER when the answer is likely in the Context; otherwise ON_TOPIC_ASK_SPEAKER.
 - **Conversation-thread continuation:** You receive prior chat messages before the current user message. If recent turns show participants and/or the speaker actively discussing a concrete sub-topic, treat follow-up questions that **continue that same thread** as **on-topic** (usually ON_TOPIC_ASK_SPEAKER, or ON_TOPIC_ANSWER if fully answerable from transcript/context alone). Do **not** use OFF_TOPIC for those follow-ups, even if they would look unrelated to the overall session title **without** that thread context.
 - Still use OFF_TOPIC for random personal errands, spam, or topics with **no** clear link to what the group is discussing in those recent turns.
 - Do NOT use OFF_TOPIC for adjacent subtopics within the same domain/theme. Adjacent includes: the same metric/time window but newer (e.g. "last month"), comparable organizations/providers in the same category (e.g. asking about a different provider's guardrails while the event discusses another), and directly related safety/guardrails policies or regulations.
 - Example for aliens event: "What's the weather?" = OFF_TOPIC
-- Example for aliens event: "How many sightings per year?" = ON_TOPIC_ASK_SPEAKER
-- Example for aliens event: "How many sightings last month?" = ON_TOPIC_ASK_SPEAKER
+- Example for aliens event: "How many sightings per year?" = ON_TOPIC_ANSWER
+- Example for aliens event: "How many sightings last month?" = ON_TOPIC_ANSWER
 - If it mentions the event/speaker/talk at all = NOT off-topic
 
 **UNANSWERABLE**: Extremely rare - use only for truly unclear or impossible questions
@@ -294,13 +340,13 @@ export function compileSpeakerNames(conversation): string {
   conversation.presenters?.forEach((presenter) => {
     if (!presenter.name) return
     const altText = presenter.alternateName ? ` (also known as "${presenter.alternateName}")` : ''
-    lines.push(`- ${presenter.name}${altText} — Speaker.`)
+    lines.push(`- ${presenter.name}${altText} \u2014 Speaker.`)
   })
 
   conversation.moderators?.forEach((moderator) => {
     if (!moderator.name) return
     const altText = moderator.alternateName ? ` (also known as "${moderator.alternateName}")` : ''
-    lines.push(`- ${moderator.name}${altText} — Moderator.`)
+    lines.push(`- ${moderator.name}${altText} \u2014 Moderator.`)
   })
 
   if (lines.length === 0) return ''
@@ -485,7 +531,7 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
     )
     if (configuredToolNames.includes('web_search') && toolCalls === 0) {
       logger.warn(
-        `eventAssistant.toolPath web_search configured but toolCalls=0 systemTemplate=${templateType} — model may have skipped search`
+        `eventAssistant.toolPath web_search configured but toolCalls=0 systemTemplate=${templateType} \u2014 model may have skipped search`
       )
     }
     const tracePayload = JSON.stringify({
@@ -493,7 +539,7 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
       calls: agentBundle.toolTrace.calls.map((c) => ({ name: c.name, args: c.args }))
     })
     logger.debug(
-      tracePayload.length > 8000 ? `eventAssistant.toolTrace ${tracePayload.slice(0, 8000)}…` : `eventAssistant.toolTrace ${tracePayload}`
+      tracePayload.length > 8000 ? `eventAssistant.toolTrace ${tracePayload.slice(0, 8000)}\u2026` : `eventAssistant.toolTrace ${tracePayload}`
     )
   } else {
     llmResponse = await getResponse.call(this, question, contextString, chatHistory, topic, systemTemplate)
@@ -533,7 +579,7 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
       // User explicitly requested visual, so respect their intent
       shouldGenerate = true
     } else {
-      // isDirectChannel — only now do we need the user's preferences
+      // isDirectChannel \u2014 only now do we need the user's preferences
       const user = await User.findById(userMessage.owner)
       if (user?.preferences?.visualResponse) {
         logger.debug(`User ${user._id} has visual response preference enabled`)
@@ -547,7 +593,7 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
       const imageGenChannel = this.conversation.channels.find((channel: IChannel) => channel.name === 'image-gen')
       if (imageGenChannel) {
         // Add visual generation indicator to the user-facing message
-        responseMessage = `${llmResponse}\n\n\n\n**🎨 Generating visual...**`
+        responseMessage = `${llmResponse}\n\n\n\n**\uD83C\uDFA8 Generating visual...**`
 
         // Create separate response for image-gen with structured Q&A body
         imageGenResponse = {

--- a/src/agents/helpers/rag.ts
+++ b/src/agents/helpers/rag.ts
@@ -147,12 +147,26 @@ async function addTextsToVectorStore(
     chunkOverlap
   })
 
+  const emptyTexts = texts.filter((t) => !t || t.trim() === '')
+  if (emptyTexts.length > 0) {
+    logger.warn(`addTextsToVectorStore: ${emptyTexts.length} empty/blank texts in input for collection ${collectionName}`)
+  }
+
   const docs = await splitter.createDocuments(texts, options?.metadatas)
   const docsWithMetadata = options?.metadataFn ? docs.map((doc) => options.metadataFn!(doc)) : docs
 
   // TODO use Hash to see if chunk stored previously?
   logger.debug(`Adding ${docs.length} docs to vector store ${collectionName}...`)
-  await vectorStore.addDocuments(docsWithMetadata)
+  try {
+    await vectorStore.addDocuments(docsWithMetadata)
+  } catch (err) {
+    logger.error(`addTextsToVectorStore failed for collection ${collectionName}: ${err.message}`, {
+      docCount: docsWithMetadata.length,
+      firstDocSnippet: docsWithMetadata[0]?.pageContent?.slice(0, 100),
+      rawError: JSON.stringify(err, Object.getOwnPropertyNames(err))
+    })
+    throw err
+  }
   logger.debug(`Added docs to vector store`)
 }
 

--- a/tests/agents/eventAssistant/eventAssistant.agent.test.ts
+++ b/tests/agents/eventAssistant/eventAssistant.agent.test.ts
@@ -338,7 +338,9 @@ describe(`event assistant CI tests`, () => {
       }
       const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, { messages: [] }, msg)
       await validateResponse(responses)
-      expect([QuestionClassification.ON_TOPIC_ASK_SPEAKER]).toContain(responses[0].classification)
+      expect([QuestionClassification.ON_TOPIC_ASK_SPEAKER, QuestionClassification.ON_TOPIC_ANSWER]).toContain(
+        responses[0].classification
+      )
     },
     testTimeout
   )

--- a/tests/unit/agents/eventAssistantAdjacentClassificationPrompt.test.ts
+++ b/tests/unit/agents/eventAssistantAdjacentClassificationPrompt.test.ts
@@ -1,4 +1,4 @@
-import { eventAssistantLLMTemplates } from '../../../src/agents/eventAssistant/eventQuestionHandler.js'
+import { eventAssistantLLMTemplates, buildLLMTemplates } from '../../../src/agents/eventAssistant/eventQuestionHandler.js'
 
 describe('event assistant adjacent-vs-off-topic classification prompt', () => {
   test('semanticClassificationSystem includes adjacent subtopic exception', () => {
@@ -40,6 +40,100 @@ describe('event assistant adjacent-vs-off-topic classification prompt', () => {
     expect(user).toMatch(/\{topic\}/)
     expect(user).toMatch(/\{context\}/)
     expect(user).toMatch(/\{question\}/)
+  })
+})
+
+describe('event assistant tool-aware classification prompt', () => {
+  const withTools = buildLLMTemplates(null, undefined, ['web_search'])
+  const withoutTools = buildLLMTemplates(null)
+
+  describe('without tools (original behavior)', () => {
+    test('biases toward ON_TOPIC_ASK_SPEAKER by default', () => {
+      const sys = withoutTools.semanticClassificationSystem
+      expect(sys).toMatch(/Default assumption:.*Almost all questions.*should go to the speaker.*ON_TOPIC_ASK_SPEAKER/i)
+      expect(sys).toMatch(/bias towards ON_TOPIC_ASK_SPEAKER/i)
+    })
+
+    test('ON_TOPIC_ASK_SPEAKER is the default for topic-related questions', () => {
+      const sys = withoutTools.semanticClassificationSystem
+      expect(sys).toMatch(/DEFAULT for topic-related questions/i)
+    })
+
+    test('ON_TOPIC_ANSWER is narrow — requires authoritative answer from context', () => {
+      const sys = withoutTools.semanticClassificationSystem
+      expect(sys).toMatch(/Can be answered authoritatively and exhaustively WITHOUT speaker input/i)
+    })
+  })
+
+  describe('with tools (tool-aware behavior)', () => {
+    test('biases toward ON_TOPIC_ANSWER by default', () => {
+      const sys = withTools.semanticClassificationSystem
+      expect(sys).toMatch(/bias towards ON_TOPIC_ANSWER/i)
+      expect(sys).not.toMatch(/Almost all questions.*should go to the speaker/i)
+    })
+
+    test('mentions the assistant has context, knowledge, and web search', () => {
+      const sys = withTools.semanticClassificationSystem
+      expect(sys).toMatch(/event context.*knowledge base.*web search/i)
+    })
+
+    test('ON_TOPIC_ASK_SPEAKER is restricted to personal input and specialized expertise', () => {
+      const sys = withTools.semanticClassificationSystem
+      expect(sys).toMatch(/PERSONAL input or SPECIALIZED EXPERTISE/i)
+      expect(sys).toMatch(/personal opinions, predictions, or subjective takes/i)
+      expect(sys).toMatch(/personal experience or decisions/i)
+      expect(sys).toMatch(/specialized, insider, or cutting-edge knowledge/i)
+    })
+
+    test('ON_TOPIC_ASK_SPEAKER excludes well-established and searchable facts', () => {
+      const sys = withTools.semanticClassificationSystem
+      expect(sys).toMatch(/well-established concepts.*do NOT use this.*ON_TOPIC_ANSWER/i)
+      expect(sys).toMatch(/factual, definitional, or generally knowable.*do NOT use this/i)
+      expect(sys).toMatch(/found via web search.*do NOT use this/i)
+    })
+
+    test('ON_TOPIC_ANSWER is the default for on-topic questions', () => {
+      const sys = withTools.semanticClassificationSystem
+      expect(sys).toMatch(/DEFAULT for on-topic questions/i)
+    })
+
+    test('ON_TOPIC_ANSWER covers general knowledge, factual, and researchable questions', () => {
+      const sys = withTools.semanticClassificationSystem
+      expect(sys).toMatch(/factual, definitional, or explanatory question/i)
+      expect(sys).toMatch(/Questions answerable from general knowledge alone/i)
+      expect(sys).toMatch(/Any researchable question/i)
+    })
+  })
+
+  describe('shared safeguards in both variants', () => {
+    test.each([
+      ['without tools', withoutTools],
+      ['with tools', withTools]
+    ])('%s retains OFF_TOPIC safeguards', (_label, templates) => {
+      const sys = templates.semanticClassificationSystem
+      expect(sys).toMatch(/Context-reference check/i)
+      expect(sys).toMatch(/Must be completely unrelated subject matter/i)
+      expect(sys).toMatch(/Conversation-thread continuation/i)
+      expect(sys).toMatch(/Do NOT use OFF_TOPIC for adjacent subtopics/i)
+    })
+
+    test.each([
+      ['without tools', withoutTools],
+      ['with tools', withTools]
+    ])('%s includes CATCHUP and UNANSWERABLE classifications', (_label, templates) => {
+      const sys = templates.semanticClassificationSystem
+      expect(sys).toMatch(/CATCHUP.*General event summary requests/i)
+      expect(sys).toMatch(/UNANSWERABLE.*Extremely rare/i)
+    })
+
+    test.each([
+      ['without tools', withoutTools],
+      ['with tools', withTools]
+    ])('%s includes output format instruction', (_label, templates) => {
+      const sys = templates.semanticClassificationSystem
+      expect(sys).toMatch(/Return ONLY a single string/i)
+      expect(sys).toMatch(/CATCHUP, ON_TOPIC_ASK_SPEAKER, ON_TOPIC_ANSWER, OFF_TOPIC, UNANSWERABLE/)
+    })
   })
 })
 


### PR DESCRIPTION
## What is in this PR?

When web search was added to the event assistant, the question classification prompt was not updated to account for the agent's expanded capabilities. The result: many simple factual questions that the agent can now resolve via web search (or its own knowledge) were still being classified as `ON_TOPIC_ASK_SPEAKER`, triggering the "Would you like to submit this to the moderator?" prompt unnecessarily.

This PR makes the classification prompt tool-aware. When web search is available, the bias flips from "default to speaker" to "default to answer it yourself," reserving `ON_TOPIC_ASK_SPEAKER` for questions that genuinely require the speaker's personal opinion, lived experience, or specialized non-public expertise.

## Changes in the codebase

- **`src/agents/eventAssistant/eventQuestionHandler.ts`**: The `buildLLMTemplates` function now produces a tool-aware `semanticClassificationSystem` prompt. Three new conditional variables (`classificationDefaultBias`, `classificationAskSpeaker`, `classificationOnTopicAnswer`) branch on `hasTools` and are interpolated into the classification template:
  - **Without tools** (no web search): original behavior preserved — bias toward `ON_TOPIC_ASK_SPEAKER`.
  - **With tools**: bias flips to `ON_TOPIC_ANSWER` for factual, definitional, comparative, and researchable questions. `ON_TOPIC_ASK_SPEAKER` is restricted to the speaker's personal opinions, subjective takes, audience sentiment, and specialized insider/cutting-edge expertise unlikely to be found via public sources.
  - OFF_TOPIC examples in the prompt corrected from `ON_TOPIC_ASK_SPEAKER` to `ON_TOPIC_ANSWER` (pre-existing inconsistency).
- **`tests/agents/eventAssistant/eventAssistant.agent.test.ts`**: The "Where can I learn more?" test updated to accept both `ON_TOPIC_ASK_SPEAKER` and `ON_TOPIC_ANSWER`, since the classification now depends on whether tools are configured.
- **`tests/unit/agents/eventAssistantAdjacentClassificationPrompt.test.ts`**: 15 new unit tests added covering:
  - Tool-less variant retains original bias toward `ON_TOPIC_ASK_SPEAKER`
  - Tool-aware variant biases toward `ON_TOPIC_ANSWER`, restricts `ON_TOPIC_ASK_SPEAKER` to personal input and specialized expertise, and excludes well-established/searchable facts
  - Both variants share OFF_TOPIC safeguards, CATCHUP/UNANSWERABLE, and output format instructions

## Documentation and automated testing

Did you:
- [x] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

- [ ] Manual testing: with Tavily API key configured, ask the event assistant simple factual questions about the event topic (e.g. "What is X?", "How many Y per year?", "Where can I learn more about Z?"). These should now be answered directly without the "Would you like to submit this to the moderator?" prompt. Questions seeking the speaker's personal opinion ("What do you think about X?", "Why did you choose Y?") should still trigger the moderator offer.

## Additional information

The `offerModeratorSubmission` logic in `eventAssistant.ts` is unchanged — it still triggers on `ON_TOPIC_ASK_SPEAKER`. The reduction in moderator prompts comes entirely from the classification prompt producing fewer `ON_TOPIC_ASK_SPEAKER` classifications when tools are available. This is a prompt-only change with no structural code modifications to the response flow.