### PR TITLE
enable jargon and visual preferences by default, disable for zoom users

### DIFF
--- a/src/adapters/zoom.ts
+++ b/src/adapters/zoom.ts
@@ -6,6 +6,7 @@ import { Direction } from '../types/index.types.js'
 import Message from '../models/message.model.js'
 
 const defaultBotName = 'LLM Engine'
+const defaultPreferences = { visualResponse: false, jargonClarification: false }
 const defaultRetention = {
   type: 'timed',
   hours: 168 // 1 week
@@ -147,7 +148,7 @@ async function processTranscript(msgChunks, participantName) {
       message: msgChunk.text,
       source: { type: 'zoom' },
       createdAt: new Date(msgChunk.end_timestamp.absolute),
-      user: { username: participantName }
+      user: { username: participantName, defaultPreferences }
     })
   }
   return msgs
@@ -160,7 +161,7 @@ async function receiveGroupChatMessage(data) {
     channels: this.chatChannels.filter(
       (channel) => channel.direction === Direction.INCOMING || channel.direction === Direction.BOTH
     ),
-    user: { username: data.data.participant.name }
+    user: { username: data.data.participant.name, defaultPreferences }
   }
   return [msg]
 }
@@ -172,7 +173,7 @@ async function receiveDirectMesssage(data) {
     channels: this.dmChannels.filter(
       (channel) => channel.direction === Direction.INCOMING || channel.direction === Direction.BOTH
     ),
-    user: { username: data.data.participant.name, dmConfig: { to: data.data.participant.id } }
+    user: { username: data.data.participant.name, dmConfig: { to: data.data.participant.id }, defaultPreferences }
   }
   return [msg]
 }
@@ -404,7 +405,8 @@ export default {
       const adapterUser: AdapterUser = {
         username: participant.name,
         dmConfig: { to: participant.id },
-        isHost: participant.is_host ?? false
+        isHost: participant.is_host ?? false,
+        defaultPreferences
       }
       return adapterUser
     }
@@ -420,7 +422,8 @@ export default {
       const adapterUser: AdapterUser = {
         username: participant.name,
         dmConfig: { to: participant.id },
-        isHost: participant.is_host ?? false
+        isHost: participant.is_host ?? false,
+        defaultPreferences
       }
       return adapterUser
     }

--- a/src/models/user.model/user.model.ts
+++ b/src/models/user.model/user.model.ts
@@ -67,7 +67,8 @@ const userSchema = new mongoose.Schema<IUser, UserModel>(
         jargonClarification: {
           type: Boolean
         }
-      }
+      },
+      _id: false
     }
   },
   {

--- a/src/models/user.model/user.model.ts
+++ b/src/models/user.model/user.model.ts
@@ -62,12 +62,15 @@ const userSchema = new mongoose.Schema<IUser, UserModel>(
     preferences: {
       type: {
         visualResponse: {
-          type: Boolean
+          type: Boolean,
+          default: true
         },
         jargonClarification: {
-          type: Boolean
+          type: Boolean,
+          default: true
         }
       },
+      default: () => ({}),
       _id: false
     }
   },

--- a/src/services/webhook.service.ts
+++ b/src/services/webhook.service.ts
@@ -17,7 +17,10 @@ async function getOrCreateUser(adapter, adapterUser) {
           pseudonym: adapterUser.pseudonym || (await userService.newPseudonym(0)),
           active: true
         }
-      ]
+      ],
+      ...(adapterUser.defaultPreferences !== undefined && {
+        preferences: adapterUser.defaultPreferences
+      })
     })
   }
   // update dmConfig by direct channel name, to be used later to send DMs

