### PR TITLE
eventHistorian posts summary on conversation stopped

### DIFF
--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -63,6 +63,8 @@ function markdownToMrkdwn(text: string): string {
       .replace(/~~(.+?)~~/gs, '~$1~')
       // Headings: # Heading → *Heading* (bold, since Slack has no headings)
       .replace(/^#{1,6}\s+(.+)$/gm, '*$1*')
+      // Bullet points: "- text" or "* text" at start of line → "• text"
+      .replace(/^[ \t]*[-*][ \t]+/gm, '• ')
       // Links: [text](url) → <url|text>
       .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<$2|$1>')
   )

--- a/src/agents/eventHistorian/capabilities.ts
+++ b/src/agents/eventHistorian/capabilities.ts
@@ -2,8 +2,11 @@ import { AgentCapabilities } from '../../types/index.types.js'
 
 export default function (agentConfig: Record<string, unknown>): AgentCapabilities {
   const topicIds: string[] = (agentConfig?.topicIds as string[]) ?? []
+  const read = topicIds.length > 0
+    ? topicIds.map((id) => ({ type: 'topic' as const, id }))
+    : [{ type: 'allPublicTopics' as const }]
   return {
-    read: topicIds.map((id) => ({ type: 'topic' as const, id })),
+    read,
     write: [{ type: 'ownConversation' as const }]
   }
 }

--- a/src/agents/eventHistorian/capabilities.ts
+++ b/src/agents/eventHistorian/capabilities.ts
@@ -1,0 +1,9 @@
+import { AgentCapabilities } from '../../types/index.types.js'
+
+export default function (agentConfig: Record<string, unknown>): AgentCapabilities {
+  const topicIds: string[] = (agentConfig?.topicIds as string[]) ?? []
+  return {
+    read: topicIds.map((id) => ({ type: 'topic' as const, id })),
+    write: [{ type: 'ownConversation' as const }]
+  }
+}

--- a/src/agents/eventHistorian/eventHistorian.ts
+++ b/src/agents/eventHistorian/eventHistorian.ts
@@ -7,6 +7,7 @@ import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
 import { extractMessageText } from '../helpers/slashCommandParser.js'
 import createEventHistoryTools, { TopicRef } from '../tools/eventHistory.js'
 import Topic from '../../models/topic.model.js'
+import Conversation from '../../models/conversation.model.js'
 import config from '../../config/config.js'
 import { checkBotIntent, matchBotMention, normalizeBotMention } from '../helpers/intentChecks.js'
 
@@ -68,7 +69,12 @@ export default verify({
     const modifiedMessage = matchBotMention(words, this.agentConfig.botName)
       ? { ...userMessage, body: normalizeBotMention(userMessage.body, this.agentConfig.botName) }
       : userMessage
-    return { userMessage: modifiedMessage, action: AgentMessageActions.CONTRIBUTE, userContributionVisible: true, suggestion: undefined }
+    return {
+      userMessage: modifiedMessage,
+      action: AgentMessageActions.CONTRIBUTE,
+      userContributionVisible: true,
+      suggestion: undefined
+    }
   },
 
   async respond(conversationHistory: ConversationHistory, userMessage) {
@@ -127,6 +133,22 @@ export default verify({
         messageType: 'text',
         channels: responseChannels,
         parent: parentMessageId
+      }
+    ]
+  },
+
+  async onConversationEvent(evt) {
+    if (evt.type !== 'conversationStopped') return []
+    const conv = await Conversation.findById(evt.conversationId).select('name summary').lean()
+    if (!conv?.summary) return []
+    const name = conv.name ?? 'An event'
+    const responseChannels = this.conversation.channels.filter((c) => c.name === 'historian')
+    return [
+      {
+        visible: true,
+        message: `*${name}* just wrapped up. Here's a summary:\n\n${conv.summary}`,
+        messageType: 'text' as const,
+        channels: responseChannels
       }
     ]
   },

--- a/src/agents/eventHistorian/eventHistorian.ts
+++ b/src/agents/eventHistorian/eventHistorian.ts
@@ -146,7 +146,7 @@ export default verify({
     return [
       {
         visible: true,
-        message: `*${name}* just wrapped up. Here's a summary:\n\n${conv.summary}`,
+        message: `*${name}* just wrapped up. Here's a summary:\n\n${conv.summary}\n\n*Have questions about the event? Ask me anything.*`,
         messageType: 'text' as const,
         channels: responseChannels
       }

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -24,6 +24,7 @@ import experts from './development/experts/index.js'
 import generic from './development/generic/index.js'
 import config from '../config/config.js'
 import voiceAssistant from './eventAssistant/voiceAssistant.js'
+import logger from '../config/logger.js'
 
 const development = {
   civilityPerMessage,
@@ -37,7 +38,7 @@ const development = {
   generic
 }
 
-export default {
+const agentTypes = {
   ...(config.enableDevelopmentAgents ? development : {}),
   backChannelMetrics,
   backChannelInsights,
@@ -52,3 +53,15 @@ export default {
   eventHistorian,
   eventSetup
 }
+
+for (const [key, agentType] of Object.entries(agentTypes)) {
+  try {
+    const { default: caps } = await import(`./${key}/capabilities.js`)
+    agentType.capabilities = caps
+    logger.info(`Loaded capabilities for agent type: ${key}`)
+  } catch {
+    logger.debug(`No capabilities for agent type: ${key}`)
+  }
+}
+
+export default agentTypes

--- a/src/auth/access.ts
+++ b/src/auth/access.ts
@@ -16,6 +16,7 @@ function assertCanRead(caller: IBaseUser, scope: ReadScope) {
 
   const grants: ReadGrant[] = caller.capabilities?.read ?? []
   const allowed = grants.some((g) => {
+    if (g.type === 'allPublicTopics') return scope.topicIsPrivate !== true
     if (g.type === scope.type) return g.id === scope.id
     if (g.type === 'topic' && scope.type === 'conversation' && scope.topicId !== undefined) return g.id === scope.topicId
     return false

--- a/src/auth/access.ts
+++ b/src/auth/access.ts
@@ -1,0 +1,49 @@
+import Conversation from '../models/conversation.model.js'
+import { IAgent, IBaseUser, ReadGrant, ReadScope, WriteGrant, WriteScope } from '../types/index.types.js'
+import AccessDeniedError from '../utils/AccessDeniedError.js'
+
+export { AccessDeniedError }
+
+function isAgent(caller: IBaseUser): caller is IAgent {
+  return caller.__t === 'Agent'
+}
+
+function assertCanRead(caller: IBaseUser, scope: ReadScope) {
+  if (!isAgent(caller)) {
+    // User read checks are not yet centralised here — fall through for now
+    return
+  }
+
+  const grants: ReadGrant[] = caller.capabilities?.read ?? []
+  const allowed = grants.some((g) => {
+    if (g.type === scope.type) return g.id === scope.id
+    if (g.type === 'topic' && scope.type === 'conversation' && scope.topicId !== undefined) return g.id === scope.topicId
+    return false
+  })
+  if (!allowed) throw new AccessDeniedError(`Agent does not have read access to ${scope.type} ${scope.id}`)
+}
+
+async function assertCanWrite(caller: IBaseUser, scope: WriteScope) {
+  if (isAgent(caller)) {
+    // An ownConversation grant resolves to the agent's actual conversation
+    const grants: WriteGrant[] = caller.capabilities?.write ?? [{ type: 'ownConversation' }]
+    const allowed = grants.some((g) => g.type === 'ownConversation' && caller.conversation?._id?.toString() === scope.id)
+    if (!allowed) throw new AccessDeniedError(`Agent does not have write access to conversation ${scope.id}`)
+  } else {
+    // User: owner of the conversation may write to it
+    const conv = await Conversation.findById(scope.id).select('owner').lean()
+    if (!conv || conv.owner.toString() !== caller._id?.toString()) {
+      throw new AccessDeniedError(`User does not have write access to conversation ${scope.id}`)
+    }
+  }
+}
+
+async function listReadableConversations(caller: IBaseUser, scope: ReadScope) {
+  assertCanRead(caller, scope)
+
+  if (scope.type === 'topic') return Conversation.find({ topic: scope.id }).exec()
+  return Conversation.find({ _id: scope.id }).exec()
+}
+
+const access = { assertCanRead, assertCanWrite, listReadableConversations }
+export default access

--- a/src/jobs/agentDispatcher.ts
+++ b/src/jobs/agentDispatcher.ts
@@ -1,0 +1,27 @@
+import Agent from '../models/user.model/agent.model/index.js'
+import access from '../auth/access.js'
+import schedule from './schedule.js'
+import logger from '../config/logger.js'
+import { ConversationEvent, ReadScope } from '../types/index.types.js'
+
+async function dispatch(event: ConversationEvent, scope: ReadScope) {
+  const candidates = await Agent.find({ active: true }).populate('conversation').exec()
+
+  let notified = 0
+  for (const agent of candidates) {
+    try {
+      access.assertCanRead(agent, scope)
+      const agentId = agent._id.toString()
+      await schedule.conversationEvent({ agentId, event })
+      notified++
+    } catch (err) {
+      logger.debug(`Agent ${agent._id} skipped: ${err.message}`)
+    }
+  }
+
+  if (notified > 0) {
+    logger.debug(`Dispatched ${event.type} to ${notified} agent(s) for ${scope.type} ${scope.id}`)
+  }
+}
+
+export default { dispatch }

--- a/src/jobs/define.ts
+++ b/src/jobs/define.ts
@@ -33,6 +33,10 @@ const defineJob = {
   summarizePdf: async () => {
     await agenda.start()
     await agenda.define('summarize pdf', JobHandlers.summarizePdf)
+  },
+  conversationEvent: async () => {
+    await agenda.start()
+    await agenda.define('conversationEvent', JobHandlers.conversationEvent)
   }
 }
 

--- a/src/jobs/handlers/agent.ts
+++ b/src/jobs/handlers/agent.ts
@@ -5,7 +5,11 @@ import resourceService from '../../services/resource.service.js'
 import { AgentMessageActions, AgentResponseZodSchema } from '../../types/index.types.js'
 
 const handleAgentResponse = async (response, agent) => {
-  AgentResponseZodSchema.parse(response)
+  const parsed = AgentResponseZodSchema.safeParse(response)
+  if (!parsed.success) {
+    logger.error(`agentResponse handler ${agent._id} - invalid response shape, skipping`, parsed.error)
+    return
+  }
   return messageService.newMessageHandler(agentResponseToMessageData(response, agent), agent)
 }
 

--- a/src/jobs/handlers/conversationEvent.ts
+++ b/src/jobs/handlers/conversationEvent.ts
@@ -14,7 +14,11 @@ const conversationEvent = async (job) => {
     logger.debug(`conversationEvent handler ${agent._id} - event type: ${event.type}`)
     const responses = await agent.onConversationEvent(event)
     for (const response of responses) {
-      AgentResponseZodSchema.parse(response)
+      const parsed = AgentResponseZodSchema.safeParse(response)
+      if (!parsed.success) {
+        logger.error(`conversationEvent handler ${agent._id} - invalid response shape, skipping`, parsed.error)
+        continue
+      }
       await messageService.newMessageHandler(agentResponseToMessageData(response, agent), agent)
     }
   } catch (error) {

--- a/src/jobs/handlers/conversationEvent.ts
+++ b/src/jobs/handlers/conversationEvent.ts
@@ -1,0 +1,25 @@
+import logger from '../../config/logger.js'
+import Agent from '../../models/user.model/agent.model/index.js'
+import messageService, { agentResponseToMessageData } from '../../services/message.service.js'
+import { AgentResponseZodSchema } from '../../types/index.types.js'
+
+const conversationEvent = async (job) => {
+  const { agentId, event } = job.attrs.data
+  try {
+    const agent = await Agent.findOne({ _id: agentId }).exec()
+    if (!agent) {
+      logger.warn(`Could not find agent ${agentId}`)
+      return
+    }
+    logger.debug(`conversationEvent handler ${agent._id} - event type: ${event.type}`)
+    const responses = await agent.onConversationEvent(event)
+    for (const response of responses) {
+      AgentResponseZodSchema.parse(response)
+      await messageService.newMessageHandler(agentResponseToMessageData(response, agent), agent)
+    }
+  } catch (error) {
+    logger.error(`conversationEvent job failed for agent ${agentId}`, error)
+  }
+}
+
+export default { conversationEvent }

--- a/src/jobs/handlers/index.ts
+++ b/src/jobs/handlers/index.ts
@@ -1,5 +1,6 @@
 import agentHandlers from './agent.js'
 import conversationHandlers from './conversation.js'
+import conversationEventHandlers from './conversationEvent.js'
 import resourceHandlers from './resource.js'
 import topicHandlers from './topic.js'
 import transcriptHandlers from './transcript.js'
@@ -8,6 +9,7 @@ const JobHandlers = {
   // Agent handlers
   agentResponse: agentHandlers.agentResponse,
   periodicAgent: agentHandlers.periodicAgent,
+  conversationEvent: conversationEventHandlers.conversationEvent,
 
   // Conversation handlers
   autoStartConversation: conversationHandlers.autoStartConversation,

--- a/src/jobs/schedule.ts
+++ b/src/jobs/schedule.ts
@@ -36,6 +36,9 @@ const schedule = {
   },
   summarizePdf: async (data: { conversationId: string; resourceId: string; filePath: string; citation: string }) => {
     await agenda.now('summarize pdf', data)
+  },
+  conversationEvent: async (data: { agentId: string; event: unknown }) => {
+    await agenda.now('conversationEvent', data)
   }
 }
 

--- a/src/jobs/startup.ts
+++ b/src/jobs/startup.ts
@@ -11,6 +11,7 @@ export async function startJobs() {
     await defineJob.cleanUpTranscripts()
     await schedule.cleanUpTranscripts()
     await defineJob.summarizePdf()
+    await defineJob.conversationEvent()
   }
 }
 

--- a/src/models/user.model/agent.model/index.ts
+++ b/src/models/user.model/agent.model/index.ts
@@ -19,6 +19,7 @@ import {
   AgentMessageActions,
   AgentEvaluation,
   AgentResponse,
+  ConversationEvent
 } from '../../../types/index.types.js'
 import { ConversationDocument } from '../../conversation.model.js'
 import { pingLLM } from '../../../agents/helpers/llmChain.js'
@@ -41,13 +42,13 @@ const llmPlatformOptionsSchema = new mongoose.Schema<ILlmPlatformOptions>({
 })
 
 export interface AgentMethods {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   respond(message?: IMessage): Promise<Array<AgentResponse<unknown>>>
   evaluate(message?: IMessage): Promise<AgentEvaluation>
   deepPatch(patch: Record<string, unknown>)
   start()
   stop()
   introduce(channel: IChannel): Promise<Array<AgentResponse<unknown>>>
+  onConversationEvent(evt: ConversationEvent): Promise<Array<AgentResponse<unknown>>>
   pingLLM(): Promise<void>
   getLLM(): Promise<unknown>
 }
@@ -532,6 +533,14 @@ agentSchema.method('deepPatch', function (origPatch) {
   Object.assign(this, update)
 
   this.conversation = conversation
+})
+
+agentSchema.method('onConversationEvent', async function (evt: ConversationEvent) {
+  const agentType = agentTypes[this.agentType]
+  if (!agentType.onConversationEvent) return []
+  if (!this.populated('conversation')) await this.populate('conversation')
+  await (this.conversation as HydratedDocument<IConversation>).populate('channels')
+  return agentType.onConversationEvent.call(this, evt)
 })
 
 agentSchema.method('introduce', async function (channel, adapterType?) {

--- a/src/models/user.model/agent.model/index.ts
+++ b/src/models/user.model/agent.model/index.ts
@@ -18,7 +18,7 @@ import {
   LLM_PLATFORMS,
   AgentMessageActions,
   AgentEvaluation,
-  AgentResponse
+  AgentResponse,
 } from '../../../types/index.types.js'
 import { ConversationDocument } from '../../conversation.model.js'
 import { pingLLM } from '../../../agents/helpers/llmChain.js'
@@ -132,6 +132,10 @@ const agentSchema = new mongoose.Schema<IAgent, AgentModel>(
       default: false
     },
     conversationHistorySettings: {
+      type: mongoose.Schema.Types.Mixed,
+      default: undefined
+    },
+    capabilities: {
       type: mongoose.Schema.Types.Mixed,
       default: undefined
     }
@@ -491,8 +495,13 @@ agentSchema.pre('validate', function () {
   if (this.ragCollectionName === undefined) {
     this.ragCollectionName = agentTypes[this.agentType].ragCollectionName
   }
+  // Resolve capabilities from agent type definition if provided
+  const { capabilities, preValidate } = agentTypes[this.agentType]
+  if (capabilities) {
+    this.capabilities = capabilities(this.agentConfig ?? {})
+  }
+
   // custom preValidate call when needed
-  const { preValidate } = agentTypes[this.agentType]
   if (preValidate) {
     preValidate.call(this)
   }

--- a/src/services/conversation.service/lifecycle.ts
+++ b/src/services/conversation.service/lifecycle.ts
@@ -136,9 +136,10 @@ export async function doStopConversation(conversation) {
   await doc.save()
 
   const topicId = doc.topic?._id?.toString() ?? doc.topic?.toString()
+  const topicIsPrivate = doc.topic?.private ?? true
   await agentDispatcher.dispatch(
     { type: 'conversationStopped', conversationId: doc._id.toString(), topicId },
-    { type: 'conversation', id: doc._id.toString(), topicId }
+    { type: 'conversation', id: doc._id.toString(), topicId, topicIsPrivate }
   )
 
   return doc

--- a/src/services/conversation.service/lifecycle.ts
+++ b/src/services/conversation.service/lifecycle.ts
@@ -15,16 +15,19 @@ import getConversationHistory from '../../agents/helpers/getConversationHistory.
 
 const transcriptBatchInterval = 30
 const SUMMARIZATION_PROMPT = `
-  Please summarize what happened during this conversation. Where possible, also draw conclusions about outcomes of the discussion. 
+  Please summarize what happened during this conversation. Where possible, also draw conclusions about outcomes of the discussion.
   When available, use as reference the listed speaker(s), moderator(s) and their bios, and event description.
 
   - **IMPORTANT**: you are summarizing for the event attendees. You are not worried about things like engagement or metrics. You want to provide a clear and concise summary of the key points and outcomes in a digestible format.
-  - **LENGTH**: write no more than three paragraphs. Be selective — prioritize the most significant points and outcomes over completeness.
+  - **FORMAT**: use exactly these three sections, each with a bold heading on its own line (not inside a bullet):
+    - **The Gist** — 2-4 sentences covering the core topic and key takeaway.
+    - **Highlights** — exactly 3 bullets with the most important facts, perspectives, or conclusions drawn from the event. Keep each bullet to one sentence.
+    - **The Breakdown** — 3-5 bullets listing the main topics or segments covered, in order. One sentence each, no sub-bullets.
   - The tone is friendly and conversational.
-  - The event content will be made up of a transcript as well as participant messages. 
+  - The event content will be made up of a transcript as well as participant messages.
   - The transcript is drawing from what was said by the speakers in the event, or in some cases might be a video presentation of some kind. Be aware that speakers are generally allowed to use whatever media they would like during the conversation.
-  - The participant messages are from attendees in a group chat either on Zoom or within a custom-built front-end app.
-  - Participants might want to know what other participants were saying relative to the event wrap-up.`
+  - The participant messages are from attendees in a group chat either on Zoom or within a custom-built front-end app. Messages labelled "AI Assistant" are from automated assistants — ignore them entirely, do not mention or attribute them.
+  - Only include a section about group chat if there were meaningful participant contributions. If the chat was empty or contained only AI Assistant messages, omit it entirely.`
 
 export const updateTranscriptStatus = async (
   conversation,
@@ -106,8 +109,8 @@ export async function doStopConversation(conversation) {
         const chatHistory = getConversationHistory(sortedMessages, { channels: ['chat'] })
         const sharedChat =
           formatMultiUserConversationHistory(chatHistory)
-            .map((m) => (m.role === 'assistant' ? `Assistant: ${m.content}` : m.content))
-            .join('\n') || 'No shared chat messages yet.'
+            .map((m) => (m.role === 'assistant' ? `AI Assistant: ${m.content}` : m.content))
+            .join('\n') || 'No participant chat messages.'
 
         // Get speaker and moderator information if available
         const speakers = `${conversationDoc.presenters?.map((p) => `${p.name}: ${p.bio}`).join(', ')}` || 'Not provided'

--- a/src/services/conversation.service/lifecycle.ts
+++ b/src/services/conversation.service/lifecycle.ts
@@ -2,6 +2,7 @@ import httpStatus from 'http-status'
 import ApiError from '../../utils/ApiError.js'
 import websocketGateway from '../../websockets/websocketGateway.js'
 import agentService from '../agent.service/index.js'
+import agentDispatcher from '../../jobs/agentDispatcher.js'
 import schedule from '../../jobs/schedule.js'
 import defineJob from '../../jobs/define.js'
 import logger from '../../config/logger.js'
@@ -88,12 +89,14 @@ export async function doStopConversation(conversation) {
   if (doc.transcript) {
     await updateTranscriptStatus(doc, 'stopped')
     const owner = await User.findById(conversation.owner)
-    
+
     if (owner) {
-      const conversationDoc = await Conversation.findOne({ _id: conversation._id }).populate('channels').populate({ path: 'messages', match: { channels: { $in: ['transcript', 'chat'] } } })
+      const conversationDoc = await Conversation.findOne({ _id: conversation._id })
+        .populate('channels')
+        .populate({ path: 'messages', match: { channels: { $in: ['transcript', 'chat'] } } })
 
       if (conversationDoc) {
-        const llm = await getModelChat(coreLLMPlatform, coreLLMModel, {maxTokens: 2000})
+        const llm = await getModelChat(coreLLMPlatform, coreLLMModel, { maxTokens: 2000 })
         const sortedMessages = conversationDoc.messages.sort(
           (a, b) => (a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0)
         )
@@ -131,5 +134,12 @@ export async function doStopConversation(conversation) {
     } else logger.warn(`No owner found for conversation ${doc._id}`)
   }
   await doc.save()
+
+  const topicId = doc.topic?._id?.toString() ?? doc.topic?.toString()
+  await agentDispatcher.dispatch(
+    { type: 'conversationStopped', conversationId: doc._id.toString(), topicId },
+    { type: 'conversation', id: doc._id.toString(), topicId }
+  )
+
   return doc
 }

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -525,6 +525,13 @@ export interface AgentCapabilities {
   read: ReadGrant[]
   write: WriteGrant[]
 }
+export interface ConversationStoppedEvent {
+  type: 'conversationStopped'
+  conversationId: string
+  topicId?: string
+}
+
+export type ConversationEvent = ConversationStoppedEvent
 
 export interface IAgent {
   _id?: mongoose.Types.ObjectId

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -516,8 +516,10 @@ export interface EmbeddingsModelDetails {
   description: string
 }
 
-export type ReadScope = { type: 'topic'; id: string } | { type: 'conversation'; id: string; topicId?: string }
-export type ReadGrant = ReadScope
+export type ReadScope =
+  | { type: 'topic'; id: string; topicIsPrivate?: boolean }
+  | { type: 'conversation'; id: string; topicId?: string; topicIsPrivate?: boolean }
+export type ReadGrant = ReadScope | { type: 'allPublicTopics' }
 export type WriteScope = { type: 'conversation'; id: string }
 export type WriteGrant = { type: 'ownConversation' }
 

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -23,6 +23,7 @@ export interface IPseudonym {
 export interface IBaseUser {
   _id?: mongoose.Types.ObjectId
   activePseudonym?: IPseudonym
+  __t?: string
 }
 
 export interface IUserPreferences {
@@ -515,6 +516,16 @@ export interface EmbeddingsModelDetails {
   description: string
 }
 
+export type ReadScope = { type: 'topic'; id: string } | { type: 'conversation'; id: string; topicId?: string }
+export type ReadGrant = ReadScope
+export type WriteScope = { type: 'conversation'; id: string }
+export type WriteGrant = { type: 'ownConversation' }
+
+export interface AgentCapabilities {
+  read: ReadGrant[]
+  write: WriteGrant[]
+}
+
 export interface IAgent {
   _id?: mongoose.Types.ObjectId
   name: string
@@ -532,6 +543,7 @@ export interface IAgent {
   llmTemplateVars?: { [key: string]: { name: string; description: string }[] }
   llmTemplates?: { [key: string]: string }
   agentConfig?: { [key: string]: unknown }
+  capabilities?: AgentCapabilities
   ragCollectionName?: string
   triggers?: Triggers
   active?: boolean

--- a/src/utils/AccessDeniedError.ts
+++ b/src/utils/AccessDeniedError.ts
@@ -1,0 +1,6 @@
+export default class AccessDeniedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AccessDeniedError'
+  }
+}

--- a/tests/adapters/slack.adapter.test.ts
+++ b/tests/adapters/slack.adapter.test.ts
@@ -282,6 +282,26 @@ describe('slack adapter tests', () => {
       it('handles mixed formatting in a single message', async () => {
         expect(await sendAndGetText('**bold** and *italic* and ~~strike~~')).toBe('*bold* and _italic_ and ~strike~')
       })
+
+      it('converts "- item" bullet to "• item"', async () => {
+        expect(await sendAndGetText('- item one')).toBe('• item one')
+      })
+
+      it('converts "* item" bullet to "• item"', async () => {
+        expect(await sendAndGetText('* item one')).toBe('• item one')
+      })
+
+      it('converts multiple bullet lines', async () => {
+        expect(await sendAndGetText('- first\n- second\n- third')).toBe('• first\n• second\n• third')
+      })
+
+      it('converts indented bullets', async () => {
+        expect(await sendAndGetText('  - indented')).toBe('• indented')
+      })
+
+      it('does not convert dashes mid-sentence', async () => {
+        expect(await sendAndGetText('well-known fact')).toBe('well-known fact')
+      })
     })
 
     describe('Slack user ID mention formatting', () => {

--- a/tests/agents/eventHistorian/eventHistorian.agent.test.ts
+++ b/tests/agents/eventHistorian/eventHistorian.agent.test.ts
@@ -306,6 +306,60 @@ A single mom of two children with primary custody, she is passionate about findi
     })
   })
 
+  describe('onConversationEvent', () => {
+    let stoppedConversation
+
+    beforeEach(async () => {
+      stoppedConversation = await createConversation({ name: 'Past Event' }, user1, topic)
+    })
+
+    it('returns empty array for non-conversationStopped event types', async () => {
+      const responses = await defaultAgentTypes.eventHistorian.onConversationEvent.call(agent, {
+        type: 'unknownEvent',
+        conversationId: stoppedConversation._id.toString()
+      })
+
+      expect(responses).toHaveLength(0)
+    })
+
+    it('returns empty array when conversation has no summary', async () => {
+      const responses = await defaultAgentTypes.eventHistorian.onConversationEvent.call(agent, {
+        type: 'conversationStopped',
+        conversationId: stoppedConversation._id.toString()
+      })
+
+      expect(responses).toHaveLength(0)
+    })
+
+    it('returns a summary message when conversation has a summary', async () => {
+      await stoppedConversation.updateOne({ summary: 'Key takeaways from the event.' })
+
+      const responses = await defaultAgentTypes.eventHistorian.onConversationEvent.call(agent, {
+        type: 'conversationStopped',
+        conversationId: stoppedConversation._id.toString()
+      })
+
+      expect(responses).toHaveLength(1)
+      expect(responses[0].message).toContain('Past Event')
+      expect(responses[0].message).toContain('Key takeaways from the event.')
+    })
+
+    it('posts to the historian channel when one exists', async () => {
+      const historianChannel = await Channel.create({ name: 'historian' })
+      conversation.channels.push(historianChannel)
+      await conversation.save()
+      await stoppedConversation.updateOne({ summary: 'A summary.' })
+
+      const responses = await defaultAgentTypes.eventHistorian.onConversationEvent.call(agent, {
+        type: 'conversationStopped',
+        conversationId: stoppedConversation._id.toString()
+      })
+
+      expect(responses[0].channels).toHaveLength(1)
+      expect(responses[0].channels[0].name).toBe('historian')
+    })
+  })
+
   describe('uses all public topics when topicIds is not configured', () => {
     let eventTopic
     let partTimeConv

--- a/tests/jobs/handlers/conversationEvent.handler.test.ts
+++ b/tests/jobs/handlers/conversationEvent.handler.test.ts
@@ -1,0 +1,104 @@
+import mongoose from 'mongoose'
+import { Conversation, Agent } from '../../../src/models/index.js'
+import { publicTopic, conversationAgentsEnabled } from '../../fixtures/conversation.fixture.js'
+import { insertTopics } from '../../fixtures/topic.fixture.js'
+import { insertUsers, registeredUser } from '../../fixtures/user.fixture.js'
+import handlers from '../../../src/jobs/handlers/conversationEvent.js'
+import { setAgentTypes } from '../../../src/models/user.model/agent.model/index.js'
+import { defaultLLMPlatform, defaultLLMModel } from '../../../src/agents/helpers/getModelChat.js'
+import messageService from '../../../src/services/message.service.js'
+import setupIntTest from '../../utils/setupIntTest.js'
+
+setupIntTest()
+
+const testAgentTypes = {
+  periodic: {
+    respond: jest.fn(),
+    evaluate: jest.fn(),
+    onConversationEvent: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+    name: 'Test Periodic Agent',
+    description: 'A periodic test agent',
+    maxTokens: 2000,
+    defaultTriggers: { periodic: { timerPeriod: 300 } },
+    priority: 10,
+    llmTemplateVars: {},
+    defaultLLMTemplates: {},
+    defaultLLMPlatform,
+    defaultLLMModel
+  }
+}
+
+describe('conversationEvent handler', () => {
+  let conversation
+  let agent
+
+  beforeAll(() => {
+    setAgentTypes(testAgentTypes)
+  })
+
+  beforeEach(async () => {
+    await insertUsers([registeredUser])
+    await insertTopics([publicTopic])
+    conversation = new Conversation({ ...conversationAgentsEnabled, active: true })
+    await conversation.save()
+    agent = new Agent({ agentType: 'periodic', conversation: conversation._id, active: true })
+    await agent.save()
+    jest.restoreAllMocks()
+  })
+
+  const makeJob = (overrides: Record<string, unknown> = {}) => ({
+    attrs: {
+      data: {
+        agentId: agent._id.toString(),
+        event: { type: 'conversationStopped', conversationId: conversation._id.toString() },
+        ...overrides
+      }
+    }
+  })
+
+  test('does not throw when agent is not found', async () => {
+    const fakeId = new mongoose.Types.ObjectId()
+    await expect(
+      handlers.conversationEvent({ attrs: { data: { agentId: fakeId.toString(), event: { type: 'conversationStopped', conversationId: 'conv-1' } } } })
+    ).resolves.not.toThrow()
+  })
+
+  test('calls onConversationEvent with the event', async () => {
+    const onConversationEventSpy = jest.spyOn(Agent.prototype, 'onConversationEvent').mockResolvedValue([])
+
+    const event = { type: 'conversationStopped', conversationId: conversation._id.toString() }
+    await handlers.conversationEvent(makeJob({ event }))
+
+    expect(onConversationEventSpy).toHaveBeenCalledWith(event)
+  })
+
+  test('calls newMessageHandler for each valid response', async () => {
+    const responses = [
+      { visible: true, message: 'Summary posted', messageType: 'text', channels: [] },
+      { visible: true, message: 'Also this', messageType: 'text', channels: [] }
+    ]
+    jest.spyOn(Agent.prototype, 'onConversationEvent').mockResolvedValue(responses)
+    const newMessageSpy = jest.spyOn(messageService, 'newMessageHandler').mockResolvedValue([])
+
+    await handlers.conversationEvent(makeJob())
+
+    expect(newMessageSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('does not call newMessageHandler when agent returns no responses', async () => {
+    jest.spyOn(Agent.prototype, 'onConversationEvent').mockResolvedValue([])
+    const newMessageSpy = jest.spyOn(messageService, 'newMessageHandler').mockResolvedValue([])
+
+    await handlers.conversationEvent(makeJob())
+
+    expect(newMessageSpy).not.toHaveBeenCalled()
+  })
+
+  test('does not throw when onConversationEvent fails', async () => {
+    jest.spyOn(Agent.prototype, 'onConversationEvent').mockRejectedValue(new Error('LLM error'))
+
+    await expect(handlers.conversationEvent(makeJob())).resolves.not.toThrow()
+  })
+})

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -4,7 +4,7 @@ import setupIntTest from '../utils/setupIntTest.js'
 import { insertUsers, registeredUser } from '../fixtures/user.fixture.js'
 import { insertTopics, newPublicTopic } from '../fixtures/topic.fixture.js'
 import conversationService from '../../src/services/conversation.service/index.js'
-import { Agent, Adapter } from '../../src/models/index.js'
+import { Agent, Adapter, Conversation } from '../../src/models/index.js'
 import ApiError from '../../src/utils/ApiError.js'
 import websocketGateway from '../../src/websockets/websocketGateway.js'
 import { supportedModels, defaultLLMPlatform, defaultLLMModel } from '../../src/agents/helpers/getModelChat.js'
@@ -16,6 +16,7 @@ import config from '../../src/config/config.js'
 import schedule from '../../src/jobs/schedule.js'
 import defineJob from '../../src/jobs/define.js'
 import transcript from '../../src/agents/helpers/transcript.js'
+import agentDispatcher from '../../src/jobs/agentDispatcher.js'
 
 jest.setTimeout(10000)
 jest.mock('agenda')
@@ -1101,6 +1102,35 @@ describe('Conversation service methods', () => {
           expect.anything()
         )
       })
+    })
+  })
+
+  describe('stopConversation()', () => {
+    let conversation
+
+    beforeEach(async () => {
+      await insertUsers([registeredUser])
+      await insertTopics([topicOne])
+      conversation = new Conversation({
+        name: 'Test Stop',
+        owner: registeredUser._id,
+        topic: topicOne._id,
+        active: true,
+        agents: [],
+        messages: []
+      })
+      await conversation.save()
+    })
+
+    test('dispatches conversationStopped event when conversation is stopped', async () => {
+      const dispatchSpy = jest.spyOn(agentDispatcher, 'dispatch').mockResolvedValue(undefined)
+
+      await conversationService.stopConversation(conversation._id.toString(), registeredUser)
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'conversationStopped', conversationId: conversation._id.toString() }),
+        expect.objectContaining({ type: 'conversation', id: conversation._id.toString() })
+      )
     })
   })
 

--- a/tests/unit/auth/access.test.ts
+++ b/tests/unit/auth/access.test.ts
@@ -1,0 +1,179 @@
+import mongoose from 'mongoose'
+import Conversation from '../../../src/models/conversation.model.js'
+import access, { AccessDeniedError } from '../../../src/auth/access.js'
+
+function makeAgent(overrides: Record<string, unknown> = {}) {
+  const conversationId = new mongoose.Types.ObjectId()
+  return {
+    __t: 'Agent',
+    _id: new mongoose.Types.ObjectId(),
+    conversation: { _id: conversationId },
+    capabilities: {
+      read: [],
+      write: [{ type: 'ownConversation' as const }]
+    },
+    ...overrides
+  }
+}
+
+function makeUser(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: new mongoose.Types.ObjectId(),
+    ...overrides
+  }
+}
+
+describe('access', () => {
+  describe('assertCanRead', () => {
+    test('user caller passes through for topic scope (not yet centralised)', () => {
+      expect(() => access.assertCanRead(makeUser(), { type: 'topic', id: 'topic-1' })).not.toThrow()
+    })
+
+    test('agent with matching topic grant passes', () => {
+      const agent = makeAgent({ capabilities: { read: [{ type: 'topic', id: 'topic-1' }], write: [] } })
+      expect(() => access.assertCanRead(agent, { type: 'topic', id: 'topic-1' })).not.toThrow()
+    })
+
+    test('agent with no read grants throws', () => {
+      const agent = makeAgent({ capabilities: { read: [], write: [] } })
+      expect(() => access.assertCanRead(agent, { type: 'topic', id: 'topic-1' })).toThrow(AccessDeniedError)
+    })
+
+    test('agent with no capabilities throws', () => {
+      const agent = makeAgent({ capabilities: undefined })
+      expect(() => access.assertCanRead(agent, { type: 'topic', id: 'topic-1' })).toThrow(AccessDeniedError)
+    })
+
+    test('agent with topic grant for a different id throws', () => {
+      const agent = makeAgent({ capabilities: { read: [{ type: 'topic', id: 'topic-2' }], write: [] } })
+      expect(() => access.assertCanRead(agent, { type: 'topic', id: 'topic-1' })).toThrow(AccessDeniedError)
+    })
+
+    test('agent with matching conversation grant passes', () => {
+      const agent = makeAgent({ capabilities: { read: [{ type: 'conversation', id: 'conv-1' }], write: [] } })
+      expect(() => access.assertCanRead(agent, { type: 'conversation', id: 'conv-1' })).not.toThrow()
+    })
+
+    test('agent with conversation grant for a different id throws', () => {
+      const agent = makeAgent({ capabilities: { read: [{ type: 'conversation', id: 'conv-2' }], write: [] } })
+      expect(() => access.assertCanRead(agent, { type: 'conversation', id: 'conv-1' })).toThrow(AccessDeniedError)
+    })
+
+    test('agent with topic grant passes for a conversation scope carrying that topicId', () => {
+      const agent = makeAgent({ capabilities: { read: [{ type: 'topic', id: 'topic-1' }], write: [] } })
+      expect(() => access.assertCanRead(agent, { type: 'conversation', id: 'conv-1', topicId: 'topic-1' })).not.toThrow()
+    })
+
+    test('agent with topic grant throws when conversation scope carries a different topicId', () => {
+      const agent = makeAgent({ capabilities: { read: [{ type: 'topic', id: 'topic-1' }], write: [] } })
+      expect(() => access.assertCanRead(agent, { type: 'conversation', id: 'conv-1', topicId: 'topic-2' })).toThrow(AccessDeniedError)
+    })
+
+    test('agent with topic grant throws when conversation scope has no topicId', () => {
+      const agent = makeAgent({ capabilities: { read: [{ type: 'topic', id: 'topic-1' }], write: [] } })
+      expect(() => access.assertCanRead(agent, { type: 'conversation', id: 'conv-1' })).toThrow(AccessDeniedError)
+    })
+
+    test('agent with multiple grants passes when any match', () => {
+      const agent = makeAgent({
+        capabilities: {
+          read: [{ type: 'topic', id: 'topic-1' }, { type: 'topic', id: 'topic-2' }],
+          write: []
+        }
+      })
+      expect(() => access.assertCanRead(agent, { type: 'topic', id: 'topic-2' })).not.toThrow()
+    })
+  })
+
+  describe('assertCanWrite', () => {
+    test('agent with ownConversation grant passes when scope matches its conversation', async () => {
+      const agent = makeAgent()
+      const conversationId = agent.conversation._id.toString()
+      await expect(access.assertCanWrite(agent, { type: 'conversation', id: conversationId })).resolves.toBeUndefined()
+    })
+
+    test('agent with ownConversation grant throws when scope is a different conversation', async () => {
+      const agent = makeAgent()
+      const otherId = new mongoose.Types.ObjectId().toString()
+      await expect(access.assertCanWrite(agent, { type: 'conversation', id: otherId })).rejects.toThrow(AccessDeniedError)
+    })
+
+    test('agent with no capabilities defaults to ownConversation grant', async () => {
+      const agent = makeAgent({ capabilities: undefined })
+      const conversationId = agent.conversation._id.toString()
+      await expect(access.assertCanWrite(agent, { type: 'conversation', id: conversationId })).resolves.toBeUndefined()
+    })
+
+    describe('user caller', () => {
+      let findByIdSpy: jest.SpyInstance
+
+      beforeEach(() => {
+        findByIdSpy = jest.spyOn(Conversation, 'findById')
+      })
+
+      afterEach(() => {
+        findByIdSpy.mockRestore()
+      })
+
+      test('passes when user owns the conversation', async () => {
+        const user = makeUser()
+        findByIdSpy.mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue({ owner: user._id })
+          })
+        })
+        await expect(access.assertCanWrite(user, { type: 'conversation', id: 'conv-1' })).resolves.toBeUndefined()
+      })
+
+      test('throws when user does not own the conversation', async () => {
+        const user = makeUser()
+        findByIdSpy.mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue({ owner: new mongoose.Types.ObjectId() })
+          })
+        })
+        await expect(access.assertCanWrite(user, { type: 'conversation', id: 'conv-1' })).rejects.toThrow(AccessDeniedError)
+      })
+
+      test('throws when conversation is not found', async () => {
+        const user = makeUser()
+        findByIdSpy.mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue(null)
+          })
+        })
+        await expect(access.assertCanWrite(user, { type: 'conversation', id: 'conv-1' })).rejects.toThrow(AccessDeniedError)
+      })
+    })
+  })
+
+  describe('listReadableConversations', () => {
+    let findSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      findSpy = jest.spyOn(Conversation, 'find').mockReturnValue({ exec: jest.fn().mockResolvedValue([]) } as unknown as ReturnType<typeof Conversation.find>)
+    })
+
+    afterEach(() => {
+      findSpy.mockRestore()
+    })
+
+    test('throws before querying when agent lacks read grant', async () => {
+      const agent = makeAgent({ capabilities: { read: [], write: [] } })
+      await expect(access.listReadableConversations(agent, { type: 'topic', id: 'topic-1' })).rejects.toThrow(AccessDeniedError)
+      expect(findSpy).not.toHaveBeenCalled()
+    })
+
+    test('queries by topic when scope is topic', async () => {
+      const agent = makeAgent({ capabilities: { read: [{ type: 'topic', id: 'topic-1' }], write: [] } })
+      await access.listReadableConversations(agent, { type: 'topic', id: 'topic-1' })
+      expect(findSpy).toHaveBeenCalledWith({ topic: 'topic-1' })
+    })
+
+    test('queries by id when scope is conversation', async () => {
+      const agent = makeAgent({ capabilities: { read: [{ type: 'conversation', id: 'conv-1' }], write: [] } })
+      await access.listReadableConversations(agent, { type: 'conversation', id: 'conv-1' })
+      expect(findSpy).toHaveBeenCalledWith({ _id: 'conv-1' })
+    })
+  })
+})

--- a/tests/unit/auth/access.test.ts
+++ b/tests/unit/auth/access.test.ts
@@ -74,6 +74,30 @@ describe('access', () => {
       expect(() => access.assertCanRead(agent, { type: 'conversation', id: 'conv-1' })).toThrow(AccessDeniedError)
     })
 
+    describe('allPublicTopics grant', () => {
+      const agent = makeAgent({ capabilities: { read: [{ type: 'allPublicTopics' }], write: [] } })
+
+      test('passes for a conversation scope on a public topic', () => {
+        expect(() => access.assertCanRead(agent, { type: 'conversation', id: 'conv-1', topicIsPrivate: false })).not.toThrow()
+      })
+
+      test('passes when topicIsPrivate is not set', () => {
+        expect(() => access.assertCanRead(agent, { type: 'conversation', id: 'conv-1' })).not.toThrow()
+      })
+
+      test('throws for a conversation scope on a private topic', () => {
+        expect(() => access.assertCanRead(agent, { type: 'conversation', id: 'conv-1', topicIsPrivate: true })).toThrow(AccessDeniedError)
+      })
+
+      test('passes for a public topic scope', () => {
+        expect(() => access.assertCanRead(agent, { type: 'topic', id: 'topic-1', topicIsPrivate: false })).not.toThrow()
+      })
+
+      test('throws for a private topic scope', () => {
+        expect(() => access.assertCanRead(agent, { type: 'topic', id: 'topic-1', topicIsPrivate: true })).toThrow(AccessDeniedError)
+      })
+    })
+
     test('agent with multiple grants passes when any match', () => {
       const agent = makeAgent({
         capabilities: {

--- a/tests/unit/jobs/agentDispatcher.test.ts
+++ b/tests/unit/jobs/agentDispatcher.test.ts
@@ -1,0 +1,81 @@
+import mongoose from 'mongoose'
+import Agent from '../../../src/models/user.model/agent.model/index.js'
+import access, { AccessDeniedError } from '../../../src/auth/access.js'
+import schedule from '../../../src/jobs/schedule.js'
+import agentDispatcher from '../../../src/jobs/agentDispatcher.js'
+import { ConversationEvent, ReadScope } from '../../../src/types/index.types.js'
+
+const event: ConversationEvent = { type: 'conversationStopped', conversationId: 'conv-1' }
+const scope: ReadScope = { type: 'conversation', id: 'conv-1', topicId: 'topic-1' }
+
+function makeAgent() {
+  return {
+    _id: new mongoose.Types.ObjectId(),
+    capabilities: { read: [{ type: 'topic', id: 'topic-1' }], write: [] }
+  }
+}
+
+function mockFind(agents: unknown[]) {
+  return jest.spyOn(Agent, 'find').mockReturnValue({
+    populate: jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue(agents)
+    })
+  } as unknown as ReturnType<typeof Agent.find>)
+}
+
+describe('agentDispatcher.dispatch', () => {
+  let assertCanReadSpy: jest.SpyInstance
+  let scheduleSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    assertCanReadSpy = jest.spyOn(access, 'assertCanRead')
+    scheduleSpy = jest.spyOn(schedule, 'conversationEvent').mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('does not schedule anything when no active agents', async () => {
+    mockFind([])
+
+    await agentDispatcher.dispatch(event, scope)
+
+    expect(scheduleSpy).not.toHaveBeenCalled()
+  })
+
+  test('schedules a job for each agent that passes assertCanRead', async () => {
+    const agents = [makeAgent(), makeAgent()]
+    mockFind(agents)
+    assertCanReadSpy.mockReturnValue(undefined)
+
+    await agentDispatcher.dispatch(event, scope)
+
+    expect(scheduleSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('skips agents that fail assertCanRead', async () => {
+    const agents = [makeAgent(), makeAgent(), makeAgent()]
+    mockFind(agents)
+    assertCanReadSpy
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(undefined)
+      .mockImplementationOnce(() => {
+        throw new AccessDeniedError('no access')
+      })
+
+    await agentDispatcher.dispatch(event, scope)
+
+    expect(scheduleSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('passes the event and agentId to schedule', async () => {
+    const agent = makeAgent()
+    mockFind([agent])
+    assertCanReadSpy.mockReturnValue(undefined)
+
+    await agentDispatcher.dispatch(event, scope)
+
+    expect(scheduleSpy).toHaveBeenCalledWith({ agentId: agent._id.toString(), event })
+  })
+})


### PR DESCRIPTION
## What is in this PR?

The goal of this PR is for the `eventHistorian` to post an event summary at the end of an event (e.g. to Slack if configured for a Slack channel). It adds infra necessary to notify agents of conversation events, determining if they have permission to read a particular conversation, either through a read grant to that specific conversation, the topic containing the conversation, or an 'allPublicTopics' grant. Agent types whose folder contains a file called `capabilities.ts` will have their read and write grants automatically loaded into the agent instances on create/update. 

`eventHistorian` is updated to post the summary generated for a conversation to the `historian` channel on receipt of any `ConversationStoppedEvent` within its scope (either app public topics or the `topicIds` configured in its `agentConfig`).

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- feat: add authorization layer with agent capabilities
- feat: add mechanism to dispatch conversation events to agents with access
- feat: send conversation stopped event to agents on conversation stop
- feat: load capabilities function from agent folder if exists
- feat: eventHistorian posts summary on conversation stopped
- feat: add allPublicTopics agent capabilities grant

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x] Hook eventHistorian to a private test Slack channel by creating the appropriate conversation (see `Create Historian Slack Conversation in our Hoppscotch for preconfigured request. Just substitute the `slackChannel` with the channel ID). Remove `topicIds` to test the default `allPublicTopics` case.
- [x] Create an event under a public topic and generate some transcript
- [x] Stop the event (manually through Hoppscotch `Stop conversation` endpoint. Events typically auto-stop 30 minutes after endTime, but this is easiest shortcut for testing)
- [ ] Verify a summary is posted to your Slack channel
- [ ] Create and stop another conversation in a private topic and verify that the summary is NOT posted to the Slack channel and all fails gracefully
- [ ] Could delete and recreate the Historian Slack Conversation with specific `topicIds` specified in `properties` and verify this also works




## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
