### PR TITLE
add agent capabilities and scope setting to DM intro message and extract fun fact

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,10 +115,11 @@ DEFAULT_OPENAI_API_KEY=
 # CLASSIFICATION_LLM_PLATFORM=
 # CLASSIFICATION_LLM_MODEL=
 
-# (Optional) Configure which model to use for document summarization
+# (Optional) Configure which platform and model to use for core system LLM tasks
+# (document summarization, pseudonym fun facts, event summaries, etc.)
 # Defaults to Bedrock Claude Haiku 4.5
-# SUMMARY_LLM_PLATFORM=
-# SUMMARY_LLM_MODEL=
+# CORE_LLM_PLATFORM=
+# CORE_LLM_MODEL=
 
 # (Optional) Configure which model to use for image generation
 # Currently only Google models are supported for image generation

--- a/src/agents/eventAssistant/eventAssistant.ts
+++ b/src/agents/eventAssistant/eventAssistant.ts
@@ -8,9 +8,10 @@ import {
   eventAssistantLLMTemplates,
   eventAssistantLlmTemplateVars,
   answerQuestion,
-  QuestionClassification,
-  generatePseudonymFunFact
+  QuestionClassification
 } from './eventQuestionHandler.js'
+import { buildSystemPromptWithPersonality } from '../helpers/agentPersonality.js'
+import { getChatPromptResponse } from '../helpers/llmChain.js'
 
 import logger from '../../config/logger.js'
 import config from '../../config/config.js'
@@ -19,6 +20,101 @@ import generateImageResponse from './imageGenerator.js'
 import { parseSlashCommands, hasCommand, extractMessageText, SlashCommand } from '../helpers/slashCommandParser.js'
 import generateMindMap from './mindMapGenerator.js'
 import { checkBotIntent, matchBotMention, normalizeBotMention } from '../helpers/intentChecks.js'
+import User from '../../models/user.model/user.model.js'
+
+const funFactSystemTemplate = `You create short, fun facts about pseudonyms. The pseudonym is in the form "adjective noun". Create a 1 sentence fun fact that is factual about the noun, but can be playful about the adjective part. Makes sure your answers are safe for work.
+  **IMPORTANT** Always start the sentence with the phrase 'Fun Fact about your pseudonym:'`
+const funFactUserTemplate = 'Create a fun fact about the pseudonym: {pseudonym}'
+
+/**
+ * Builds a dynamic capability description for the WELCOME check-in message.
+ * Varies based on which tools and features are enabled in agentConfig.
+ */
+export function buildCheckinCapabilityDescription(agentConfig): string {
+  const toolNames: string[] = agentConfig?.tools || []
+  const hasWebSearch = toolNames.includes('web_search')
+  const hasModerator = agentConfig?.moderatorSupport
+
+  const capabilities = [
+    '- Re-explain anything from the event in simpler terms',
+    '- Answer any question about the event privately',
+    '- Summarize what they missed if they stepped away',
+    '- Clarify jargon or terminology used by the speaker'
+  ]
+
+  if (hasWebSearch) {
+    capabilities.push('- Research related topics, people, or claims the speaker briefly mentioned')
+  }
+  capabilities.push('- Just work with a fragment like "I\'m lost" or "the second part" — no need to form a full question')
+  capabilities.push('- Use /visual to get a diagram or image to help explain a concept')
+  capabilities.push('- Use /mindmap to generate a visual map of the key topics discussed')
+
+  if (hasModerator) {
+    capabilities.push('- Use /mod to submit a question anonymously to the moderator for Q&A')
+  }
+
+  return capabilities.join('\n')
+}
+
+export async function generatePseudonymFunFact(channel) {
+  // Find the user participant (not the agent)
+  const userParticipantId = channel.participants.find(
+    (participantId: string) => participantId.toString() !== this._id.toString()
+  )
+  const user = await User.findById(userParticipantId)
+  const activePseudonym = user?.pseudonyms?.find((p) => p.active)
+
+  if (!activePseudonym?.pseudonym) {
+    logger.debug(`No active pseudonym found for user ${user?._id} on channel ${channel.name}, cannot generate fun fact.`)
+    return null
+  }
+
+  const llm = await this.getLLM()
+
+  const funFact = await getChatPromptResponse(llm, funFactSystemTemplate, funFactUserTemplate, {
+    pseudonym: activePseudonym.pseudonym
+  })
+
+  return funFact
+}
+
+/**
+ * Generates the first DM a participant receives — a warm, contextual intro that incorporates
+ * the pseudonym fun fact, capability description, and a brief trust note. Used by introduce()
+ * for all DM channels. Falls back to the template string if the LLM call fails.
+ * Called with `this` = agent instance.
+ */
+async function buildDmIntroMessage(this, channel): Promise<string | null> {
+  const botName = this.agentConfig?.botName || config.conversationBotName
+  const personalityName = this.agentConfig?.personality ?? (config.enableAgentPersonality ? 'sarcastic-expert' : null)
+  const capabilityDescription = buildCheckinCapabilityDescription(this.agentConfig)
+  const funFact = await generatePseudonymFunFact.call(this, channel).catch(() => null)
+
+  const base = `You are ${botName}, a private AI assistant for this event. Your job is to send a participant their very first message — a brief, warm welcome that sets concrete expectations for what this private channel is for.
+
+Rules:
+- If a fun fact is provided, open with it as a light icebreaker — make it feel like a casual aside, not a formal introduction
+- Otherwise open with a simple "Hi!" — do not address the participant by name
+- 2-3 sentences describing what this channel is for, with 1-2 concrete examples (e.g. asking a question privately, typing "I'm lost", asking for a recap)
+- Include one brief trust note: their pseudonym keeps them anonymous, and their messages are never used to train AI models
+- End with explicit permission to not respond: "No need to reply — just wanted you to know I'm here."
+- Never imply the participant should participate more, or that silence is a problem
+- Friendly and direct, not formal`
+
+  const systemPrompt = buildSystemPromptWithPersonality(base, personalityName)
+
+  const userPrompt = `You are sending the first message to a participant in a private channel at a live event.
+
+Event: "${this.conversation.name}"
+${this.conversation.description ? `Description: ${this.conversation.description}` : ''}
+What ${botName} can do in this private channel:
+${capabilityDescription}
+${funFact ? `\nFun fact to open with: ${funFact}` : ''}
+Write their welcome message.`
+
+  const llm = await this.getLLM()
+  return (await getChatPromptResponse(llm, systemPrompt, userPrompt, {})) as string
+}
 
 const MODERATOR_MESSAGE_TYPES = new Set(['moderator_offered', 'moderator_submitted', 'moderator_declined'])
 
