### PR TITLE
Support separate Slack bot identities in the same workspace

### DIFF
--- a/src/adapters/slack/client.ts
+++ b/src/adapters/slack/client.ts
@@ -10,12 +10,12 @@ class SlackClientPool {
     this.maxSize = maxSize
   }
 
-  getClient(workspaceId, botToken): WebClient {
-    if (this.clients.has(workspaceId)) {
+  getClient(botToken: string): WebClient {
+    if (this.clients.has(botToken)) {
       // Move to end (most recently used)
-      const client = this.clients.get(workspaceId)
-      this.clients.delete(workspaceId)
-      this.clients.set(workspaceId, client!)
+      const client = this.clients.get(botToken)
+      this.clients.delete(botToken)
+      this.clients.set(botToken, client!)
       return client!
     }
     const client = new WebClient(botToken)
@@ -24,7 +24,7 @@ class SlackClientPool {
       const firstKey = this.clients.keys().next().value
       this.clients.delete(firstKey)
     }
-    this.clients.set(workspaceId, client)
+    this.clients.set(botToken, client)
     return client
   }
 

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -1,7 +1,7 @@
 import { ChatPostMessageResponse } from '@slack/web-api'
 import type { KnownBlock, Block } from '@slack/types'
 import logger from '../../config/logger.js'
-import slackClientPool from './slackClientPool.js'
+import slackClientPool from './client.js'
 import { AdapterMessage } from '../../types/adapter.types.js'
 import Message from '../../models/message.model.js'
 
@@ -80,7 +80,7 @@ export default {
     const text = markdownToMrkdwn(message.body)
       .replace(/(?<![<@\w])(U[A-Z0-9]{6,})\b/g, '<@$1>')
       .replace(/(?<!<)@(U[A-Z0-9]{6,})\b/g, '<@$1>')
-    const slackWebClient = slackClientPool.getClient(this.config.workspace, this.config.botToken)
+    const slackWebClient = slackClientPool.getClient(this.config.botToken)
 
     let threadTs: string | undefined
     if (message.parentMessage) {
@@ -123,7 +123,7 @@ export default {
       }
     })
     if (!this.config.botUserId) {
-      const slackWebClient = slackClientPool.getClient(this.config.workspace, this.config.botToken)
+      const slackWebClient = slackClientPool.getClient(this.config.botToken)
       const authResult = await slackWebClient.auth.test()
       if (!authResult.ok || !authResult.user_id) {
         throw new Error(`Failed to look up Slack bot user ID: ${authResult.error}`)

--- a/src/conversations/eventHistorian.ts
+++ b/src/conversations/eventHistorian.ts
@@ -38,6 +38,21 @@ const eventHistorian: ConversationType = {
       type: 'string'
     },
     {
+      name: 'slackSigningSecret',
+      label: 'Slack App Signing Secret',
+      description: 'The signing secret for the Slack app. Defaults to the system-wide signing secret if not provided.',
+      required: false,
+      type: 'string'
+    },
+    {
+      name: 'slackAppKey',
+      label: 'Slack App Key in Webhook',
+      description:
+        'The app key for the Slack app, used as last part ofwebhook URL to route incoming messages to the appropriate adapter.',
+      required: false,
+      type: 'string'
+    },
+    {
       name: 'botName',
       label: 'Bot Name',
       description: 'The display name for the bot',
@@ -83,7 +98,9 @@ const eventHistorian: ConversationType = {
         workspace: '{{{properties.slackWorkspace}}}',
         botToken: '{{{properties.slackBotToken}}}',
         botUserId: '{{{properties.slackBotUserId}}}', // for normalizing incoming messages
-        botName: '{{{properties.botName}}}'
+        botName: '{{{properties.botName}}}',
+        signingSecret: '{{{properties.slackSigningSecret}}}',
+        appKey: '{{{properties.slackAppKey}}}'
       },
       chatChannels: [
         {

--- a/src/handlers/helpers/findSlackAdapter.ts
+++ b/src/handlers/helpers/findSlackAdapter.ts
@@ -31,14 +31,15 @@ export default async function findSlackAdapter({
   appKey?: string
   payload: SlackPayload
 }): Promise<AdapterDocument | null> {
-  const eventTeam = payload?.event?.team
+  // Slack's API still calls workspaces "teams", so `event.team` is the workspace ID.
+  const slackWorkspaceId = payload?.event?.team
   if (appKey) {
     const byAppKey = await Adapter.findOne({ type: 'slack', 'config.appKey': appKey })
     if (byAppKey) {
       // A bot lives in one workspace. If the payload claims a different one, refuse the lookup
       // even though the URL matched a row. Keeps a leaked URL from being probed with forged
       // payloads from other workspaces.
-      if (eventTeam && byAppKey.config?.workspace !== eventTeam) return null
+      if (slackWorkspaceId && byAppKey.config?.workspace !== slackWorkspaceId) return null
       return byAppKey
     }
   }

--- a/src/handlers/helpers/findSlackAdapter.ts
+++ b/src/handlers/helpers/findSlackAdapter.ts
@@ -34,9 +34,17 @@ export default async function findSlackAdapter({
   appKey?: string
   payload: SlackPayload
 }): Promise<AdapterDocument | null> {
+  const eventTeam = payload?.event?.team
   if (appKey) {
     const byAppKey = await Adapter.findOne({ type: 'slack', 'config.appKey': appKey })
-    if (byAppKey) return byAppKey
+    if (byAppKey) {
+      // Defense in depth: a single Slack bot lives in one workspace. If the event payload claims
+      // to come from a different workspace, treat the lookup as unmatched. The signature check
+      // would normally catch a forged payload, but rejecting on shape here keeps a leaked appKey
+      // URL from being used to probe with payloads from arbitrary workspaces.
+      if (eventTeam && byAppKey.config?.workspace !== eventTeam) return null
+      return byAppKey
+    }
   }
 
   const event = payload?.event

--- a/src/handlers/helpers/findSlackAdapter.ts
+++ b/src/handlers/helpers/findSlackAdapter.ts
@@ -1,0 +1,51 @@
+import Adapter, { AdapterDocument } from '../../models/adapter.model.js'
+
+type SlackEvent = {
+  type?: string
+  channel?: string
+  channel_type?: string
+  team?: string
+}
+
+type SlackPayload = {
+  event?: SlackEvent
+}
+
+/**
+ * Find the Slack Adapter row a webhook belongs to.
+ *
+ * Lookup order:
+ *   1. `config.appKey` if an appKey was provided (new per-bot URL shape:
+ *      `/v1/webhooks/slack/:appKey`).
+ *   2. `config.workspace` + `config.channel` derived from the event payload
+ *      (the original Berkie URL shape, kept as a fallback so existing webhook
+ *      URLs keep working through the rollout).
+ *
+ * DM events (`channel_type === 'im'`) match on the workspace's
+ * `config.channel === 'direct'` adapter, mirroring the legacy handler.
+ *
+ * Returns null when nothing matches, so callers can decide how to respond
+ * (typically with a 401 to avoid leaking which side is wrong).
+ */
+export default async function findSlackAdapter({
+  appKey,
+  payload
+}: {
+  appKey?: string
+  payload: SlackPayload
+}): Promise<AdapterDocument | null> {
+  if (appKey) {
+    const byAppKey = await Adapter.findOne({ type: 'slack', 'config.appKey': appKey })
+    if (byAppKey) return byAppKey
+  }
+
+  const event = payload?.event
+  if (!event?.team) return null
+
+  if (event.channel_type === 'im') {
+    return Adapter.findOne({ type: 'slack', 'config.channel': 'direct', 'config.workspace': event.team })
+  }
+
+  if (!event.channel) return null
+  return Adapter.findOne({ type: 'slack', 'config.channel': event.channel, 'config.workspace': event.team })
+}

--- a/src/handlers/helpers/findSlackAdapter.ts
+++ b/src/handlers/helpers/findSlackAdapter.ts
@@ -12,20 +12,17 @@ type SlackPayload = {
 }
 
 /**
- * Find the Slack Adapter row a webhook belongs to.
+ * Find the database row for the Slack bot that should receive a webhook.
  *
- * Lookup order:
- *   1. `config.appKey` if an appKey was provided (new per-bot URL shape:
- *      `/v1/webhooks/slack/:appKey`).
- *   2. `config.workspace` + `config.channel` derived from the event payload
- *      (the original Berkie URL shape, kept as a fallback so existing webhook
- *      URLs keep working through the rollout).
+ * Tries two lookup paths:
+ *   1. By the bot identifier carried in the webhook URL (when present).
+ *   2. By the workspace and channel found inside the event payload.
  *
- * DM events (`channel_type === 'im'`) match on the workspace's
- * `config.channel === 'direct'` adapter, mirroring the legacy handler.
+ * Direct-message events use a fixed channel name ("direct") on the row,
+ * since a DM isn't tied to a specific channel ID.
  *
- * Returns null when nothing matches, so callers can decide how to respond
- * (typically with a 401 to avoid leaking which side is wrong).
+ * Returns null if nothing matches. Callers should respond 401 rather than
+ * 404 so the response doesn't reveal which Slack channels are wired up.
  */
 export default async function findSlackAdapter({
   appKey,
@@ -38,10 +35,9 @@ export default async function findSlackAdapter({
   if (appKey) {
     const byAppKey = await Adapter.findOne({ type: 'slack', 'config.appKey': appKey })
     if (byAppKey) {
-      // Defense in depth: a single Slack bot lives in one workspace. If the event payload claims
-      // to come from a different workspace, treat the lookup as unmatched. The signature check
-      // would normally catch a forged payload, but rejecting on shape here keeps a leaked appKey
-      // URL from being used to probe with payloads from arbitrary workspaces.
+      // A bot lives in one workspace. If the payload claims a different one, refuse the lookup
+      // even though the URL matched a row. Keeps a leaked URL from being probed with forged
+      // payloads from other workspaces.
       if (eventTeam && byAppKey.config?.workspace !== eventTeam) return null
       return byAppKey
     }

--- a/src/handlers/helpers/resolveSlackSigningSecret.ts
+++ b/src/handlers/helpers/resolveSlackSigningSecret.ts
@@ -2,14 +2,12 @@ import config from '../../config/config.js'
 import logger from '../../config/logger.js'
 
 /**
- * Resolve the Slack signing secret to validate a webhook against.
+ * Pick the Slack signing secret used to validate a bot's webhook signature.
  *
- * Precedence: per-adapter `config.signingSecret` first, then the global
- * env-var secret (`config.slack.signingSecret`). The env-var fallback exists
- * so Berkie keeps working during the rollout. Once every Slack-backed
- * adapter has its own row-stored secret, the env var (and this fallback)
- * can be deleted. A deprecation warning fires each time we fall through so
- * the cutover progress is visible in logs.
+ * Each bot can store its own secret on its database row. If a bot doesn't
+ * have one, this falls back to the global env-var secret and logs a warning
+ * so the gap is visible. Once every bot has its own secret stored, the
+ * env-var fallback can be removed.
  */
 export default function resolveSlackSigningSecret(adapter: { config?: Record<string, unknown> } | null | undefined): string {
   const adapterSecret = adapter?.config?.signingSecret

--- a/src/handlers/helpers/resolveSlackSigningSecret.ts
+++ b/src/handlers/helpers/resolveSlackSigningSecret.ts
@@ -1,0 +1,26 @@
+import config from '../../config/config.js'
+import logger from '../../config/logger.js'
+
+/**
+ * Resolve the Slack signing secret to validate a webhook against.
+ *
+ * Precedence: per-adapter `config.signingSecret` first, then the global
+ * env-var secret (`config.slack.signingSecret`). The env-var fallback exists
+ * so Berkie keeps working during the rollout. Once every Slack-backed
+ * adapter has its own row-stored secret, the env var (and this fallback)
+ * can be deleted. A deprecation warning fires each time we fall through so
+ * the cutover progress is visible in logs.
+ */
+export default function resolveSlackSigningSecret(adapter: { config?: Record<string, unknown> } | null | undefined): string {
+  const adapterSecret = adapter?.config?.signingSecret
+  if (typeof adapterSecret === 'string' && adapterSecret) return adapterSecret
+
+  if (config.slack.signingSecret) {
+    logger.warn(
+      'Falling back to global SLACK_SIGNING_SECRET env var. Set adapter.config.signingSecret per bot and remove the env var when rollout is complete.'
+    )
+    return config.slack.signingSecret
+  }
+
+  throw new Error('No Slack signing secret available: set adapter.config.signingSecret or the SLACK_SIGNING_SECRET env var.')
+}

--- a/src/handlers/slack.ts
+++ b/src/handlers/slack.ts
@@ -4,6 +4,7 @@ import config from '../config/config.js'
 import logger from '../config/logger.js'
 import validateSignature from './helpers/validateSignature.js'
 import findSlackAdapter from './helpers/findSlackAdapter.js'
+import resolveSlackSigningSecret from './helpers/resolveSlackSigningSecret.js'
 import webhookService from '../services/webhook.service.js'
 import slackInteractionHandler from './slackInteraction.js'
 
@@ -66,7 +67,8 @@ const handleEvent = async (req, res) => {
   // Skip bot messages to prevent loops and skip messages with subtypes, which are not user messages (they represent events like user joining a channel, etc)
   if (event.type === 'message' && !event.bot_id && !event.subtype) {
     // TODO limit same Slack channel to one active Conversation
-    const slackAdapter = await findSlackAdapter({ appKey: req.params?.appKey, payload })
+    // Middleware already resolved and attached the adapter when validating the signature.
+    const slackAdapter = req.slackAdapter ?? (await findSlackAdapter({ appKey: req.params?.appKey, payload }))
     if (!slackAdapter) {
       throw new ApiError(
         httpStatus.NOT_FOUND,
@@ -95,11 +97,36 @@ const middleware = async (req, res, next) => {
     if (!rawBody) {
       throw new ApiError(httpStatus.BAD_REQUEST, 'Raw body missing')
     }
-    const isValid = validateSignature(slackTimestamp, rawBody, slackSignature, config.slack.signingSecret)
 
+    // A request can only be tied to a specific bot's signing secret if it carries either a
+    // :appKey route param or an event payload with a team ID we can look up by. URL verification
+    // (sent before any Adapter row exists), interactive payloads (form-encoded, JSON nested in a
+    // field), and other event-less callbacks don't, so they validate against the env-var secret.
+    const appKey: string | undefined = req.params?.appKey
+    const eventTeam: string | undefined = req.body?.event?.team
+    const canIdentifyAdapter = Boolean(appKey || eventTeam)
+
+    if (!canIdentifyAdapter) {
+      const isValid = validateSignature(slackTimestamp, rawBody, slackSignature, config.slack.signingSecret)
+      if (!isValid) {
+        throw new ApiError(httpStatus.UNAUTHORIZED, 'Invalid Slack signature')
+      }
+      next()
+      return
+    }
+
+    const slackAdapter = await findSlackAdapter({ appKey, payload: req.body })
+    if (!slackAdapter) {
+      // Stay deliberately vague: don't reveal whether the adapter is missing or the signature is bad.
+      throw new ApiError(httpStatus.UNAUTHORIZED, 'Invalid Slack signature')
+    }
+
+    const isValid = validateSignature(slackTimestamp, rawBody, slackSignature, resolveSlackSigningSecret(slackAdapter))
     if (!isValid) {
       throw new ApiError(httpStatus.UNAUTHORIZED, 'Invalid Slack signature')
     }
+
+    req.slackAdapter = slackAdapter
     next()
   } catch (err) {
     next(err)

--- a/src/handlers/slack.ts
+++ b/src/handlers/slack.ts
@@ -103,8 +103,9 @@ const middleware = async (req, res, next) => {
     // ID to look it up by. URL verification and button-click payloads have neither, so they fall
     // back to the global env-var secret.
     const appKey: string | undefined = req.params?.appKey
-    const eventTeam: string | undefined = req.body?.event?.team
-    const canIdentifyAdapter = Boolean(appKey || eventTeam)
+    // Slack's API still calls workspaces "teams", so `event.team` is the workspace ID.
+    const slackWorkspaceId: string | undefined = req.body?.event?.team
+    const canIdentifyAdapter = Boolean(appKey || slackWorkspaceId)
 
     if (!canIdentifyAdapter) {
       const isValid = validateSignature(slackTimestamp, rawBody, slackSignature, config.slack.signingSecret)

--- a/src/handlers/slack.ts
+++ b/src/handlers/slack.ts
@@ -1,9 +1,9 @@
 import httpStatus from 'http-status'
 import ApiError from '../utils/ApiError.js'
-import Adapter from '../models/adapter.model.js'
 import config from '../config/config.js'
 import logger from '../config/logger.js'
 import validateSignature from './helpers/validateSignature.js'
+import findSlackAdapter from './helpers/findSlackAdapter.js'
 import webhookService from '../services/webhook.service.js'
 import slackInteractionHandler from './slackInteraction.js'
 
@@ -65,22 +65,8 @@ const handleEvent = async (req, res) => {
   }
   // Skip bot messages to prevent loops and skip messages with subtypes, which are not user messages (they represent events like user joining a channel, etc)
   if (event.type === 'message' && !event.bot_id && !event.subtype) {
-    let slackAdapter
     // TODO limit same Slack channel to one active Conversation
-    if (event.channel_type === 'im') {
-      // Only one Conversation can process Slack DMs, since they are not related to a specific "conversation" or "channel"
-      slackAdapter = await Adapter.findOne({
-        type: 'slack',
-        'config.channel': 'direct',
-        'config.workspace': event.team
-      })
-    } else {
-      slackAdapter = await Adapter.findOne({
-        type: 'slack',
-        'config.channel': event.channel,
-        'config.workspace': event.team
-      })
-    }
+    const slackAdapter = await findSlackAdapter({ appKey: req.params?.appKey, payload })
     if (!slackAdapter) {
       throw new ApiError(
         httpStatus.NOT_FOUND,

--- a/src/handlers/slack.ts
+++ b/src/handlers/slack.ts
@@ -67,7 +67,7 @@ const handleEvent = async (req, res) => {
   // Skip bot messages to prevent loops and skip messages with subtypes, which are not user messages (they represent events like user joining a channel, etc)
   if (event.type === 'message' && !event.bot_id && !event.subtype) {
     // TODO limit same Slack channel to one active Conversation
-    // Middleware already resolved and attached the adapter when validating the signature.
+    // The middleware already looked up the bot when it validated the signature, so reuse it.
     const slackAdapter = req.slackAdapter ?? (await findSlackAdapter({ appKey: req.params?.appKey, payload }))
     if (!slackAdapter) {
       throw new ApiError(
@@ -98,10 +98,10 @@ const middleware = async (req, res, next) => {
       throw new ApiError(httpStatus.BAD_REQUEST, 'Raw body missing')
     }
 
-    // A request can only be tied to a specific bot's signing secret if it carries either a
-    // :appKey route param or an event payload with a team ID we can look up by. URL verification
-    // (sent before any Adapter row exists), interactive payloads (form-encoded, JSON nested in a
-    // field), and other event-less callbacks don't, so they validate against the env-var secret.
+    // To validate against a specific bot's secret, the request first has to identify the bot:
+    // either the URL carries a bot identifier, or the body has an event payload with a workspace
+    // ID to look it up by. URL verification and button-click payloads have neither, so they fall
+    // back to the global env-var secret.
     const appKey: string | undefined = req.params?.appKey
     const eventTeam: string | undefined = req.body?.event?.team
     const canIdentifyAdapter = Boolean(appKey || eventTeam)

--- a/src/routes/v1/webhooks.route.ts
+++ b/src/routes/v1/webhooks.route.ts
@@ -95,6 +95,10 @@ const router = express.Router()
  *         $ref: '#/components/responses/NotFound'
  *
  */
+// Per-bot Slack URL: identifies which Slack app this webhook belongs to. Registered before the
+// catch-all so req.params.appKey is populated. The legacy /v1/webhooks/slack URL (no segment)
+// still works via the catch-all and falls back to workspace+channel lookup.
+router.post('/slack/:appKey', useAdapter(), webhookController.processEvent)
 router.post('*', useAdapter(), webhookController.processEvent)
 
 export default router

--- a/src/routes/v1/webhooks.route.ts
+++ b/src/routes/v1/webhooks.route.ts
@@ -95,9 +95,9 @@ const router = express.Router()
  *         $ref: '#/components/responses/NotFound'
  *
  */
-// Per-bot Slack URL: identifies which Slack app this webhook belongs to. Registered before the
-// catch-all so req.params.appKey is populated. The legacy /v1/webhooks/slack URL (no segment)
-// still works via the catch-all and falls back to workspace+channel lookup.
+// Slack webhook URL with a bot identifier in the path. Registered before the catch-all so the
+// identifier is captured as a route param. The shorter /v1/webhooks/slack URL (no identifier)
+// still works via the catch-all and figures out the bot from the message body.
 router.post('/slack/:appKey', useAdapter(), webhookController.processEvent)
 router.post('*', useAdapter(), webhookController.processEvent)
 

--- a/tests/adapters/slack.adapter.test.ts
+++ b/tests/adapters/slack.adapter.test.ts
@@ -7,7 +7,7 @@ import { publicTopic } from '../fixtures/conversation.fixture.js'
 import { insertTopics } from '../fixtures/topic.fixture.js'
 import Adapter from '../../src/models/adapter.model.js'
 import websocketGateway from '../../src/websockets/websocketGateway.js'
-import slackClientPool from '../../src/adapters/slack/slackClientPool.js'
+import slackClientPool from '../../src/adapters/slack/client.js'
 
 import { Direction } from '../../src/types/index.types.js'
 

--- a/tests/adapters/slack.client.test.ts
+++ b/tests/adapters/slack.client.test.ts
@@ -12,10 +12,10 @@ describe('slack client cache', () => {
   })
 
   it('returns distinct WebClient instances for two different bot tokens in the same workspace', () => {
-    // Two bots (e.g. Berkie and VA) installed in the same Slack workspace must get
-    // separate clients, since the cache key is the bot token, not the workspace.
-    const berkie = slackClientPool.getClient('xoxb-berkie-token')
-    const va = slackClientPool.getClient('xoxb-va-token')
-    expect(berkie).not.toBe(va)
+    // Two bots installed in the same Slack workspace must get separate clients. The cache
+    // keys on the bot token so the bots can't collide on each other's connections.
+    const firstBot = slackClientPool.getClient('xoxb-first-bot-token')
+    const secondBot = slackClientPool.getClient('xoxb-second-bot-token')
+    expect(firstBot).not.toBe(secondBot)
   })
 })

--- a/tests/adapters/slack.client.test.ts
+++ b/tests/adapters/slack.client.test.ts
@@ -1,0 +1,21 @@
+import slackClientPool from '../../src/adapters/slack/client.js'
+
+describe('slack client cache', () => {
+  beforeEach(() => {
+    slackClientPool.clear()
+  })
+
+  it('returns the same WebClient instance when called twice with the same bot token', () => {
+    const a = slackClientPool.getClient('xoxb-token-1')
+    const b = slackClientPool.getClient('xoxb-token-1')
+    expect(a).toBe(b)
+  })
+
+  it('returns distinct WebClient instances for two different bot tokens in the same workspace', () => {
+    // Two bots (e.g. Berkie and VA) installed in the same Slack workspace must get
+    // separate clients, since the cache key is the bot token, not the workspace.
+    const berkie = slackClientPool.getClient('xoxb-berkie-token')
+    const va = slackClientPool.getClient('xoxb-va-token')
+    expect(berkie).not.toBe(va)
+  })
+})

--- a/tests/handlers/helpers/findSlackAdapter.test.ts
+++ b/tests/handlers/helpers/findSlackAdapter.test.ts
@@ -9,10 +9,11 @@ import findSlackAdapter from '../../../src/handlers/helpers/findSlackAdapter.js'
 setupIntTest()
 
 const makeAdapter = async (config: Record<string, unknown>) => {
-  // Fresh _id per call: the shared fixture pins one, which collides when used twice.
+  // A fresh _id per call — the shared fixture pins one, which collides when reused.
   const conversation = new Conversation({ ...conversationAgentsEnabled, _id: new mongoose.Types.ObjectId() })
   await conversation.save()
-  // botToken + botUserId satisfy the slack adapter pre-validate hook without hitting Slack.
+  // botToken and botUserId satisfy the Slack adapter's pre-save validation without calling out
+  // to Slack's auth.test endpoint.
   return Adapter.create({
     type: 'slack',
     config: { botToken: 'xoxb-test', botUserId: 'U_TEST', ...config },
@@ -54,10 +55,9 @@ describe('findSlackAdapter', () => {
   })
 
   it('returns null when the appKey matches but the event came from a different workspace', async () => {
-    // Defense in depth: a single Slack bot lives in one workspace. If an event payload claims to
-    // come from a different one, refuse it even though the appKey lookup hit a row — the
-    // signature check should already catch this, but the cheap pre-check rejects forged shapes
-    // before we hand the bot's secret to the validator.
+    // A bot lives in one workspace. If a payload claims a different one, refuse it even though
+    // the appKey lookup hit a row. The signature check would normally catch a forged payload,
+    // but rejecting on shape keeps a leaked URL from being probed with payloads from elsewhere.
     await makeAdapter({ channel: 'C_VA', workspace: 'W_VA', appKey: 'va' })
 
     const found = await findSlackAdapter({

--- a/tests/handlers/helpers/findSlackAdapter.test.ts
+++ b/tests/handlers/helpers/findSlackAdapter.test.ts
@@ -1,0 +1,77 @@
+import mongoose from 'mongoose'
+import setupIntTest from '../../utils/setupIntTest.js'
+import Adapter from '../../../src/models/adapter.model.js'
+import Conversation from '../../../src/models/conversation.model.js'
+import { conversationAgentsEnabled, publicTopic } from '../../fixtures/conversation.fixture.js'
+import { insertTopics } from '../../fixtures/topic.fixture.js'
+import findSlackAdapter from '../../../src/handlers/helpers/findSlackAdapter.js'
+
+setupIntTest()
+
+const makeAdapter = async (config: Record<string, unknown>) => {
+  // Fresh _id per call: the shared fixture pins one, which collides when used twice.
+  const conversation = new Conversation({ ...conversationAgentsEnabled, _id: new mongoose.Types.ObjectId() })
+  await conversation.save()
+  // botToken + botUserId satisfy the slack adapter pre-validate hook without hitting Slack.
+  return Adapter.create({
+    type: 'slack',
+    config: { botToken: 'xoxb-test', botUserId: 'U_TEST', ...config },
+    conversation: conversation._id,
+    active: true
+  })
+}
+
+describe('findSlackAdapter', () => {
+  beforeEach(async () => {
+    await insertTopics([publicTopic])
+  })
+
+  it('resolves by appKey when provided and a match exists', async () => {
+    await makeAdapter({ channel: 'C_OTHER', workspace: 'T1', appKey: 'berkie' })
+    const va = await makeAdapter({ channel: 'C_VA', workspace: 'T1', appKey: 'va' })
+
+    const found = await findSlackAdapter({ appKey: 'va', payload: { event: {} } })
+    expect(found?._id.toString()).toBe(va._id.toString())
+  })
+
+  it('falls back to workspace+channel when no appKey is provided', async () => {
+    const berkie = await makeAdapter({ channel: 'C123', workspace: 'T1' })
+
+    const found = await findSlackAdapter({
+      payload: { event: { type: 'message', channel: 'C123', team: 'T1' } }
+    })
+    expect(found?._id.toString()).toBe(berkie._id.toString())
+  })
+
+  it('resolves the workspace DM adapter when the event is an im', async () => {
+    await makeAdapter({ channel: 'C123', workspace: 'T1' })
+    const dm = await makeAdapter({ channel: 'direct', workspace: 'T1' })
+
+    const found = await findSlackAdapter({
+      payload: { event: { type: 'message', channel_type: 'im', channel: 'D123', team: 'T1' } }
+    })
+    expect(found?._id.toString()).toBe(dm._id.toString())
+  })
+
+  it('falls back to workspace+channel when appKey is provided but not found', async () => {
+    const berkie = await makeAdapter({ channel: 'C123', workspace: 'T1' })
+
+    const found = await findSlackAdapter({
+      appKey: 'nonexistent',
+      payload: { event: { type: 'message', channel: 'C123', team: 'T1' } }
+    })
+    expect(found?._id.toString()).toBe(berkie._id.toString())
+  })
+
+  it('returns null when nothing matches', async () => {
+    const found = await findSlackAdapter({
+      payload: { event: { type: 'message', channel: 'C_MISSING', team: 'T_MISSING' } }
+    })
+    expect(found).toBeNull()
+  })
+
+  it('returns null when there is no event on the payload', async () => {
+    const found = await findSlackAdapter({ payload: {} })
+    expect(found).toBeNull()
+  })
+})

--- a/tests/handlers/helpers/findSlackAdapter.test.ts
+++ b/tests/handlers/helpers/findSlackAdapter.test.ts
@@ -9,7 +9,7 @@ import findSlackAdapter from '../../../src/handlers/helpers/findSlackAdapter.js'
 setupIntTest()
 
 const makeAdapter = async (config: Record<string, unknown>) => {
-  // A fresh _id per call — the shared fixture pins one, which collides when reused.
+  // A fresh _id per call: the shared fixture pins one, which collides when reused.
   const conversation = new Conversation({ ...conversationAgentsEnabled, _id: new mongoose.Types.ObjectId() })
   await conversation.save()
   // botToken and botUserId satisfy the Slack adapter's pre-save validation without calling out

--- a/tests/handlers/helpers/findSlackAdapter.test.ts
+++ b/tests/handlers/helpers/findSlackAdapter.test.ts
@@ -53,6 +53,20 @@ describe('findSlackAdapter', () => {
     expect(found?._id.toString()).toBe(dm._id.toString())
   })
 
+  it('returns null when the appKey matches but the event came from a different workspace', async () => {
+    // Defense in depth: a single Slack bot lives in one workspace. If an event payload claims to
+    // come from a different one, refuse it even though the appKey lookup hit a row — the
+    // signature check should already catch this, but the cheap pre-check rejects forged shapes
+    // before we hand the bot's secret to the validator.
+    await makeAdapter({ channel: 'C_VA', workspace: 'W_VA', appKey: 'va' })
+
+    const found = await findSlackAdapter({
+      appKey: 'va',
+      payload: { event: { type: 'message', channel: 'C_VA', team: 'W_DIFFERENT' } }
+    })
+    expect(found).toBeNull()
+  })
+
   it('falls back to workspace+channel when appKey is provided but not found', async () => {
     const berkie = await makeAdapter({ channel: 'C123', workspace: 'T1' })
 

--- a/tests/handlers/helpers/resolveSlackSigningSecret.test.ts
+++ b/tests/handlers/helpers/resolveSlackSigningSecret.test.ts
@@ -1,0 +1,38 @@
+import config from '../../../src/config/config.js'
+import resolveSlackSigningSecret from '../../../src/handlers/helpers/resolveSlackSigningSecret.js'
+
+describe('resolveSlackSigningSecret', () => {
+  let originalEnvSecret: string
+
+  beforeAll(() => {
+    originalEnvSecret = config.slack.signingSecret
+  })
+
+  afterAll(() => {
+    config.slack.signingSecret = originalEnvSecret
+  })
+
+  it('returns the adapter-specific secret when set', () => {
+    config.slack.signingSecret = 'env-secret'
+    const adapter = { config: { signingSecret: 'per-adapter-secret' } }
+    expect(resolveSlackSigningSecret(adapter)).toBe('per-adapter-secret')
+  })
+
+  it('falls back to the global env secret when the adapter has none', () => {
+    config.slack.signingSecret = 'env-secret'
+    const adapter = { config: {} }
+    expect(resolveSlackSigningSecret(adapter)).toBe('env-secret')
+  })
+
+  it('falls back when the adapter has no config at all', () => {
+    config.slack.signingSecret = 'env-secret'
+    const adapter = {}
+    expect(resolveSlackSigningSecret(adapter)).toBe('env-secret')
+  })
+
+  it('throws when neither adapter nor env secret is available', () => {
+    config.slack.signingSecret = ''
+    const adapter = { config: {} }
+    expect(() => resolveSlackSigningSecret(adapter)).toThrow(/signing secret/i)
+  })
+})

--- a/tests/handlers/slack.handler.test.ts
+++ b/tests/handlers/slack.handler.test.ts
@@ -268,7 +268,7 @@ describe('POST /v1/webhooks/slack', () => {
       expect(receiveMessageSpy).not.toHaveBeenCalled()
     })
 
-    test('should return 404 if slack adapter not found for channel', async () => {
+    test('should return 401 if slack adapter not found for channel', async () => {
       const messageEvent = {
         type: 'message',
         text: 'Hello from unknown channel!',
@@ -281,17 +281,19 @@ describe('POST /v1/webhooks/slack', () => {
       const timestamp = Math.floor(Date.now() / 1000).toString()
       const signature = generateSlackSignature(timestamp, JSON.stringify(payload))
 
+      // 401 (not 404): the middleware refuses to confirm whether the adapter is missing or
+      // the signature is bad, so attackers can't enumerate which channels are wired up.
       await request(app)
         .post('/v1/webhooks/slack')
         .set('x-slack-signature', signature)
         .set('x-slack-request-timestamp', timestamp)
         .send(payload)
-        .expect(httpStatus.NOT_FOUND)
+        .expect(httpStatus.UNAUTHORIZED)
 
       expect(receiveMessageSpy).not.toHaveBeenCalled()
     })
 
-    test('should return 404 if slack adapter not found for workspace', async () => {
+    test('should return 401 if slack adapter not found for workspace', async () => {
       const messageEvent = {
         type: 'message',
         text: 'Hello!',
@@ -309,7 +311,7 @@ describe('POST /v1/webhooks/slack', () => {
         .set('x-slack-signature', signature)
         .set('x-slack-request-timestamp', timestamp)
         .send(payload)
-        .expect(httpStatus.NOT_FOUND)
+        .expect(httpStatus.UNAUTHORIZED)
 
       expect(receiveMessageSpy).not.toHaveBeenCalled()
     })
@@ -441,6 +443,84 @@ describe('POST /v1/webhooks/slack', () => {
         .set('x-slack-request-timestamp', timestamp)
         .send(payload)
         .expect(httpStatus.OK)
+
+      expect(receiveMessageSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Per-adapter signing secret', () => {
+    test('accepts a webhook signed with the adapter-specific secret', async () => {
+      slackAdapter.config = { ...slackAdapter.config, signingSecret: 'per-adapter-secret' }
+      slackAdapter.markModified('config')
+      await slackAdapter.save()
+
+      const payload = {
+        event: { type: 'message', text: 'hi', channel: 'C1234567890', team: '123456' }
+      }
+      const timestamp = Math.floor(Date.now() / 1000).toString()
+      const signature = generateSlackSignature(timestamp, JSON.stringify(payload), 'per-adapter-secret')
+
+      await request(app)
+        .post('/v1/webhooks/slack')
+        .set('x-slack-signature', signature)
+        .set('x-slack-request-timestamp', timestamp)
+        .send(payload)
+        .expect(httpStatus.OK)
+
+      expect(receiveMessageSpy).toHaveBeenCalled()
+    })
+
+    test('rejects a webhook signed with the env secret when the adapter has its own secret', async () => {
+      slackAdapter.config = { ...slackAdapter.config, signingSecret: 'per-adapter-secret' }
+      slackAdapter.markModified('config')
+      await slackAdapter.save()
+
+      const payload = {
+        event: { type: 'message', text: 'hi', channel: 'C1234567890', team: '123456' }
+      }
+      const timestamp = Math.floor(Date.now() / 1000).toString()
+      const wrongSignature = generateSlackSignature(timestamp, JSON.stringify(payload), 'test-signing-secret')
+
+      await request(app)
+        .post('/v1/webhooks/slack')
+        .set('x-slack-signature', wrongSignature)
+        .set('x-slack-request-timestamp', timestamp)
+        .send(payload)
+        .expect(httpStatus.UNAUTHORIZED)
+
+      expect(receiveMessageSpy).not.toHaveBeenCalled()
+    })
+
+    test('falls back to the env secret when the adapter has no signingSecret of its own', async () => {
+      const payload = {
+        event: { type: 'message', text: 'hi', channel: 'C1234567890', team: '123456' }
+      }
+      const timestamp = Math.floor(Date.now() / 1000).toString()
+      const signature = generateSlackSignature(timestamp, JSON.stringify(payload), 'test-signing-secret')
+
+      await request(app)
+        .post('/v1/webhooks/slack')
+        .set('x-slack-signature', signature)
+        .set('x-slack-request-timestamp', timestamp)
+        .send(payload)
+        .expect(httpStatus.OK)
+
+      expect(receiveMessageSpy).toHaveBeenCalled()
+    })
+
+    test('rejects with 401 when no adapter matches the webhook payload', async () => {
+      const payload = {
+        event: { type: 'message', text: 'hi', channel: 'C_NONE', team: 'T_NONE' }
+      }
+      const timestamp = Math.floor(Date.now() / 1000).toString()
+      const signature = generateSlackSignature(timestamp, JSON.stringify(payload), 'test-signing-secret')
+
+      await request(app)
+        .post('/v1/webhooks/slack')
+        .set('x-slack-signature', signature)
+        .set('x-slack-request-timestamp', timestamp)
+        .send(payload)
+        .expect(httpStatus.UNAUTHORIZED)
 
       expect(receiveMessageSpy).not.toHaveBeenCalled()
     })

--- a/tests/handlers/slack.handler.test.ts
+++ b/tests/handlers/slack.handler.test.ts
@@ -281,8 +281,8 @@ describe('POST /v1/webhooks/slack', () => {
       const timestamp = Math.floor(Date.now() / 1000).toString()
       const signature = generateSlackSignature(timestamp, JSON.stringify(payload))
 
-      // 401 (not 404): the middleware refuses to confirm whether the adapter is missing or
-      // the signature is bad, so attackers can't enumerate which channels are wired up.
+      // 401 instead of 404: the middleware refuses to confirm whether the bot is missing or
+      // the signature is bad, so attackers can't probe which channels are wired up.
       await request(app)
         .post('/v1/webhooks/slack')
         .set('x-slack-signature', signature)
@@ -449,48 +449,46 @@ describe('POST /v1/webhooks/slack', () => {
   })
 
   describe('Per-bot URL routing (:appKey)', () => {
-    test('routes a request at /v1/webhooks/slack/:appKey to the adapter with that appKey', async () => {
+    test('routes a request at /v1/webhooks/slack/:appKey to the matching bot', async () => {
       const mongoose = await import('mongoose')
-      // VA-style second bot. Workspace + channel deliberately mismatch the incoming payload so the
-      // ONLY way to resolve this adapter is via the :appKey URL segment.
-      const vaConvo = new Conversation({ ...conversationAgentsEnabled, _id: new mongoose.Types.ObjectId() })
-      await vaConvo.save()
-      const vaAdapter = await Adapter.create({
+      // A second bot in the same workspace, with a channel the incoming payload doesn't mention.
+      // That makes the bot identifier in the URL the only way to resolve this bot — falling back
+      // to workspace+channel wouldn't match.
+      const secondConvo = new Conversation({ ...conversationAgentsEnabled, _id: new mongoose.Types.ObjectId() })
+      await secondConvo.save()
+      const secondBot = await Adapter.create({
         type: 'slack',
         config: {
-          // Same workspace as the payload (a single bot lives in one workspace), but a different
-          // channel than the payload's. That makes the appKey URL segment the only way to resolve
-          // this adapter — workspace+channel fallback would not match.
-          channel: 'C_VA_NEVER_IN_PAYLOAD',
-          workspace: 'T_VA_WORKSPACE',
-          appKey: 'va',
-          signingSecret: 'va-secret',
-          botToken: 'xoxb-va',
-          botUserId: 'U_VA'
+          channel: 'C_NEVER_IN_PAYLOAD',
+          workspace: 'T_SHARED_WORKSPACE',
+          appKey: 'second-bot',
+          signingSecret: 'second-bot-secret',
+          botToken: 'xoxb-second-bot',
+          botUserId: 'U_SECOND'
         },
-        conversation: vaConvo._id,
+        conversation: secondConvo._id,
         active: true
       })
 
       const payload = {
-        event: { type: 'message', text: 'hi VA', channel: 'C_OTHER', team: 'T_VA_WORKSPACE' }
+        event: { type: 'message', text: 'hi', channel: 'C_OTHER', team: 'T_SHARED_WORKSPACE' }
       }
       const timestamp = Math.floor(Date.now() / 1000).toString()
-      const signature = generateSlackSignature(timestamp, JSON.stringify(payload), 'va-secret')
+      const signature = generateSlackSignature(timestamp, JSON.stringify(payload), 'second-bot-secret')
 
       await request(app)
-        .post('/v1/webhooks/slack/va')
+        .post('/v1/webhooks/slack/second-bot')
         .set('x-slack-signature', signature)
         .set('x-slack-request-timestamp', timestamp)
         .send(payload)
         .expect(httpStatus.OK)
 
-      expect(receiveMessageSpy).toHaveBeenCalledWith(expect.objectContaining({ _id: vaAdapter._id }), payload.event)
+      expect(receiveMessageSpy).toHaveBeenCalledWith(expect.objectContaining({ _id: secondBot._id }), payload.event)
     })
 
-    test('legacy /v1/webhooks/slack still works for the original bot with no appKey', async () => {
+    test('the shorter /v1/webhooks/slack URL still resolves a bot from the message body', async () => {
       const payload = {
-        event: { type: 'message', text: 'hi Berkie', channel: 'C1234567890', team: '123456' }
+        event: { type: 'message', text: 'hi', channel: 'C1234567890', team: '123456' }
       }
       const timestamp = Math.floor(Date.now() / 1000).toString()
       const signature = generateSlackSignature(timestamp, JSON.stringify(payload), 'test-signing-secret')

--- a/tests/handlers/slack.handler.test.ts
+++ b/tests/handlers/slack.handler.test.ts
@@ -448,6 +448,61 @@ describe('POST /v1/webhooks/slack', () => {
     })
   })
 
+  describe('Per-bot URL routing (:appKey)', () => {
+    test('routes a request at /v1/webhooks/slack/:appKey to the adapter with that appKey', async () => {
+      const mongoose = await import('mongoose')
+      // VA-style second bot. Workspace + channel deliberately mismatch the incoming payload so the
+      // ONLY way to resolve this adapter is via the :appKey URL segment.
+      const vaConvo = new Conversation({ ...conversationAgentsEnabled, _id: new mongoose.Types.ObjectId() })
+      await vaConvo.save()
+      const vaAdapter = await Adapter.create({
+        type: 'slack',
+        config: {
+          channel: 'C_VA_NEVER_IN_PAYLOAD',
+          workspace: 'W_VA_NEVER_IN_PAYLOAD',
+          appKey: 'va',
+          signingSecret: 'va-secret',
+          botToken: 'xoxb-va',
+          botUserId: 'U_VA'
+        },
+        conversation: vaConvo._id,
+        active: true
+      })
+
+      const payload = {
+        event: { type: 'message', text: 'hi VA', channel: 'C_OTHER', team: 'T_OTHER' }
+      }
+      const timestamp = Math.floor(Date.now() / 1000).toString()
+      const signature = generateSlackSignature(timestamp, JSON.stringify(payload), 'va-secret')
+
+      await request(app)
+        .post('/v1/webhooks/slack/va')
+        .set('x-slack-signature', signature)
+        .set('x-slack-request-timestamp', timestamp)
+        .send(payload)
+        .expect(httpStatus.OK)
+
+      expect(receiveMessageSpy).toHaveBeenCalledWith(expect.objectContaining({ _id: vaAdapter._id }), payload.event)
+    })
+
+    test('legacy /v1/webhooks/slack still works for the original bot with no appKey', async () => {
+      const payload = {
+        event: { type: 'message', text: 'hi Berkie', channel: 'C1234567890', team: '123456' }
+      }
+      const timestamp = Math.floor(Date.now() / 1000).toString()
+      const signature = generateSlackSignature(timestamp, JSON.stringify(payload), 'test-signing-secret')
+
+      await request(app)
+        .post('/v1/webhooks/slack')
+        .set('x-slack-signature', signature)
+        .set('x-slack-request-timestamp', timestamp)
+        .send(payload)
+        .expect(httpStatus.OK)
+
+      expect(receiveMessageSpy).toHaveBeenCalledWith(expect.objectContaining({ _id: slackAdapter._id }), payload.event)
+    })
+  })
+
   describe('Per-adapter signing secret', () => {
     test('accepts a webhook signed with the adapter-specific secret', async () => {
       slackAdapter.config = { ...slackAdapter.config, signingSecret: 'per-adapter-secret' }

--- a/tests/handlers/slack.handler.test.ts
+++ b/tests/handlers/slack.handler.test.ts
@@ -452,7 +452,7 @@ describe('POST /v1/webhooks/slack', () => {
     test('routes a request at /v1/webhooks/slack/:appKey to the matching bot', async () => {
       const mongoose = await import('mongoose')
       // A second bot in the same workspace, with a channel the incoming payload doesn't mention.
-      // That makes the bot identifier in the URL the only way to resolve this bot — falling back
+      // That makes the bot identifier in the URL the only way to resolve this bot; falling back
       // to workspace+channel wouldn't match.
       const secondConvo = new Conversation({ ...conversationAgentsEnabled, _id: new mongoose.Types.ObjectId() })
       await secondConvo.save()

--- a/tests/handlers/slack.handler.test.ts
+++ b/tests/handlers/slack.handler.test.ts
@@ -458,8 +458,11 @@ describe('POST /v1/webhooks/slack', () => {
       const vaAdapter = await Adapter.create({
         type: 'slack',
         config: {
+          // Same workspace as the payload (a single bot lives in one workspace), but a different
+          // channel than the payload's. That makes the appKey URL segment the only way to resolve
+          // this adapter — workspace+channel fallback would not match.
           channel: 'C_VA_NEVER_IN_PAYLOAD',
-          workspace: 'W_VA_NEVER_IN_PAYLOAD',
+          workspace: 'T_VA_WORKSPACE',
           appKey: 'va',
           signingSecret: 'va-secret',
           botToken: 'xoxb-va',
@@ -470,7 +473,7 @@ describe('POST /v1/webhooks/slack', () => {
       })
 
       const payload = {
-        event: { type: 'message', text: 'hi VA', channel: 'C_OTHER', team: 'T_OTHER' }
+        event: { type: 'message', text: 'hi VA', channel: 'C_OTHER', team: 'T_VA_WORKSPACE' }
       }
       const timestamp = Math.floor(Date.now() / 1000).toString()
       const signature = generateSlackSignature(timestamp, JSON.stringify(payload), 'va-secret')


### PR DESCRIPTION
## What is in this PR

Every Slack-backed agent today shares one Slack identity, because the security secret we use to validate webhooks is a single global value. This PR lets each Slack bot have its own webhook URL and its own signing secret, so we can install a second bot in the same workspace and have it show up as its own bot user. Existing Slack flows keep working: bots without their own secret yet fall back to the global one. The new lookup also rejects any webhook whose workspace ID doesn't match the bot the URL points to.

## Changes in the codebase

- Each Slack bot can store its own webhook signing secret on its database row. Bots without one fall back to the global secret and log a warning, so we can see where the gap still is.
- Slack webhook URLs can include a bot identifier in the path, giving each bot its own install URL. The shorter URL still works and figures out the bot from the message body.
- Webhook signatures check against the receiving bot's own secret. If a webhook claims a workspace that doesn't match the bot it's addressed to, the lookup refuses it.
- Slack API connections cache by bot token, so two bots in the same workspace don't share a connection.
- Webhooks that don't identify a specific bot (URL verification pings, button-click payloads) still use the global secret.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

**1. Confirm Berkie still works locally using the env-var fallback.**
- [ ] In `.env`, uncomment and set `SLACK_SIGNING_SECRET=<Berkie's signing secret from api.slack.com/apps>`. Restart `yarn dev` so the value loads. Make sure ngrok is running.
- [ ] In Hoppscotch, open the team collection and find Create Berkie Slack Conversation. Fill in the `<...>` values using Berkie's bot credentials. Send. Expect a 201 response. The endpoint auto-creates the conversation, its Slack adapter, and its channels from the `chatbot` ConversationType definition.
- [ ] In Mongo, confirm Berkie's Adapter row has no per-bot signing secret:
    ```sh
    mongosh "mongodb://127.0.0.1:27017/llm_engine"
    ```
    ```js
    db.adapters.findOne({ type: 'slack' }, { 'config.signingSecret': 1, 'config.channel': 1 })
    ```
    Expect the result to show only `_id` and `config.channel`, with no `config.signingSecret` field.
- [ ] In Slack, invite Berkie to the channel referenced in `config.channel` if it isn't already in there.
- [ ] @-mention Berkie in that channel with any message.
- [ ] Confirm Berkie replies.
- [ ] In the `yarn dev` terminal, confirm the fallback warning fires on Berkie's request:
    `Falling back to global SLACK_SIGNING_SECRET env var. Set adapter.config.signingSecret per bot and remove the env var when rollout is complete.`

**2. Confirm a per-bot secret works locally with the new URL shape.**
Ask Chelsea to add you to her channel with the local bot running, or create your own using the steps below:
- [ ] At [api.slack.com/apps](https://api.slack.com/apps), click **Create New App** → **From scratch**. Name it "Test Bot 2" and pick our workspace. Open it.
- [ ] **OAuth & Permissions** → "Scopes" → add Bot Token Scopes: `chat:write`, `channels:history`, `app_mentions:read`, `im:history`. Click "Install to Workspace" at the top. Copy the Bot User OAuth Token (`xoxb-...`).
- [ ] **Basic Information** → "App Credentials" → copy the Signing Secret.
- [ ] **Event Subscriptions** → enable. Set Request URL to `https://<random>.ngrok-free.app/v1/webhooks/slack/test-bot-2`. Wait for "Verified ✓" (this is itself a real signed handshake going through the new route). Under "Subscribe to bot events", add `message.channels` and `message.im`. Save.
- [ ] In Hoppscotch, open the team collection and find "Create Slack Conversation with Adapter for Standalone Bot". Fill in the remaining values, then send.
- [ ] Expect a 201 response. Note the conversation `_id` for the teardown step.
- [ ] In Slack, invite your new bot to the test channel: type `/invite @<bot-name>` in that channel.
- [ ] Post a message in the channel.
- [ ] Confirm the new bot's webhook reaches the server: in the `yarn dev` terminal, expect a successful (non-401) request log and **no** fallback warning for this request.

**3. Tear down: delete the newly created conversation and the Slack app when finished.**
- [ ] In Hoppscotch: `DELETE {{baseUrl}}/v1/conversations/<conversation _id from step 2>`.
- [ ] At api.slack.com/apps, delete your new bot if you created one (don't delete Berkie).

## Additional information

No new or changed environment variables. The existing global signing secret stays in place as a fallback during the rollout and can be removed once every Slack bot stores its own secret.