--- a/src/types/adapter.types.ts
+++ b/src/types/adapter.types.ts
@@ -1,10 +1,11 @@
-import type { AdapterChannelConfig } from './index.types.js'
+import type { AdapterChannelConfig, IUserPreferences } from './index.types.js'
 
 export interface AdapterUser {
   username: string
   pseudonym?: string
   dmConfig?: Record<string, unknown>
   isHost?: boolean
+  defaultPreferences?: IUserPreferences
 }
 
 export interface AdapterMessage<T> {

--- a/tests/adapters/zoom.adapter.test.ts
+++ b/tests/adapters/zoom.adapter.test.ts
@@ -20,6 +20,8 @@ jest.setTimeout(120000)
 // Mock fetch for sendMessage tests
 global.fetch = jest.fn()
 
+const zoomDefaultPreferences = { visualResponse: false, jargonClarification: false }
+
 setupIntTest()
 
 describe('zoom adapter tests', () => {
@@ -171,28 +173,28 @@ describe('zoom adapter tests', () => {
       const expectedMsg1 = {
         message: 'Welcome to the meeting!',
         source: { type: 'zoom' },
-        user: { username: 'Jennifer Hickey' },
+        user: { username: 'Jennifer Hickey', defaultPreferences: zoomDefaultPreferences },
         channels: adapter.audioChannels,
         createdAt: new Date('2025-05-16T19:32:54.522382Z')
       }
       const expectedMsg2 = {
         message: 'Great to see everyone!',
         source: { type: 'zoom' },
-        user: { username: 'Jennifer Hickey' },
+        user: { username: 'Jennifer Hickey', defaultPreferences: zoomDefaultPreferences },
         channels: adapter.audioChannels,
         createdAt: new Date('2025-05-16T19:33:20.522382Z')
       }
       const expectedMsg3 = {
         message: 'Welcome to our special guest!',
         source: { type: 'zoom' },
-        user: { username: 'Jennifer Hickey' },
+        user: { username: 'Jennifer Hickey', defaultPreferences: zoomDefaultPreferences },
         channels: adapter.audioChannels,
         createdAt: new Date('2025-05-16T19:33:55.522382Z')
       }
       const expectedMsg4 = {
         message: 'Happy to be here!',
         source: { type: 'zoom' },
-        user: { username: 'John Doe' },
+        user: { username: 'John Doe', defaultPreferences: zoomDefaultPreferences },
         channels: adapter.audioChannels,
         createdAt: new Date('2025-05-16T19:34:43.522382Z')
       }
@@ -238,7 +240,7 @@ describe('zoom adapter tests', () => {
         {
           message: 'Hello everyone!',
           source: { type: 'zoom' },
-          user: { username: 'Alice Smith' },
+          user: { username: 'Alice Smith', defaultPreferences: zoomDefaultPreferences },
           channels: adapter.chatChannels
         }
       ])
@@ -274,7 +276,7 @@ describe('zoom adapter tests', () => {
       expect(msgs).toHaveLength(1)
       expect(msgs[0].message).toBe('Hello everyone!')
       expect(msgs[0].source).toEqual({ type: 'zoom' })
-      expect(msgs[0].user).toEqual({ username: 'Alice Smith' })
+      expect(msgs[0].user).toEqual({ username: 'Alice Smith', defaultPreferences: zoomDefaultPreferences })
       expect(msgs[0].channels).toHaveLength(1)
       expect(msgs[0].channels[0].name).toBe('chat-incoming')
       expect(msgs[0].channels[0].direction).toBe(Direction.INCOMING)
@@ -310,7 +312,7 @@ describe('zoom adapter tests', () => {
       expect(msgs).toHaveLength(1)
       expect(msgs[0].message).toBe('Hello everyone!')
       expect(msgs[0].source).toEqual({ type: 'zoom' })
-      expect(msgs[0].user).toEqual({ username: 'Alice Smith' })
+      expect(msgs[0].user).toEqual({ username: 'Alice Smith', defaultPreferences: zoomDefaultPreferences })
       expect(msgs[0].channels).toHaveLength(1)
       expect(msgs[0].channels[0].name).toBe('chat-both')
       expect(msgs[0].channels[0].direction).toBe(Direction.BOTH)
@@ -456,7 +458,7 @@ describe('zoom adapter tests', () => {
       expect(msgs).toHaveLength(1)
       expect(msgs[0].message).toBe("I think that's wrong")
       expect(msgs[0].source).toEqual({ type: 'zoom' })
-      expect(msgs[0].user).toEqual({ username: 'Charlie Brown' })
+      expect(msgs[0].user).toEqual({ username: 'Charlie Brown', defaultPreferences: zoomDefaultPreferences })
     })
 
     it('preserves @ symbols in the reply portion', async () => {
@@ -486,7 +488,7 @@ describe('zoom adapter tests', () => {
       const msgs = await adapter.receiveMessage(replyMessage)
       expect(msgs).toHaveLength(1)
       expect(msgs[0].message).toBe('Actually @bot can you explain this?')
-      expect(msgs[0].user).toEqual({ username: 'Dana White' })
+      expect(msgs[0].user).toEqual({ username: 'Dana White', defaultPreferences: zoomDefaultPreferences })
     })
 
     it('preserves @ symbols in regular messages (not replies)', async () => {
@@ -516,7 +518,7 @@ describe('zoom adapter tests', () => {
       const msgs = await adapter.receiveMessage(regularMessage)
       expect(msgs).toHaveLength(1)
       expect(msgs[0].message).toBe('@bot please help with this task')
-      expect(msgs[0].user).toEqual({ username: 'Eve Anderson' })
+      expect(msgs[0].user).toEqual({ username: 'Eve Anderson', defaultPreferences: zoomDefaultPreferences })
     })
 
     it('preserves quotes in regular messages (not replies)', async () => {
@@ -546,7 +548,7 @@ describe('zoom adapter tests', () => {
       const msgs = await adapter.receiveMessage(messageWithQuotes)
       expect(msgs).toHaveLength(1)
       expect(msgs[0].message).toBe('I think the answer is "42" according to the documentation')
-      expect(msgs[0].user).toEqual({ username: 'Frank Miller' })
+      expect(msgs[0].user).toEqual({ username: 'Frank Miller', defaultPreferences: zoomDefaultPreferences })
     })
     it('preserves extra quotes in reply portion', async () => {
       await createConversation('Meeting with Quoted Text')
@@ -575,7 +577,7 @@ describe('zoom adapter tests', () => {
       const msgs = await adapter.receiveMessage(messageWithQuotes)
       expect(msgs).toHaveLength(1)
       expect(msgs[0].message).toBe('I think the answer is "42"')
-      expect(msgs[0].user).toEqual({ username: 'Frank Miller' })
+      expect(msgs[0].user).toEqual({ username: 'Frank Miller', defaultPreferences: zoomDefaultPreferences })
     })
 
     it('removes "Replying to" prefix even with @ symbols in quote', async () => {
@@ -605,7 +607,7 @@ describe('zoom adapter tests', () => {
       const msgs = await adapter.receiveMessage(replyMessage)
       expect(msgs).toHaveLength(1)
       expect(msgs[0].message).toBe('Yes, they should both help')
-      expect(msgs[0].user).toEqual({ username: 'Grace Lee' })
+      expect(msgs[0].user).toEqual({ username: 'Grace Lee', defaultPreferences: zoomDefaultPreferences })
     })
 
     it('correctly processes DM messages with direct channel when enabled', async () => {
@@ -647,7 +649,7 @@ describe('zoom adapter tests', () => {
           message: 'Hello bot, can you help me?',
           source: { type: 'zoom' },
           channels: adapter.dmChannels,
-          user: { username: 'Alice Smith', dmConfig: { to: 102 } }
+          user: { username: 'Alice Smith', dmConfig: { to: 102 }, defaultPreferences: zoomDefaultPreferences }
         }
       ])
     })
@@ -684,7 +686,11 @@ describe('zoom adapter tests', () => {
       expect(msgs).toHaveLength(1)
       expect(msgs[0].message).toBe('Hello bot, can you help me?')
       expect(msgs[0].source).toEqual({ type: 'zoom' })
-      expect(msgs[0].user).toEqual({ username: 'Alice Smith', dmConfig: { to: 102 } })
+      expect(msgs[0].user).toEqual({
+        username: 'Alice Smith',
+        dmConfig: { to: 102 },
+        defaultPreferences: zoomDefaultPreferences
+      })
       expect(msgs[0].channels).toHaveLength(1)
       expect(msgs[0].channels[0].name).toBe('dm-incoming')
       expect(msgs[0].channels[0].direction).toBe(Direction.INCOMING)
@@ -722,7 +728,11 @@ describe('zoom adapter tests', () => {
       expect(msgs).toHaveLength(1)
       expect(msgs[0].message).toBe('Hello bot, can you help me?')
       expect(msgs[0].source).toEqual({ type: 'zoom' })
-      expect(msgs[0].user).toEqual({ username: 'Alice Smith', dmConfig: { to: 102 } })
+      expect(msgs[0].user).toEqual({
+        username: 'Alice Smith',
+        dmConfig: { to: 102 },
+        defaultPreferences: zoomDefaultPreferences
+      })
       expect(msgs[0].channels).toHaveLength(1)
       expect(msgs[0].channels[0].name).toBe('dm-both')
       expect(msgs[0].channels[0].direction).toBe(Direction.BOTH)
@@ -1739,6 +1749,91 @@ describe('zoom adapter tests', () => {
         // Should match the message where pseudonym AND partial text both match
         expect(msgs[0].parentMessage.toString()).toBe(matchingMessage._id.toString())
       })
+    })
+  })
+
+  describe('defaultPreferences', () => {
+    it('includes defaultPreferences with both set to false on transcript messages', async () => {
+      await createConversation('Meeting with Transcript')
+      adapter.audioChannels = [{ name: 'transcript' }]
+      await adapter.save()
+
+      const message = {
+        data: {
+          data: {
+            words: [{ text: 'Hello!', end_timestamp: { absolute: '2025-05-16T19:32:54.522382Z' } }],
+            participant: { id: 1, name: 'Test User', is_host: false, platform: 'zoom', extra_data: null }
+          }
+        },
+        event: 'transcript.data'
+      }
+
+      const msgs = await adapter.receiveMessage(message)
+      expect(msgs[0].user.defaultPreferences).toEqual({ visualResponse: false, jargonClarification: false })
+    })
+
+    it('includes defaultPreferences with both set to false on group chat messages', async () => {
+      await createConversation('Meeting with Chat')
+      adapter.chatChannels = [{ name: 'participant' }]
+      await adapter.save()
+
+      const message = {
+        data: {
+          data: {
+            data: { text: 'Hello!', to: 'everyone' },
+            participant: { id: 1, name: 'Test User', is_host: false, platform: 'zoom' }
+          }
+        },
+        event: 'participant_events.chat_message'
+      }
+
+      const msgs = await adapter.receiveMessage(message)
+      expect(msgs[0].user.defaultPreferences).toEqual({ visualResponse: false, jargonClarification: false })
+    })
+
+    it('includes defaultPreferences with both set to false on DM messages', async () => {
+      await createConversation('Meeting with DMs')
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+      adapter.dmChannels = [{ name: 'dm' }]
+      await adapter.save()
+
+      const message = {
+        data: {
+          data: {
+            data: { text: 'Private message', to: 'only_bot' },
+            participant: { id: 1, name: 'Test User', is_host: false, platform: 'zoom' }
+          }
+        },
+        event: 'participant_events.chat_message'
+      }
+
+      const msgs = await adapter.receiveMessage(message)
+      expect(msgs[0].user.defaultPreferences).toEqual({ visualResponse: false, jargonClarification: false })
+    })
+
+    it('includes defaultPreferences with both set to false when participant joins', async () => {
+      await createConversation('Meeting with Participant Join')
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+      adapter.dmChannels = [{ name: 'dm' }]
+      await adapter.save()
+
+      const participant = { id: 1, name: 'Test User', is_host: false, platform: 'zoom' }
+      const adapterUser = await adapter.participantJoined(participant)
+
+      expect(adapterUser.defaultPreferences).toEqual({ visualResponse: false, jargonClarification: false })
+    })
+
+    it('includes defaultPreferences with both set to false when participant is updated', async () => {
+      await createConversation('Meeting with Participant Update')
+      adapter.dmChannels = [{ name: 'dm' }]
+      await adapter.save()
+
+      const participant = { id: 1, name: 'Test User', is_host: true, platform: 'zoom' }
+      const adapterUser = await adapter.participantUpdated(participant)
+
+      expect(adapterUser.defaultPreferences).toEqual({ visualResponse: false, jargonClarification: false })
     })
   })
 
@@ -2798,7 +2893,12 @@ describe('zoom adapter tests', () => {
       }
 
       const adapterUser = await adapter.participantJoined(participant)
-      expect(adapterUser).toEqual({ username: 'New Joiner', dmConfig: { to: 200 }, isHost: false })
+      expect(adapterUser).toEqual({
+        username: 'New Joiner',
+        dmConfig: { to: 200 },
+        isHost: false,
+        defaultPreferences: zoomDefaultPreferences
+      })
     })
 
     it('does not configure direct channel when DMs are not enabled', async () => {

--- a/tests/integration/user.test.ts
+++ b/tests/integration/user.test.ts
@@ -234,7 +234,7 @@ describe('User routes', () => {
   })
 
   describe('GET v1/users/user/:userId/preferences', () => {
-    test('should return 200 and empty object when preferences not set', async () => {
+    test('should return 200 and default preferences when preferences not set', async () => {
       await insertUsers([registeredUser])
       const ret = await request(app)
         .get(`/v1/users/user/${registeredUser._id}/preferences`)
@@ -242,7 +242,7 @@ describe('User routes', () => {
         .send()
         .expect(httpStatus.OK)
 
-      expect(ret.body).toEqual({})
+      expect(ret.body).toEqual({ visualResponse: true, jargonClarification: true })
     })
 
     test('should return 200 and user preferences when set', async () => {

--- a/tests/services/webhook.service.test.ts
+++ b/tests/services/webhook.service.test.ts
@@ -539,6 +539,90 @@ describe('adapter service tests', () => {
       expect(newUser!.pseudonyms[0].active).toBe(true)
     })
 
+    it('creates new user with schema default preferences (true) when no defaultPreferences provided', async () => {
+      jest.spyOn(websocketGateway, 'broadcastNewMessage').mockResolvedValue()
+      await createConversation('Meeting with Default Preferences')
+
+      const channel = await Channel.create({ name: 'participant' })
+      conversation.channels.push(channel)
+      await conversation.save()
+
+      mockAdapterType.receiveMessage.mockResolvedValue([
+        {
+          user: { username: 'Default Prefs User' },
+          channels: [{ name: 'participant', direct: false }],
+          message: 'Hello!',
+          source: 'test'
+        }
+      ])
+
+      await webhookService.receiveMessage(adapter, {})
+
+      const newUser = await User.findOne({ username: 'Default Prefs User' })
+      expect(newUser!.preferences!.visualResponse).toBe(true)
+      expect(newUser!.preferences!.jargonClarification).toBe(true)
+    })
+
+    it('creates new user with adapter-supplied defaultPreferences when provided', async () => {
+      jest.spyOn(websocketGateway, 'broadcastNewMessage').mockResolvedValue()
+      await createConversation('Meeting with Zoom-like Preferences')
+
+      const channel = await Channel.create({ name: 'participant' })
+      conversation.channels.push(channel)
+      await conversation.save()
+
+      mockAdapterType.receiveMessage.mockResolvedValue([
+        {
+          user: {
+            username: 'Zoom Prefs User',
+            defaultPreferences: { visualResponse: false, jargonClarification: false }
+          },
+          channels: [{ name: 'participant', direct: false }],
+          message: 'Hello!',
+          source: 'test'
+        }
+      ])
+
+      await webhookService.receiveMessage(adapter, {})
+
+      const newUser = await User.findOne({ username: 'Zoom Prefs User' })
+      expect(newUser!.preferences!.visualResponse).toBe(false)
+      expect(newUser!.preferences!.jargonClarification).toBe(false)
+    })
+
+    it('does not override preferences of an existing user on subsequent messages', async () => {
+      jest.spyOn(websocketGateway, 'broadcastNewMessage').mockResolvedValue()
+      await createConversation('Meeting with Existing User Preferences')
+
+      const channel = await Channel.create({ name: 'participant' })
+      conversation.channels.push(channel)
+      await conversation.save()
+
+      const existingUser = await User.create({
+        username: 'Returning User',
+        pseudonyms: [{ token: 'some-token', pseudonym: 'Snappy Salmon', active: true }],
+        preferences: { visualResponse: true, jargonClarification: true }
+      })
+
+      mockAdapterType.receiveMessage.mockResolvedValue([
+        {
+          user: {
+            username: 'Returning User',
+            defaultPreferences: { visualResponse: false, jargonClarification: false }
+          },
+          channels: [{ name: 'participant', direct: false }],
+          message: 'Hello again!',
+          source: 'test'
+        }
+      ])
+
+      await webhookService.receiveMessage(adapter, {})
+
+      const user = await User.findById(existingUser._id)
+      expect(user!.preferences!.visualResponse).toBe(true)
+      expect(user!.preferences!.jargonClarification).toBe(true)
+    })
+
     it('does not create direct channels when adapter has no chat or DM channels configured', async () => {
       const broadcastMsgSpy = jest.spyOn(websocketGateway, 'broadcastNewMessage').mockResolvedValue()
 


### PR DESCRIPTION
## What is in this PR?

Set default preferences to true for NextSpace users that can easily turn off jargon clarification or visual responses if not desired. Disable these preferences for Zoom users who have no way to change preferences.

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- refactor: remove _id from user preferences
nested schema does not need _id property and returning from getPreferences causing issues (not technically related to this change, but noticed during testing)
- feat: enable jargon and visual preferences by default, disable for zoom users
allow adapters to override default prefs where they can't be easily configured by users

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Create an EA conversation with Zoom and NextSpace adapters and run with a jargon-y talk
- [ ] Clear NS cookie to create a new user and verify that jargon and visual preferences are set by default
- [ ] Play video to generate jargon and ensure that jargon clarifications show on NS, but not in Zoom DM
- [ ] Ask a question designed to elicit a visual response (process, timeline, how things related, etc) and ensure visual works
- [ ] Turn off jargon pref in NS
- [ ] Verify no additional jargon clarifications received


## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