@@ -172,11 +268,8 @@ export default verify({
     perMessage: { directMessages: true, channels: ['chat', 'image-gen'], allowMessagesFromAgents: true }
   },
   agentConfig: {
-    introMessage:
-      "Hi! I'm {{agentConfig.botName}}, your AI event assistant. Ask me anything, or tap '/' to see available commands.",
     chatIntroMessage: `Welcome! I'm {{agentConfig.botName}}, your AI event assistant. This is a space to chat with other event participants. You can also ask me questions with an @{{agentConfig.botName}} mention. Just remember that everyone can see what you ask me here. Use the {{agentConfig.botName}} tab if you want to talk privately. Have fun!`,
     enablePersonality: config.enableAgentPersonality,
-    zoomIntroMessage: "Hi! I'm {{agentConfig.botName}}, your AI event assistant. Ask me anything about the event!",
     zoomChatIntroMessage:
       "Welcome! I'm {{agentConfig.botName}}, your AI event assistant. You can ask me questions in the chat with an @{{agentConfig.botName}} mention. Or send me a DM if you want to talk privately.",
     tools: getDefaultEventAssistantToolNames()
@@ -295,39 +388,21 @@ export default verify({
       }, agentConfig.botName: ${this.agentConfig?.botName}`
     )
     if (channel.direct) {
-      const templateStr = adapterType === 'zoom' ? this.agentConfig.zoomIntroMessage : this.agentConfig.introMessage
-      logger.debug(`[introduce] DM path - templateStr: ${templateStr}`)
-      let introMessage
+      // LLM-generated intro: fun fact opener, capability description, trust note, no-reply close.
       try {
-        introMessage = renderAgentTemplate(templateStr, this.toObject())
-        logger.debug(`[introduce] DM rendered introMessage: ${introMessage}`)
-      } catch (err) {
-        logger.error(`[introduce] renderAgentTemplate error (DM): ${err}`)
-        throw err
-      }
-
-      if (adapterType === 'zoom' && this.agentConfig?.moderatorSupport) {
-        introMessage = `${introMessage} Use /mod to send a question to the moderator.`
-      }
-
-      if (adapterType !== 'zoom') {
-        const funFact = await generatePseudonymFunFact.call(this, channel)
-        if (funFact) {
-          introMessage = `${introMessage}\n\n${funFact}`
-        }
-      }
-
+        const introText = await buildDmIntroMessage.call(this, channel)
       return [
         {
-          message: {
-            text: introMessage,
-            type: 'intro'
-          },
+            message: { text: introText, type: 'intro' },
           messageType: 'json',
           channels: [channel],
           visible: true
         }
       ]
+      } catch (err) {
+        logger.error('[introduce] LLM call failed for DM intro', err)
+        return []
+      }
     }
     if (channel.name === 'chat') {
       const templateStr = adapterType === 'zoom' ? this.agentConfig.zoomChatIntroMessage : this.agentConfig.chatIntroMessage

--- a/src/agents/eventAssistant/eventAssistant.ts
+++ b/src/agents/eventAssistant/eventAssistant.ts
@@ -25,10 +25,11 @@ import { checkBotIntent, matchBotMention, normalizeBotMention } from '../helpers
  * Builds a dynamic capability description for the WELCOME check-in message.
  * Varies based on which tools and features are enabled in agentConfig.
  */
-export function buildCheckinCapabilityDescription(agentConfig): string {
+export function buildCheckinCapabilityDescription(agentConfig, adapterType?: string): string {
   const toolNames: string[] = agentConfig?.tools || []
   const hasWebSearch = toolNames.includes('web_search')
   const hasModerator = agentConfig?.moderatorSupport
+  const isZoom = adapterType === 'zoom'
 
   const capabilities = [
     '- Re-explain anything from the event in simpler terms',
@@ -40,12 +41,17 @@ export function buildCheckinCapabilityDescription(agentConfig): string {
   if (hasWebSearch) {
     capabilities.push('- Research related topics, people, or claims the speaker briefly mentioned')
   }
-  capabilities.push('- Just work with a fragment like "I\'m lost" or "the second part" — no need to form a full question')
-  capabilities.push('- Use /visual to get a diagram or image to help explain a concept')
-  capabilities.push('- Use /mindmap to generate a visual map of the key topics discussed')
+  if (!isZoom) {
+    capabilities.push('- Use /visual to get a diagram or image to help explain a concept')
+    capabilities.push('- Use /mindmap to generate a visual map of the key topics discussed')
+    if (hasModerator) {
+      capabilities.push('- Use /mod to submit a question anonymously to the moderator for Q&A')
+    }
+  }
 
-  if (hasModerator) {
-    capabilities.push('- Use /mod to submit a question anonymously to the moderator for Q&A')
+  for (let i = capabilities.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[capabilities[i], capabilities[j]] = [capabilities[j], capabilities[i]]
   }
 
   return capabilities.join('\n')
@@ -56,33 +62,29 @@ export function buildCheckinCapabilityDescription(agentConfig): string {
  * the capability description and a brief trust note. Used by introduce() for all DM channels.
  * Called with `this` = agent instance.
  */
-async function buildDmIntroMessage(this): Promise<string | null> {
+async function buildDmIntroMessage(this, adapterType?: string): Promise<string | null> {
   const botName = this.agentConfig?.botName || config.conversationBotName
   const personalityName = this.agentConfig?.personality ?? (config.enableAgentPersonality ? 'sarcastic-expert' : null)
-  const capabilityDescription = buildCheckinCapabilityDescription(this.agentConfig)
+  const capabilityDescription = buildCheckinCapabilityDescription(this.agentConfig, adapterType)
 
-  const base = `You are ${botName}, a private AI assistant for this event. Your job is to send a participant their very first message — a brief, warm welcome that sets concrete expectations for what this private channel is for.
-
-Rules:
-- Otherwise open with a simple "Hi!" — do not address the participant by name
-- 2-3 sentences describing what this channel is for, with 1-2 concrete examples (e.g. asking a question privately, typing "I'm lost", asking for a recap)
-- Include one brief trust note: their pseudonym keeps them anonymous, and their messages are never used to train AI models
-- End with explicit permission to not respond: "No need to reply — just wanted you to know I'm here."
-- Never imply the participant should participate more, or that silence is a problem
-- Friendly and direct, not formal`
+  const base = `You are ${botName}, a private AI assistant for this event. Write 1-2 short sentences highlighting what you can help with. Prefer natural, conversational examples (e.g. "ask me to catch you up" or "ask me to simplify something") over listing slash commands. Do not re-explain the channel's purpose or privacy. Friendly and direct, not formal. Output only those sentences, nothing else.`
 
   const systemPrompt = buildSystemPromptWithPersonality(base, personalityName)
 
-  const userPrompt = `You are sending the first message to a participant in a private channel at a live event.
-
-Event: "${this.conversation.name}"
+  const userPrompt = `Event: "${this.conversation.name}"
 ${this.conversation.description ? `Description: ${this.conversation.description}` : ''}
-What ${botName} can do in this private channel:
-${capabilityDescription}
-Write their welcome message.`
+Available capabilities (pick 1-2 to highlight):
+${capabilityDescription}`
 
   const llm = await this.getLLM()
-  return (await getChatPromptResponse(llm, systemPrompt, userPrompt, {})) as string
+  const body = await getChatPromptResponse(llm, systemPrompt, userPrompt, {})
+  let commandHint: string
+  if (adapterType === 'zoom') {
+    commandHint = this.agentConfig?.moderatorSupport ? 'Use /mod to send a question to the moderator.' : ''
+  } else {
+    commandHint = 'Just type / if you want to see what else I can do.'
+  }
+  return `Hi! I'm ${botName}, your private, anonymous support during this session. ${body}${commandHint ? ` ${commandHint}` : ''} Your pseudonym keeps you anonymous, and nothing you share is ever used to train AI models. No need to respond, just know I'm here.`
 }
 
 const MODERATOR_MESSAGE_TYPES = new Set(['moderator_offered', 'moderator_submitted', 'moderator_declined'])
@@ -364,7 +366,7 @@ export default verify({
     if (channel.direct) {
       // LLM-generated intro: capability description, trust note, no-reply close.
       try {
-        const introText = await buildDmIntroMessage.call(this)
+        const introText = await buildDmIntroMessage.call(this, adapterType)
         return [
           {
             message: { text: introText, type: 'intro' },

--- a/src/agents/eventAssistant/eventAssistant.ts
+++ b/src/agents/eventAssistant/eventAssistant.ts
@@ -20,11 +20,6 @@ import generateImageResponse from './imageGenerator.js'
 import { parseSlashCommands, hasCommand, extractMessageText, SlashCommand } from '../helpers/slashCommandParser.js'
 import generateMindMap from './mindMapGenerator.js'
 import { checkBotIntent, matchBotMention, normalizeBotMention } from '../helpers/intentChecks.js'
-import User from '../../models/user.model/user.model.js'
-
-const funFactSystemTemplate = `You create short, fun facts about pseudonyms. The pseudonym is in the form "adjective noun". Create a 1 sentence fun fact that is factual about the noun, but can be playful about the adjective part. Makes sure your answers are safe for work.
-  **IMPORTANT** Always start the sentence with the phrase 'Fun Fact about your pseudonym:'`
-const funFactUserTemplate = 'Create a fun fact about the pseudonym: {pseudonym}'
 
 /**
  * Builds a dynamic capability description for the WELCOME check-in message.
@@ -56,44 +51,19 @@ export function buildCheckinCapabilityDescription(agentConfig): string {
   return capabilities.join('\n')
 }
 
-export async function generatePseudonymFunFact(channel) {
-  // Find the user participant (not the agent)
-  const userParticipantId = channel.participants.find(
-    (participantId: string) => participantId.toString() !== this._id.toString()
-  )
-  const user = await User.findById(userParticipantId)
-  const activePseudonym = user?.pseudonyms?.find((p) => p.active)
-
-  if (!activePseudonym?.pseudonym) {
-    logger.debug(`No active pseudonym found for user ${user?._id} on channel ${channel.name}, cannot generate fun fact.`)
-    return null
-  }
-
-  const llm = await this.getLLM()
-
-  const funFact = await getChatPromptResponse(llm, funFactSystemTemplate, funFactUserTemplate, {
-    pseudonym: activePseudonym.pseudonym
-  })
-
-  return funFact
-}
-
 /**
  * Generates the first DM a participant receives — a warm, contextual intro that incorporates
- * the pseudonym fun fact, capability description, and a brief trust note. Used by introduce()
- * for all DM channels. Falls back to the template string if the LLM call fails.
+ * the capability description and a brief trust note. Used by introduce() for all DM channels.
  * Called with `this` = agent instance.
  */
-async function buildDmIntroMessage(this, channel): Promise<string | null> {
+async function buildDmIntroMessage(this): Promise<string | null> {
   const botName = this.agentConfig?.botName || config.conversationBotName
   const personalityName = this.agentConfig?.personality ?? (config.enableAgentPersonality ? 'sarcastic-expert' : null)
   const capabilityDescription = buildCheckinCapabilityDescription(this.agentConfig)
-  const funFact = await generatePseudonymFunFact.call(this, channel).catch(() => null)
 
   const base = `You are ${botName}, a private AI assistant for this event. Your job is to send a participant their very first message — a brief, warm welcome that sets concrete expectations for what this private channel is for.
 
 Rules:
-- If a fun fact is provided, open with it as a light icebreaker — make it feel like a casual aside, not a formal introduction
 - Otherwise open with a simple "Hi!" — do not address the participant by name
 - 2-3 sentences describing what this channel is for, with 1-2 concrete examples (e.g. asking a question privately, typing "I'm lost", asking for a recap)
 - Include one brief trust note: their pseudonym keeps them anonymous, and their messages are never used to train AI models
@@ -109,7 +79,6 @@ Event: "${this.conversation.name}"
 ${this.conversation.description ? `Description: ${this.conversation.description}` : ''}
 What ${botName} can do in this private channel:
 ${capabilityDescription}
-${funFact ? `\nFun fact to open with: ${funFact}` : ''}
 Write their welcome message.`
 
   const llm = await this.getLLM()
@@ -132,8 +101,11 @@ function filterModeratorHistory(conversationHistory) {
       const prev = msgs[i - 1]
       const next = msgs[i + 1]
       if (
-        prev?.bodyType === 'json' && (prev.body as Record<string, unknown>)?.type === 'moderator_offered' &&
-        next?.bodyType === 'json' && ((next.body as Record<string, unknown>)?.type === 'moderator_submitted' || (next.body as Record<string, unknown>)?.type === 'moderator_declined')
+        prev?.bodyType === 'json' &&
+        (prev.body as Record<string, unknown>)?.type === 'moderator_offered' &&
+        next?.bodyType === 'json' &&
+        ((next.body as Record<string, unknown>)?.type === 'moderator_submitted' ||
+          (next.body as Record<string, unknown>)?.type === 'moderator_declined')
       ) {
         return false
       }
@@ -367,7 +339,9 @@ export default verify({
     const modifiedMessage = { ...userMessage }
     modifiedMessage.body = extractMessageText(userMessage)
 
-    const agentResponses = await answerQuestion.call(this, modifiedMessage, filterModeratorHistory(conversationHistory), { forceVisual })
+    const agentResponses = await answerQuestion.call(this, modifiedMessage, filterModeratorHistory(conversationHistory), {
+      forceVisual
+    })
 
     if (this.agentConfig?.moderatorSupport) {
       offerModeratorSubmission(userMessage, agentResponses, this.conversation)
@@ -388,17 +362,17 @@ export default verify({
       }, agentConfig.botName: ${this.agentConfig?.botName}`
     )
     if (channel.direct) {
-      // LLM-generated intro: fun fact opener, capability description, trust note, no-reply close.
+      // LLM-generated intro: capability description, trust note, no-reply close.
       try {
-        const introText = await buildDmIntroMessage.call(this, channel)
-      return [
-        {
+        const introText = await buildDmIntroMessage.call(this)
+        return [
+          {
             message: { text: introText, type: 'intro' },
-          messageType: 'json',
-          channels: [channel],
-          visible: true
-        }
-      ]
+            messageType: 'json',
+            channels: [channel],
+            visible: true
+          }
+        ]
       } catch (err) {
         logger.error('[introduce] LLM call failed for DM intro', err)
         return []

--- a/src/agents/eventAssistant/eventQuestionHandler.ts
+++ b/src/agents/eventAssistant/eventQuestionHandler.ts
@@ -279,10 +279,6 @@ export const eventAssistantLlmTemplateVars = {
   ]
 }
 
-const funFactSystemTemplate = `You create short, fun facts about pseudonyms. The pseudonym is in the form "adjective noun". Create a 1 sentence fun fact that is factual about the noun, but can be playful about the adjective part. Makes sure your answers are safe for work.
-  **IMPORTANT** Always start the sentence with the phrase 'Fun Fact about your pseudonym:'`
-const funFactUserTemplate = 'Create a fun fact about the pseudonym: {pseudonym}'
-
 async function getResponse(question, context, chatHistory, topic, systemTemplate) {
   const llm = await this.getLLM()
   return getChatPromptResponse(llm, systemTemplate, this.llmTemplates.user, { context, question, topic }, chatHistory)
@@ -348,28 +344,6 @@ export function compileSpeakerNames(conversation): string {
 
   if (lines.length === 0) return ''
   return `## Event Participants:\n${lines.join('\n')}\n\n`
-}
-
-export async function generatePseudonymFunFact(channel) {
-  // Find the user participant (not the agent)
-  const userParticipantId = channel.participants.find(
-    (participantId: string) => participantId.toString() !== this._id.toString()
-  )
-  const user = await User.findById(userParticipantId)
-  const activePseudonym = user?.pseudonyms?.find((p) => p.active)
-
-  if (!activePseudonym?.pseudonym) {
-    logger.debug(`No active pseudonym found for user ${user?._id} on channel ${channel.name}, cannot generate fun fact.`)
-    return null
-  }
-
-  const llm = await this.getLLM()
-
-  const funFact = await getChatPromptResponse(llm, funFactSystemTemplate, funFactUserTemplate, {
-    pseudonym: activePseudonym.pseudonym
-  })
-
-  return funFact
 }
 
 export async function answerQuestion(userMessage, conversationHistory, options?) {

--- a/src/agents/helpers/getModelChat.ts
+++ b/src/agents/helpers/getModelChat.ts
@@ -55,8 +55,10 @@ export const defaultLLMModel = supportedModels[0].llmModel
 // These can be model family names (e.g., "sonnet", "haiku") or exact model IDs
 export const { classificationLLMPlatform } = config
 export const { classificationLLMModel } = config
-export const { summaryLLMPlatform } = config
-export const { summaryLLMModel } = config
+
+// Used for core system tasks like generating fun facts and reading summaries
+export const { coreLLMPlatform } = config
+export const { coreLLMModel } = config
 // No platform specified because only Google is currently supported for image generation
 export const { imageGenerationLLMModel } = config
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -97,12 +97,12 @@ const envVarsSchema = Joi.object()
       .default('bedrock')
       .description('Platform to use for classification tasks (e.g., bedrock, openai, google)'),
     CLASSIFICATION_LLM_MODEL: Joi.string().default('sonnet').description('Model to use for classification tasks'),
-    SUMMARY_LLM_PLATFORM: Joi.string()
+    CORE_LLM_PLATFORM: Joi.string()
       .default('bedrock')
-      .description('Platform to use for document summarization (e.g., bedrock, openai, google)'),
-    SUMMARY_LLM_MODEL: Joi.string()
+      .description('Platform to use for core system LLM tasks (e.g., bedrock, openai, google)'),
+    CORE_LLM_MODEL: Joi.string()
       .default('us.anthropic.claude-haiku-4-5-20251001-v1:0')
-      .description('Model to use for document summarization'),
+      .description('Model to use for core system LLM tasks (summaries, fun facts, etc.)'),
     IMAGE_GENERATION_LLM_MODEL: Joi.string()
       .default('gemini-3-pro-image-preview')
       .description('Model to use for image generation tasks'),
@@ -241,8 +241,8 @@ const config = {
   conversationBotName: envVars.CONVERSATION_BOT_NAME,
   classificationLLMPlatform: envVars.CLASSIFICATION_LLM_PLATFORM,
   classificationLLMModel: envVars.CLASSIFICATION_LLM_MODEL,
-  summaryLLMPlatform: envVars.SUMMARY_LLM_PLATFORM,
-  summaryLLMModel: envVars.SUMMARY_LLM_MODEL,
+  coreLLMPlatform: envVars.CORE_LLM_PLATFORM,
+  coreLLMModel: envVars.CORE_LLM_MODEL,
   imageGenerationLLMModel: envVars.IMAGE_GENERATION_LLM_MODEL,
   semanticScholar: {
     apiKey: envVars.SEMANTIC_SCHOLAR_API_KEY

--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -152,6 +152,9 @@ components:
           items:
             type: string
           description: Array of Conversation IDs
+        funFact:
+          type: string
+          description: LLM-generated fun fact about the pseudonym
 
     Profile:
       type: object

--- a/src/models/user.model/schemas/pseudonym.schema.ts
+++ b/src/models/user.model/schemas/pseudonym.schema.ts
@@ -24,6 +24,9 @@ const pseudonymSchema = new mongoose.Schema<IPseudonym>({
   conversations: {
     type: [String],
     default: []
+  },
+  funFact: {
+    type: String
   }
 })
 export default pseudonymSchema

--- a/src/services/resource.service.ts
+++ b/src/services/resource.service.ts
@@ -6,7 +6,7 @@ import httpStatus from 'http-status'
 import { z } from 'zod'
 import { PDFLoader } from '@langchain/community/document_loaders/fs/pdf'
 import backgroundCollection, { BACKGROUND_DOCS_BASE, buildFullCitation } from '../agents/helpers/backgroundCollection.js'
-import { getModelChat, summaryLLMPlatform, summaryLLMModel } from '../agents/helpers/getModelChat.js'
+import { getModelChat, coreLLMPlatform, coreLLMModel } from '../agents/helpers/getModelChat.js'
 import { getChatPromptResponse } from '../agents/helpers/llmChain.js'
 import logger from '../config/logger.js'
 import Conversation from '../models/conversation.model.js'
@@ -59,7 +59,7 @@ const summarizePdf = async (conversationId: string, resourceId: string, filePath
     content = content.slice(0, PDF_MAX_CHARS_FOR_SUMMARY)
   }
 
-  const llm = await getModelChat(summaryLLMPlatform, summaryLLMModel)
+  const llm = await getModelChat(coreLLMPlatform, coreLLMModel)
   const structured = await getChatPromptResponse(
     llm,
     SUMMARIZATION_PROMPT,

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -9,6 +9,27 @@ import ApiError from '../utils/ApiError.js'
 import { pseudonymAdjectives, pseudonymNouns } from '../config/pseudonym-dictionaries.js'
 import logger from '../config/logger.js'
 import config from '../config/config.js'
+import { getModelChat, coreLLMPlatform, coreLLMModel } from '../agents/helpers/getModelChat.js'
+import { getChatPromptResponse } from '../agents/helpers/llmChain.js'
+
+const funFactSystemTemplate = `You create short, fun facts about pseudonyms. The pseudonym is in the form "adjective noun". Create a 1 sentence fun fact that is factual about the noun, but can be playful about the adjective part. Makes sure your answers are safe for work.
+Output only the fun fact sentence itself — no headings, labels, pseudonym names, or additional commentary.`
+
+const funFactUserTemplate = 'Create a fun fact about the pseudonym: {pseudonym}'
+
+// Skip fun fact generation when truly random pseudonyms are enabled — those aren't human-readable.
+const generatePseudonymFunFact = async (pseudonym: string) => {
+  if (config.trulyRandomPseudonyms === 'true') {
+    return null
+  }
+  try {
+    const llm = await getModelChat(coreLLMPlatform, coreLLMModel)
+    return (await getChatPromptResponse(llm, funFactSystemTemplate, funFactUserTemplate, { pseudonym })) as string
+  } catch (err) {
+    logger.warn(`Failed to generate fun fact for pseudonym "${pseudonym}": ${err.message}`)
+    return null
+  }
+}
 
 const tokenKey = 'greenheron'
 /**
@@ -54,6 +75,11 @@ const createUser = async (userBody) => {
   }
 
   const user = await User.create(userProps)
+  const funFact = await generatePseudonymFunFact(user.pseudonyms[0].pseudonym)
+  if (funFact) {
+    user.pseudonyms[0].funFact = funFact
+    await user.save()
+  }
   return user
 }
 
@@ -115,6 +141,12 @@ const addPseudonym = async (requestBody, requestUser) => {
   })
   user!.pseudonyms.push(newPseudonym)
   await user!.save()
+  const addedPseudo = user!.pseudonyms[user!.pseudonyms.length - 1]
+  const funFact = await generatePseudonymFunFact(addedPseudo.pseudonym)
+  if (funFact) {
+    addedPseudo.funFact = funFact
+    await user!.save()
+  }
   return user
 }
 /**
@@ -137,6 +169,14 @@ const activatePseudonym = async (requestBody, requestUser) => {
     throw new ApiError(httpStatus.NOT_FOUND, 'Pseudonym not found')
   }
   await user!.save()
+  const activatedPseudo = user!.pseudonyms.find((p) => p.token === requestBody.token)
+  if (activatedPseudo && !activatedPseudo.funFact) {
+    const funFact = await generatePseudonymFunFact(activatedPseudo.pseudonym)
+    if (funFact) {
+      activatedPseudo.funFact = funFact
+      await user!.save()
+    }
+  }
   return user
 }
 /**

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -17,6 +17,7 @@ export interface IPseudonym {
   active: boolean
   isDeleted: boolean
   conversations: string[]
+  funFact?: string
 }
 
 export interface IBaseUser {

--- a/tests/agents/eventAssistant/alternateName.agent.test.ts
+++ b/tests/agents/eventAssistant/alternateName.agent.test.ts
@@ -33,7 +33,7 @@ describe('alternate name enforcement', () => {
 
   const startTime = new Date(Date.now() - 10 * 60 * 1000)
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     topic = await createPublicTopic()
     user1 = await createUser('curious-attendee')
 

--- a/tests/agents/eventAssistant/eventAssistant.agent.test.ts
+++ b/tests/agents/eventAssistant/eventAssistant.agent.test.ts
@@ -498,17 +498,6 @@ describe(`event assistant CI tests`, () => {
       expect(msgs).toHaveLength(0)
     })
 
-    it('incorporates a fun fact about the user pseudonym into the DM intro', async () => {
-      const testUser = await createUser('Curious Elephant')
-      const [directChannel] = await Channel.create([
-        { name: 'direct-test-pseudonym', direct: true, participants: [testUser._id, agent._id] }
-      ])
-      const msgs = await agent.introduce(directChannel)
-      console.log('Fun fact DM intro:', msgs[0]?.message?.text)
-      expect(msgs).toHaveLength(1)
-      expect(msgs[0].message.text.toLowerCase()).toContain('elephant')
-    })
-
     it('includes custom botName in chat intro', async () => {
       const customBotName = 'MyCustomBot'
       agent.agentConfig = { ...agent.agentConfig, botName: customBotName }

--- a/tests/agents/eventAssistant/eventAssistant.agent.test.ts
+++ b/tests/agents/eventAssistant/eventAssistant.agent.test.ts
@@ -509,6 +509,15 @@ describe(`event assistant CI tests`, () => {
       expect(msgs[0].message.text).not.toContain('{{agentConfig.botName}}')
     })
 
+    it('includes type-/ hint in non-zoom DM intro', async () => {
+      const [directChannel] = await Channel.create([
+        { name: 'direct-agents-hint', direct: true, participants: [user1._id, agent._id] }
+      ])
+      const msgs = await agent.introduce(directChannel)
+      console.log('DM intro (type-/ hint):', msgs[0]?.message?.text)
+      expect(msgs[0].message.text).toContain('Just type /')
+    })
+
     it('sends an LLM-generated intro for zoom DM channels', async () => {
       const [directChannel] = await Channel.create([
         { name: 'direct-zoom-agents', direct: true, participants: [user1._id, agent._id] }
@@ -519,6 +528,27 @@ describe(`event assistant CI tests`, () => {
       expect(msgs[0].messageType).toBe('json')
       expect(msgs[0].message.type).toBe('intro')
       expect(msgs[0].message.text.length).toBeGreaterThan(20)
+    })
+
+    it('omits command hint in zoom DM intro when moderatorSupport is disabled', async () => {
+      agent.agentConfig = { ...agent.agentConfig, moderatorSupport: false }
+      const [directChannel] = await Channel.create([
+        { name: 'direct-zoom-nomod', direct: true, participants: [user1._id, agent._id] }
+      ])
+      const msgs = await agent.introduce(directChannel, 'zoom')
+      console.log('Zoom DM intro (no mod):', msgs[0]?.message?.text)
+      expect(msgs[0].message.text).not.toContain('/mod')
+      expect(msgs[0].message.text).not.toContain('Just type /')
+    })
+
+    it('includes /mod hint in zoom DM intro when moderatorSupport is enabled', async () => {
+      agent.agentConfig = { ...agent.agentConfig, moderatorSupport: true }
+      const [directChannel] = await Channel.create([
+        { name: 'direct-zoom-mod', direct: true, participants: [user1._id, agent._id] }
+      ])
+      const msgs = await agent.introduce(directChannel, 'zoom')
+      console.log('Zoom DM intro (with mod):', msgs[0]?.message?.text)
+      expect(msgs[0].message.text).toContain('/mod')
     })
 
     it('uses zoomChatIntroMessage for zoom chat intro', async () => {

--- a/tests/agents/eventAssistant/eventAssistant.agent.test.ts
+++ b/tests/agents/eventAssistant/eventAssistant.agent.test.ts
@@ -451,56 +451,97 @@ describe(`event assistant CI tests`, () => {
     expect(responses).toHaveLength(0)
   })
 
-  it('introduces itself on new DM channels', async () => {
-    const [directChannel] = await Channel.create([
-      { name: 'direct-jh-agents', direct: true, participants: [user1._id, agent._id] }
-    ])
-    const msgs = await agent.introduce(directChannel)
-    expect(msgs).toHaveLength(1)
-    expect(msgs[0].messageType).toBe('json')
-    expect(msgs[0].message.type).toBe('intro')
-    // Should contain the rendered bot name (template vars resolved)
-    expect(msgs[0].message.text).toContain(agent.agentConfig.botName)
-    expect(msgs[0].message.text).not.toContain('{{agentConfig.botName}}')
-    // Should contain a fun fact about the pseudonym
-    expect(msgs[0].message.text).toMatch(/fun fact about your pseudonym:/i)
-    // Should mention the pseudonym or at least "badger" (the noun part)
-    expect(msgs[0].message.text.toLowerCase()).toMatch(/badger/)
-    expect(msgs[0].channels).toHaveLength(1)
-    expect(msgs[0].channels[0]).toEqual(directChannel)
-  })
+  describe('introduce', () => {
+    it('sends an LLM-generated intro to DM channels', async () => {
+      const [directChannel] = await Channel.create([
+        { name: 'direct-jh-agents', direct: true, participants: [user1._id, agent._id] }
+      ])
+      const msgs = await agent.introduce(directChannel)
+      console.log('DM intro:', msgs[0]?.message?.text)
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].messageType).toBe('json')
+      expect(msgs[0].message.type).toBe('intro')
+      expect(msgs[0].message.text.length).toBeGreaterThan(20)
+      expect(msgs[0].channels).toHaveLength(1)
+      expect(msgs[0].channels[0]).toEqual(directChannel)
+    })
 
-  it('introduces itself on chat channels', async () => {
-    const [chatChannel] = await Channel.create([{ name: 'chat' }])
-    const msgs = await agent.introduce(chatChannel)
-    expect(msgs).toHaveLength(1)
-    expect(msgs[0].messageType).toBe('json')
-    expect(msgs[0].message.type).toBe('intro')
-    // chatIntroMessage is a template — verify the bot name was rendered into it
-    expect(msgs[0].message.text).toContain(`@${agent.agentConfig.botName}`)
-    expect(msgs[0].message.text).not.toContain('{{agentConfig.botName}}')
-    expect(msgs[0].channels).toHaveLength(1)
-    expect(msgs[0].channels[0]).toEqual(chatChannel)
-  })
+    it('sends a template-based intro to the chat channel', async () => {
+      const [chatChannel] = await Channel.create([{ name: 'chat' }])
+      const msgs = await agent.introduce(chatChannel)
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].messageType).toBe('json')
+      expect(msgs[0].message.type).toBe('intro')
+      expect(msgs[0].message.text).toContain(`@${agent.agentConfig.botName}`)
+      expect(msgs[0].message.text).not.toContain('{{agentConfig.botName}}')
+      expect(msgs[0].channels).toHaveLength(1)
+      expect(msgs[0].channels[0]).toEqual(chatChannel)
+    })
 
-  it('renders template vars in chatIntroMessage using agent data', async () => {
-    agent.agentConfig = {
-      ...agent.agentConfig,
-      chatIntroMessage: 'Welcome to {{conversation.name}}!'
-    }
-    const [chatChannel] = await Channel.create([{ name: 'chat' }])
-    const msgs = await agent.introduce(chatChannel)
-    expect(msgs).toHaveLength(1)
-    expect(msgs[0].messageType).toBe('json')
-    expect(msgs[0].message.type).toBe('intro')
-    expect(msgs[0].message.text).toEqual(`Welcome to ${conversation.name}!`)
-  })
+    it('renders template vars in chatIntroMessage using agent data', async () => {
+      agent.agentConfig = {
+        ...agent.agentConfig,
+        chatIntroMessage: 'Welcome to {{conversation.name}}!'
+      }
+      const [chatChannel] = await Channel.create([{ name: 'chat' }])
+      const msgs = await agent.introduce(chatChannel)
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].messageType).toBe('json')
+      expect(msgs[0].message.type).toBe('intro')
+      expect(msgs[0].message.text).toEqual(`Welcome to ${conversation.name}!`)
+    })
 
-  it('does not introduce itself on non-direct or chat channels', async () => {
-    await agent.save()
-    const [channel] = await Channel.create([{ name: 'testchannel' }])
-    const msgs = await agent.introduce(channel)
-    expect(msgs).toHaveLength(0)
+    it('returns empty array for non-DM, non-chat channels', async () => {
+      await agent.save()
+      const [channel] = await Channel.create([{ name: 'testchannel' }])
+      const msgs = await agent.introduce(channel)
+      expect(msgs).toHaveLength(0)
+    })
+
+    it('incorporates a fun fact about the user pseudonym into the DM intro', async () => {
+      const testUser = await createUser('Curious Elephant')
+      const [directChannel] = await Channel.create([
+        { name: 'direct-test-pseudonym', direct: true, participants: [testUser._id, agent._id] }
+      ])
+      const msgs = await agent.introduce(directChannel)
+      console.log('Fun fact DM intro:', msgs[0]?.message?.text)
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].message.text.toLowerCase()).toContain('elephant')
+    })
+
+    it('includes custom botName in chat intro', async () => {
+      const customBotName = 'MyCustomBot'
+      agent.agentConfig = { ...agent.agentConfig, botName: customBotName }
+      const [chatChannel] = await Channel.create([{ name: 'chat' }])
+      const msgs = await agent.introduce(chatChannel)
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].message.type).toBe('intro')
+      expect(msgs[0].message.text).toContain(`@${customBotName}`)
+      expect(msgs[0].message.text).not.toContain('{{agentConfig.botName}}')
+    })
+
+    it('sends an LLM-generated intro for zoom DM channels', async () => {
+      const [directChannel] = await Channel.create([
+        { name: 'direct-zoom-agents', direct: true, participants: [user1._id, agent._id] }
+      ])
+      const msgs = await agent.introduce(directChannel, 'zoom')
+      console.log('Zoom DM intro:', msgs[0]?.message?.text)
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].messageType).toBe('json')
+      expect(msgs[0].message.type).toBe('intro')
+      expect(msgs[0].message.text.length).toBeGreaterThan(20)
+    })
+
+    it('uses zoomChatIntroMessage for zoom chat intro', async () => {
+      const [chatChannel] = await Channel.create([{ name: 'chat' }])
+      const msgs = await agent.introduce(chatChannel, 'zoom')
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].messageType).toBe('json')
+      expect(msgs[0].message.type).toBe('intro')
+      expect(msgs[0].message.text).toContain(agent.agentConfig.botName)
+      expect(msgs[0].message.text).not.toContain('{{agentConfig.botName}}')
+      expect(msgs[0].message.text).toContain('send me a DM')
+    })
   })
 
   it('does not respond to messages not intended for the assistant (may be unanswerable)', async () => {
@@ -591,113 +632,6 @@ describe(`event assistant CI tests`, () => {
 
       const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, { messages: [] }, evaluation.userMessage)
       await validateResponse(responses, 'chat')
-    })
-
-    it('includes custom botName in rendered DM intro message', async () => {
-      const customBotName = 'MyCustomBot'
-      agent.agentConfig = { ...agent.agentConfig, botName: customBotName }
-
-      const [directChannel] = await Channel.create([
-        { name: 'direct-custom-bot', direct: true, participants: [user1._id, agent._id] }
-      ])
-      const msgs = await agent.introduce(directChannel)
-      expect(msgs).toHaveLength(1)
-      expect(msgs[0].messageType).toBe('json')
-      expect(msgs[0].message.type).toBe('intro')
-      expect(msgs[0].message.text).toContain(customBotName)
-      expect(msgs[0].message.text).not.toContain('{{agentConfig.botName}}')
-    })
-
-    it('includes custom botName in rendered chat intro message', async () => {
-      const customBotName = 'MyCustomBot'
-      agent.agentConfig = { ...agent.agentConfig, botName: customBotName }
-
-      // Channel name must be 'chat' to match the introduce() logic
-      const [chatChannel] = await Channel.create([{ name: 'chat' }])
-      const msgs = await agent.introduce(chatChannel)
-      expect(msgs).toHaveLength(1)
-      expect(msgs[0].messageType).toBe('json')
-      expect(msgs[0].message.type).toBe('intro')
-      expect(msgs[0].message.text).toContain(`@${customBotName}`)
-      expect(msgs[0].message.text).not.toContain('{{agentConfig.botName}}')
-    })
-  })
-
-  it('includes a fun fact about the user pseudonym in DM intro', async () => {
-    // Create a user with a clear "adjective noun" pseudonym
-    const testUser = await createUser('Curious Elephant')
-    const [directChannel] = await Channel.create([
-      { name: 'direct-test-pseudonym', direct: true, participants: [testUser._id, agent._id] }
-    ])
-    const msgs = await agent.introduce(directChannel)
-
-    expect(msgs).toHaveLength(1)
-    expect(msgs[0].messageType).toBe('json')
-    expect(msgs[0].message.type).toBe('intro')
-    const introMessage = msgs[0].message.text
-
-    // Should contain the rendered bot name (template vars resolved)
-    expect(introMessage).toContain(agent.agentConfig.botName)
-    expect(introMessage).not.toContain('{{agentConfig.botName}}')
-
-    // Should have the fun fact header
-    expect(introMessage).toMatch(/fun fact about your pseudonym:/i)
-
-    // Should mention "elephant" (the noun part) in the fun fact
-    expect(introMessage.toLowerCase()).toContain('elephant')
-
-    // The fun fact should be factual about elephants
-    // We can't predict exact LLM output, but it should be substantive (more than just the header)
-    const funFactPart = introMessage.split(/fun fact about your pseudonym:/i)[1]
-    expect(funFactPart.length).toBeGreaterThan(20) // Should be at least 1-2 sentences
-  })
-
-  // ZOOM ADAPTER INTRO TESTS
-
-  describe('zoom adapter type', () => {
-    it('uses zoomIntroMessage for zoom DM intro', async () => {
-      const [directChannel] = await Channel.create([
-        { name: 'direct-zoom-agents', direct: true, participants: [user1._id, agent._id] }
-      ])
-      const msgs = await agent.introduce(directChannel, 'zoom')
-      expect(msgs).toHaveLength(1)
-      expect(msgs[0].messageType).toBe('json')
-      expect(msgs[0].message.type).toBe('intro')
-      expect(msgs[0].message.text).toContain(agent.agentConfig.botName)
-      expect(msgs[0].message.text).not.toContain('{{agentConfig.botName}}')
-      // Zoom DM uses the zoomIntroMessage template
-      expect(msgs[0].message.text).toContain('Ask me anything about the event')
-    })
-
-    it('does not include fun fact in zoom DM intro', async () => {
-      const [directChannel] = await Channel.create([
-        { name: 'direct-zoom-agents-nofact', direct: true, participants: [user1._id, agent._id] }
-      ])
-      const msgs = await agent.introduce(directChannel, 'zoom')
-      expect(msgs).toHaveLength(1)
-      // Fun fact is suppressed for zoom adapter
-      expect(msgs[0].message.text).not.toMatch(/fun fact about your pseudonym:/i)
-    })
-
-    it('uses zoomChatIntroMessage for zoom chat intro', async () => {
-      const [chatChannel] = await Channel.create([{ name: 'chat' }])
-      const msgs = await agent.introduce(chatChannel, 'zoom')
-      expect(msgs).toHaveLength(1)
-      expect(msgs[0].messageType).toBe('json')
-      expect(msgs[0].message.type).toBe('intro')
-      expect(msgs[0].message.text).toContain(agent.agentConfig.botName)
-      expect(msgs[0].message.text).not.toContain('{{agentConfig.botName}}')
-      // zoomChatIntroMessage prompts DM for private questions
-      expect(msgs[0].message.text).toContain('send me a DM')
-    })
-
-    it('non-zoom DM intro still includes fun fact', async () => {
-      const [directChannel] = await Channel.create([
-        { name: 'direct-socket-agents', direct: true, participants: [user1._id, agent._id] }
-      ])
-      const msgs = await agent.introduce(directChannel)
-      expect(msgs).toHaveLength(1)
-      expect(msgs[0].message.text).toMatch(/fun fact about your pseudonym:/i)
     })
   })
 

--- a/tests/services/user.service.test.ts
+++ b/tests/services/user.service.test.ts
@@ -1,10 +1,15 @@
+/* eslint-disable no-console */
 import mongoose from 'mongoose'
 import setupIntTest from '../utils/setupIntTest.js'
 import { insertUsers, registeredUser } from '../fixtures/user.fixture.js'
 import { insertMessages, messageOne } from '../fixtures/message.fixture.js'
 import userService from '../../src/services/user.service.js'
+import { User } from '../../src/models/index.js'
+import config from '../../src/config/config.js'
 
 setupIntTest()
+
+jest.setTimeout(30000)
 
 const createVote = () => ({
   _id: new mongoose.Types.ObjectId(),
@@ -34,6 +39,23 @@ describe('User service methods', () => {
       expect(user.pseudonyms[0].pseudonym).toBe(userBody.pseudonym)
       expect(user.pseudonyms[0].active).toBe(true)
       expect(user.role).toBe('admin')
+    })
+
+    test('should generate and store a fun fact for the initial pseudonym', async () => {
+      const user = await userService.createUser({ username: 'u1', token: 't1', pseudonym: 'Bold Aardvark' })
+      console.log('createUser fun fact:', user.pseudonyms[0].funFact)
+      expect(user.pseudonyms[0].funFact).toBeDefined()
+    })
+
+    test('should skip fun fact generation when trulyRandomPseudonyms is enabled', async () => {
+      const original = config.trulyRandomPseudonyms
+      config.trulyRandomPseudonyms = 'true'
+      try {
+        const user = await userService.createUser({ username: 'u2', token: 't2', pseudonym: 'Woodpecker_e65ddfe1d20' })
+        expect(user.pseudonyms[0].funFact).toBeUndefined()
+      } finally {
+        config.trulyRandomPseudonyms = original
+      }
     })
 
     test('should create a user without email if not provided', async () => {
@@ -68,6 +90,55 @@ describe('User service methods', () => {
     })
   })
 
+  describe('addPseudonym()', () => {
+    test('should generate and store a fun fact for the added pseudonym', async () => {
+      const user = await User.create({
+        username: 'addtest',
+        pseudonyms: [{ token: 'tok1', pseudonym: 'Calm Cobra', active: true }],
+        role: 'admin'
+      })
+      await userService.addPseudonym({ token: 'tok2', pseudonym: 'Brave Beaver' }, { id: user._id })
+      const updated = await User.findById(user._id)
+      const added = updated!.pseudonyms.find((p) => p.pseudonym === 'Brave Beaver')
+      console.log('addPseudonym fun fact:', added!.funFact)
+      expect(added!.funFact).toBeDefined()
+    })
+  })
+
+  describe('activatePseudonym()', () => {
+    test('should generate a fun fact when activating a pseudonym that does not have one', async () => {
+      const user = await User.create({
+        username: 'activatetest',
+        pseudonyms: [
+          { token: 'tok1', pseudonym: 'Calm Cobra', active: true },
+          { token: 'tok2', pseudonym: 'Brave Beaver', active: false }
+        ],
+        role: 'admin'
+      })
+      await userService.activatePseudonym({ token: 'tok2' }, { id: user._id })
+      const updated = await User.findById(user._id)
+      const activated = updated!.pseudonyms.find((p) => p.token === 'tok2')
+      console.log('activatePseudonym fun fact:', activated!.funFact)
+      expect(activated!.funFact).toBeDefined()
+    })
+
+    test('should not regenerate a fun fact when activating a pseudonym that already has one', async () => {
+      const existingFact = 'Fun Fact about your pseudonym: existing fact'
+      const user = await User.create({
+        username: 'activatetest2',
+        pseudonyms: [
+          { token: 'tok1', pseudonym: 'Calm Cobra', active: true },
+          { token: 'tok2', pseudonym: 'Brave Beaver', active: false, funFact: existingFact }
+        ],
+        role: 'admin'
+      })
+      await userService.activatePseudonym({ token: 'tok2' }, { id: user._id })
+      const updated = await User.findById(user._id)
+      const activated = updated!.pseudonyms.find((p) => p.token === 'tok2')
+      expect(activated!.funFact).toBe(existingFact)
+    })
+  })
+
   describe('goodReputation()', () => {
     beforeEach(() => {
       // Add five upvotes
@@ -78,7 +149,6 @@ describe('User service methods', () => {
     })
 
     test('should return true if user vote score < -5 and account is more than 1 week old', async () => {
-      // Set created date to > week ago
       const d = new Date()
       d.setDate(d.getDate() - 8)
       registeredUser.createdAt = d.toISOString()
@@ -91,13 +161,11 @@ describe('User service methods', () => {
     })
 
     test('should return false if user vote score < -5', async () => {
-      // Set created date to > week ago
       const d = new Date()
       d.setDate(d.getDate() - 8)
       registeredUser.createdAt = d.toISOString()
       await insertUsers([registeredUser])
       messageOne.downVotes = []
-      // Add eleven downvotes
       for (let x = 0; x < 11; x++) {
         messageOne.downVotes.push(createVote())
       }
@@ -109,7 +177,6 @@ describe('User service methods', () => {
     })
 
     test('should return false if user account is less than one week old', async () => {
-      // Set created date to > week ago
       const d = new Date()
       registeredUser.createdAt = d.toISOString()
       await insertUsers([registeredUser])
@@ -121,12 +188,10 @@ describe('User service methods', () => {
     })
 
     test('should return false if user account is less than one week old user vote score < -5', async () => {
-      // Set created date to > week ago
       const d = new Date()
       registeredUser.createdAt = d.toISOString()
       await insertUsers([registeredUser])
       messageOne.downVotes = []
-      // Add eleven downvotes
       for (let x = 0; x < 11; x++) {
         messageOne.downVotes.push(createVote())
       }


### PR DESCRIPTION
## What is in this PR?

Changes event assistant intro messages to set a no-pressure welcome vibe, describe capabilities, and explain privacy/safety, in order to better establish trust. Removes pseudonym fun fact from intro, instead having the core product generate it and save it with the user data model when a user is created or a new user pseudonym is activated.

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- feat: add agent capabilities and scope setting to DM intro message
- refactor: rename summarization model env variables to core to reflect general usage by core system
planning to expand the use cases for the core (non-agent) system to use llms, more descriptive
- feat: remove pseudonym fun fact from EA intro message and store with pseudonym
generate fun fact for active pseudo when user created or active pseudo changed
- feat: add static introductory text to LLM-generated capabilities description in info msg
use llm to somewhat randomly highlight capabilities, hard-code the rest of the intro
- test: ensure transcript is loaded for all alternate name tests (unrelated but needed for CI to pass)

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] SUMMARY_LLM_PLATFORM/MODEL env vars renamed to CORE_LLM_PLATFORM, CORE_LLM_MODEL, but you were most likely using the defaults anyway
- [ ] Test in conjunction with FE PR https://github.com/berkmancenter/nextspace/pull/122
- [ ] Create an EA conversation with both NextSpace and Zoom platforms. Enable Moderator Support
- [ ] On NS, verify that the Berkie intro message looks something like (the part in bold is LLM-generated and should describe what Berkie can do): 
Hi! I'm Berkie, your private, anonymous support during this session. **Got questions about what Jessica's arguing? Ask me anything. Or if you step out, ask me to catch you up on what you missed.** Just type / if you want to see what else I can do. Your pseudonym keeps you anonymous, and nothing you share is ever used to train AI models. No need to respond, just know I'm here.
- [ ]  In Zoom, you should get a DM intro that says something like:
Hi! I'm Berkie, your private, anonymous support during this session. **Ask me to catch you up if you step out, or dig into any claim Jessica makes that you want more context on.** Use /mod to send a question to the moderator. Your pseudonym keeps you anonymous, and nothing you share is ever used to train AI models. No need to respond, just know I'm here.
- [ ] Create second EA conversation for Zoom without moderator support
- [ ] Verify the Zoom DM message for this one does NOT say 'Use /mod to send a question to the moderator. '


## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
