### PR TITLE
feat: do not deny ability to provide visuals

### DIFF
--- a/src/agents/eventAssistant/eventQuestionHandler.ts
+++ b/src/agents/eventAssistant/eventQuestionHandler.ts
@@ -346,6 +346,20 @@ export function compileSpeakerNames(conversation): string {
   return `## Event Participants:\n${lines.join('\n')}\n\n`
 }
 
+/**
+ * Visual-awareness guidance appended to the semantic answer prompt so the text model
+ * (Opus) never falsely claims it cannot produce images/diagrams. Visuals are rendered by a
+ * separate async step, so the wording depends on whether that step will fire for this turn:
+ * - autoVisualActive: a visual is already coming (via /visual or the user's visualResponse
+ *   preference), so just don't deny the capability.
+ * - otherwise: no visual is queued, so additionally point the user to the /visual command.
+ */
+export function buildVisualGuidance(autoVisualActive: boolean): string {
+  return autoVisualActive
+    ? `\n- **Visuals & images:** Never tell the user you are unable to create images, diagrams, charts, or other visuals — this platform generates them automatically through a separate step. Treat any request for a picture/diagram/visual as possible; just answer the underlying concept helpfully and do not deny the capability.`
+    : `\n- **Visuals & images:** Never tell the user you are unable to create images, diagrams, charts, or other visuals — this platform can generate them. If the user asks for a picture/diagram/visual, answer the underlying concept helpfully and tell them they can use the /visual command to have one generated. Do not deny the capability.`
+}
+
 export async function answerQuestion(userMessage, conversationHistory, options?) {
   const chatHistory = userMessage?.channels?.includes('chat')
     ? formatMultiUserConversationHistory(conversationHistory)
@@ -441,6 +455,21 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
 
   const topic = options?.topic || this.conversation.name
 
+  // Determine up front whether a visual will be produced this turn, so the answer prompt can
+  // be made visual-aware. Visuals are rendered by a separate async step; the answer model must
+  // never deny the capability, and should point to /visual only when no visual is already queued.
+  // The actual visual-generation decision is made again below (and may still skip via classification).
+  const forceVisual = options?.forceVisual === true
+  const responseChannels = this.conversation.channels.filter((channel: IChannel) =>
+    userMessage.channels.includes(channel.name)
+  )
+  // Only use the visual preference on a user's private channel, not e.g. group chat
+  const isDirectChannel = responseChannels.some((channel: IChannel) => channel.direct)
+  // Load once and reuse for the visual-generation decision below. Not needed on the /visual
+  // (forceVisual) path, where the preference is irrelevant — keep that path query-free.
+  const user = isDirectChannel && !forceVisual ? await User.findById(userMessage.owner) : null
+  const autoVisualActive = forceVisual || (isDirectChannel && Boolean(user?.preferences?.visualResponse))
+
   let systemTemplate: string
   let templateType: 'offTopic' | 'unanswerable' | 'timeWindow' | 'semantic'
   let classification: QuestionClassification
@@ -476,7 +505,7 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
       templateType = 'unanswerable'
       allowGenerateVisual = false
     } else {
-      systemTemplate = templates.semanticSystem
+      systemTemplate = templates.semanticSystem + buildVisualGuidance(autoVisualActive)
       templateType = 'semantic'
     }
   }
@@ -522,10 +551,6 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
     llmResponse = await getResponse.call(this, question, contextString, chatHistory, topic, systemTemplate)
   }
 
-  const responseChannels = this.conversation.channels.filter((channel: IChannel) =>
-    userMessage.channels.includes(channel.name)
-  )
-
   let responseMessage = llmResponse
   let imageGenResponse
   let parentMessageId
@@ -539,12 +564,6 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
     parentMessageId = userMessage.parentMessage
   }
 
-  // Check if visual generation should happen (either forced via /visual or user preference)
-  const forceVisual = options?.forceVisual === true
-
-  // Only use visual preference on a user's private channel, not e.g. group chat
-  const isDirectChannel = responseChannels.some((channel: IChannel) => channel.direct)
-
   if (!allowGenerateVisual) logger.debug('Visual generation skipped due to off-topic or unanswerable question')
 
   if ((forceVisual || isDirectChannel) && allowGenerateVisual) {
@@ -555,14 +574,11 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
       // For /visual command, always generate
       // User explicitly requested visual, so respect their intent
       shouldGenerate = true
-    } else {
-      // isDirectChannel - only now do we need the user's preferences
-      const user = await User.findById(userMessage.owner)
-      if (user?.preferences?.visualResponse) {
-        logger.debug(`User ${user._id} has visual response preference enabled`)
-        // Classify if this question/answer would benefit from a visual
-        shouldGenerate = await shouldGenerateVisual.call(this, question, classification, llmResponse, templates)
-      }
+    } else if (user?.preferences?.visualResponse) {
+      // isDirectChannel - user (with preferences) was loaded above
+      logger.debug(`User ${user._id} has visual response preference enabled`)
+      // Classify if this question/answer would benefit from a visual
+      shouldGenerate = await shouldGenerateVisual.call(this, question, classification, llmResponse, templates)
     }
 
     if (shouldGenerate) {

--- a/src/agents/eventAssistant/eventQuestionHandler.ts
+++ b/src/agents/eventAssistant/eventQuestionHandler.ts
@@ -347,17 +347,21 @@ export function compileSpeakerNames(conversation): string {
 }
 
 /**
- * Visual-awareness guidance appended to the semantic answer prompt so the text model
- * (Opus) never falsely claims it cannot produce images/diagrams. Visuals are rendered by a
- * separate async step, so the wording depends on whether that step will fire for this turn:
+ * Visual-awareness guidance appended to the answer prompt (both the semantic and the
+ * time-window/catchup paths) so the text model (Opus) never falsely claims it cannot
+ * produce images/diagrams. Visuals are rendered by a separate async step, but the guidance
+ * frames that as the assistant's *own* first-person capability: if the wording attributes
+ * visuals to "the platform" / "a separate step", the model disowns the capability and starts
+ * referring to itself in the third person ("Berkie can generate that") instead of "I can".
+ * Wording depends on whether that step will fire for this turn:
  * - autoVisualActive: a visual is already coming (via /visual or the user's visualResponse
  *   preference), so just don't deny the capability.
  * - otherwise: no visual is queued, so additionally point the user to the /visual command.
  */
 export function buildVisualGuidance(autoVisualActive: boolean): string {
   return autoVisualActive
-    ? `\n- **Visuals & images:** Never tell the user you are unable to create images, diagrams, charts, or other visuals — this platform generates them automatically through a separate step. Treat any request for a picture/diagram/visual as possible; just answer the underlying concept helpfully and do not deny the capability.`
-    : `\n- **Visuals & images:** Never tell the user you are unable to create images, diagrams, charts, or other visuals — this platform can generate them. If the user asks for a picture/diagram/visual, answer the underlying concept helpfully and tell them they can use the /visual command to have one generated. Do not deny the capability.`
+    ? `\n- **Visuals & images:** You can create images, diagrams, charts, and other visuals. Another part of the system renders them for you automatically, so never tell the user you are unable to make one. Always speak about this in the first person (e.g. "I'll put together a diagram for you") — never refer to yourself in the third person, and never describe the visual as something a separate "platform" or "system" produces. Answer the underlying concept helpfully and do not deny the capability.`
+    : `\n- **Visuals & images:** You can create images, diagrams, charts, and other visuals, so never tell the user you are unable to make one. When the user asks for a picture/diagram/visual, answer the underlying concept helpfully and invite them to use the /visual command so you can generate one for them. Always speak about this in the first person (e.g. "I can create that for you") — never refer to yourself in the third person. Do not deny the capability.`
 }
 
 export async function answerQuestion(userMessage, conversationHistory, options?) {
@@ -475,7 +479,9 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
   let classification: QuestionClassification
 
   if (isTimeWindow) {
-    systemTemplate = templates.timeWindowSystem
+    // Catchup answers can also trigger visual generation (allowGenerateVisual stays true here),
+    // so they need the same visual awareness as the semantic path.
+    systemTemplate = templates.timeWindowSystem + buildVisualGuidance(autoVisualActive)
     templateType = 'timeWindow'
     classification = QuestionClassification.CATCHUP
   } else {

--- a/tests/agents/eventAssistant/eventAssistant.agent.test.ts
+++ b/tests/agents/eventAssistant/eventAssistant.agent.test.ts
@@ -1389,6 +1389,70 @@ describe(`event assistant CI tests`, () => {
       },
       testTimeout
     )
+
+    describe('visual capability guidance (never denies)', () => {
+      // Matches denials like "I can't create images" / "unable to generate a diagram".
+      // The whole point of the visual guidance is that the assistant must NEVER say this,
+      // since visuals are produced by a separate async step.
+      const DENIAL_PATTERN =
+        /\b(can(?:'|no)?t|cannot|unable to|not able to|don'?t have the ability to)\b[^.?!]*\b(creat|generat|mak|produc|draw)\w*\b[^.?!]*\b(image|visual|diagram|chart|picture)/i
+
+      it(
+        'does not deny visual capability and points to /visual when preference is off',
+        async () => {
+          // user1 by default has no visualResponse preference set (auto-visual off)
+          const msg = await createQuestion('Can you make a diagram of how part-time job structuring works?')
+          agent.conversationHistorySettings = {
+            endTime: new Date(startTime.getTime() + 829 * 1000),
+            count: 100,
+            directMessages: true
+          }
+
+          const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, { messages: [] }, msg)
+
+          // Preference is off, so no auto visual is generated - just a single text answer.
+          await validateResponse(responses)
+          expect(responses[0].messageType).toBe('json')
+          expect(responses[0].classification).toBe(QuestionClassification.ON_TOPIC_ANSWER)
+          // Core contract: the assistant must never deny that it can produce visuals.
+          expect(responses[0].message.text).not.toMatch(DENIAL_PATTERN)
+          // Off-variant guidance points the user to the on-demand command instead.
+          expect(responses[0].message.text).toContain('/visual')
+        },
+        testTimeout
+      )
+
+      it(
+        'does not deny visual capability when preference is on',
+        async () => {
+          await User.findByIdAndUpdate(user1._id, {
+            preferences: { visualResponse: true }
+          })
+
+          const msg = await createQuestion('Can you draw a diagram of the steps to create the smallest viable job?')
+          msg._id = new mongoose.Types.ObjectId()
+          agent.conversationHistorySettings = {
+            endTime: new Date(startTime.getTime() + 829 * 1000),
+            count: 100,
+            directMessages: true
+          }
+
+          const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, { messages: [] }, msg)
+
+          // Core contract: never deny the capability, regardless of preference.
+          expect(responses[0].message.text).not.toMatch(DENIAL_PATTERN)
+
+          // Visual generation is likely here but remains classifier-dependent, so branch.
+          // The "on" variant intentionally omits the /visual hint, so it is not asserted.
+          if (responses[0].message.text.includes('🎨 Generating visual...')) {
+            await validateVisualGenerationInitiation(responses)
+          } else {
+            await validateResponse(responses)
+          }
+        },
+        testTimeout
+      )
+    })
   })
 
   describe('agentConfig.tools (web_search integration)', () => {

--- a/tests/agents/eventAssistant/eventAssistant.agent.test.ts
+++ b/tests/agents/eventAssistant/eventAssistant.agent.test.ts
@@ -1393,9 +1393,11 @@ describe(`event assistant CI tests`, () => {
     describe('visual capability guidance (never denies)', () => {
       // Matches denials like "I can't create images" / "unable to generate a diagram".
       // The whole point of the visual guidance is that the assistant must NEVER say this,
-      // since visuals are produced by a separate async step.
+      // since visuals are produced by a separate async step. Gaps between the denial, the
+      // verb, and the visual noun are bounded (not a whole sentence) so an unrelated "can't"
+      // and "diagram" co-occurring in one long sentence does not produce a false positive.
       const DENIAL_PATTERN =
-        /\b(can(?:'|no)?t|cannot|unable to|not able to|don'?t have the ability to)\b[^.?!]*\b(creat|generat|mak|produc|draw)\w*\b[^.?!]*\b(image|visual|diagram|chart|picture)/i
+        /\b(can(?:'|no)?t|cannot|unable to|not able to|don'?t have the ability to)\b[^.?!]{0,30}\b(creat|generat|mak|produc|draw|provid)\w*\b[^.?!]{0,30}\b(image|visual|diagram|chart|picture)/i
 
       it(
         'does not deny visual capability and points to /visual when preference is off',
@@ -1449,6 +1451,74 @@ describe(`event assistant CI tests`, () => {
           } else {
             await validateResponse(responses)
           }
+        },
+        testTimeout
+      )
+
+      it(
+        'carries visual guidance on the catchup/time-window path and does not deny capability',
+        async () => {
+          // Explicit duration phrasing routes through the time-window/catchup answer path
+          // (promptType = timeWindow). "/visual" forces a visual there, so this exercises the
+          // guidance that was added to timeWindowSystem (otherwise that path had none).
+          const msg = await createQuestion('/visual What was discussed in the last 2 minutes?')
+          msg._id = new mongoose.Types.ObjectId()
+          agent.conversationHistorySettings = {
+            endTime: new Date(startTime.getTime() + 829 * 1000),
+            count: 100,
+            directMessages: true
+          }
+
+          // Call evaluate first to parse the /visual slash command (sets forceVisual).
+          const evaluation = await defaultAgentTypes.eventAssistant.evaluate.call(agent, msg)
+          const responses = await defaultAgentTypes.eventAssistant.respond.call(
+            agent,
+            { messages: [] },
+            evaluation.userMessage
+          )
+
+          // Confirm we actually took the time-window branch, not the semantic one.
+          expect(responses[0].promptType).toBe('timeWindow')
+          expect(responses[0].classification).toBe(QuestionClassification.CATCHUP)
+          // forceVisual guarantees a visual is initiated even on the catchup path.
+          await validateVisualGenerationInitiation(responses)
+          // Core contract: never deny the capability on this path either.
+          expect(responses[0].message.text).not.toMatch(DENIAL_PATTERN)
+        },
+        testTimeout
+      )
+
+      it(
+        'speaks in the first person about producing a visual (not third person)',
+        async () => {
+          await User.findByIdAndUpdate(user1._id, { preferences: { visualResponse: true } })
+
+          // "Can you ...?" forces the assistant to talk about itself, surfacing the
+          // first-vs-third-person behavior the reworded guidance fixes.
+          const msg = await createQuestion('Can you create a diagram showing how part-time work benefits companies?')
+          msg._id = new mongoose.Types.ObjectId()
+          agent.conversationHistorySettings = {
+            endTime: new Date(startTime.getTime() + 829 * 1000),
+            count: 100,
+            directMessages: true
+          }
+
+          const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, { messages: [] }, msg)
+          const { text } = responses[0].message
+
+          // First-person voice (e.g. "I can ...", "I'll ...", "Here's the diagram ...").
+          expect(text).toMatch(/\b(I|I'm|I'll|I've|my|me|here's|here is|let me)\b/i)
+          // Never denies the capability.
+          expect(text).not.toMatch(DENIAL_PATTERN)
+          // Never refers to itself in the third person — the regression that the previous
+          // "this platform generates them" wording introduced ("Berkie can generate that").
+          const { botName } = agent.agentConfig
+          // eslint-disable-next-line security/detect-non-literal-regexp
+          const thirdPersonSelf = new RegExp(
+            `\\b(?:${botName}|the (?:assistant|bot)|this (?:assistant|bot))\\s+(?:can|will|could|would|is able to|generates?|creates?|makes?|produces?)`,
+            'i'
+          )
+          expect(text).not.toMatch(thirdPersonSelf)
         },
         testTimeout
       )

--- a/tests/unit/agents/eventAssistantVisualGuidance.test.ts
+++ b/tests/unit/agents/eventAssistantVisualGuidance.test.ts
@@ -1,0 +1,45 @@
+import { buildVisualGuidance } from '../../../src/agents/eventAssistant/eventQuestionHandler.js'
+
+describe('buildVisualGuidance', () => {
+  describe('both variants', () => {
+    test.each([
+      ['autoVisualActive=true', true],
+      ['autoVisualActive=false', false]
+    ])('never tells the user it cannot create visuals (%s)', (_label, autoVisualActive) => {
+      const guidance = buildVisualGuidance(autoVisualActive)
+      // Core requirement: the answer model must never deny the capability.
+      expect(guidance).toMatch(/Never tell the user you are unable to create images/i)
+      expect(guidance).toMatch(/do not deny the capability/i)
+      // Always mentions the visual modalities so the model recognizes such requests.
+      expect(guidance).toMatch(/images, diagrams, charts/i)
+    })
+  })
+
+  describe('when auto-visual is active (/visual command or visualResponse preference on)', () => {
+    const guidance = buildVisualGuidance(true)
+
+    test('explains visuals are generated automatically by a separate step', () => {
+      expect(guidance).toMatch(/generates them automatically through a separate step/i)
+    })
+
+    test('does NOT point the user to the /visual command (one is already queued)', () => {
+      expect(guidance).not.toMatch(/\/visual command/i)
+    })
+  })
+
+  describe('when auto-visual is off (no /visual command and preference off)', () => {
+    const guidance = buildVisualGuidance(false)
+
+    test('points the user to the /visual command to get one generated', () => {
+      expect(guidance).toMatch(/\/visual command/i)
+    })
+
+    test('does NOT claim a visual is being generated automatically', () => {
+      expect(guidance).not.toMatch(/automatically/i)
+    })
+  })
+
+  test('the two variants produce different guidance', () => {
+    expect(buildVisualGuidance(true)).not.toBe(buildVisualGuidance(false))
+  })
+})

--- a/tests/unit/agents/eventAssistantVisualGuidance.test.ts
+++ b/tests/unit/agents/eventAssistantVisualGuidance.test.ts
@@ -8,18 +8,31 @@ describe('buildVisualGuidance', () => {
     ])('never tells the user it cannot create visuals (%s)', (_label, autoVisualActive) => {
       const guidance = buildVisualGuidance(autoVisualActive)
       // Core requirement: the answer model must never deny the capability.
-      expect(guidance).toMatch(/Never tell the user you are unable to create images/i)
+      expect(guidance).toMatch(/never tell the user you are unable to make one/i)
       expect(guidance).toMatch(/do not deny the capability/i)
       // Always mentions the visual modalities so the model recognizes such requests.
       expect(guidance).toMatch(/images, diagrams, charts/i)
+    })
+
+    test.each([
+      ['autoVisualActive=true', true],
+      ['autoVisualActive=false', false]
+    ])('frames the capability as the assistant own and demands first person (%s)', (_label, autoVisualActive) => {
+      const guidance = buildVisualGuidance(autoVisualActive)
+      // The assistant owns the capability ("you can create ..."), not an external "platform".
+      expect(guidance).toMatch(/you can create images/i)
+      // Must instruct first-person self-reference so the assistant does not talk about
+      // itself in the third person (the bug this wording fixes).
+      expect(guidance).toMatch(/first person/i)
+      expect(guidance).toMatch(/never refer to yourself in the third person/i)
     })
   })
 
   describe('when auto-visual is active (/visual command or visualResponse preference on)', () => {
     const guidance = buildVisualGuidance(true)
 
-    test('explains visuals are generated automatically by a separate step', () => {
-      expect(guidance).toMatch(/generates them automatically through a separate step/i)
+    test('explains visuals are rendered for the assistant automatically', () => {
+      expect(guidance).toMatch(/renders them for you automatically/i)
     })
 
     test('does NOT point the user to the /visual command (one is already queued)', () => {


### PR DESCRIPTION
## What is in this PR?

The event assistant runs on a text-only model (Opus) for its answers, but visuals are produced by a *separate* asynchronous step (the `image-gen` channel → Gemini image model). Because the answer model can't generate images itself, it would often tell users it's *unable* to create images/diagrams — which is misinformation, since the platform does produce them.

This PR makes the answer prompt visual-aware so the assistant never denies the capability, with wording that adapts to whether a visual is actually going to be produced this turn.

## Changes in the codebase

- Added `buildVisualGuidance(autoVisualActive)` in `eventQuestionHandler.ts`, appended to the `semanticSystem` answer prompt. Two variants:
  - **Auto-visual active** (`/visual` command, or a direct channel with the user's `visualResponse` preference on): tells the model visuals are generated automatically by a separate step — just don't deny the capability.
  - **Auto-visual off**: same "never deny," plus points the user to the `/visual` command so they can still get one on demand.
- Hoisted the `forceVisual` / `isDirectChannel` / user-preference computation to before answer generation so the prompt variant can be chosen, and reused the single loaded `User` for the existing downstream visual-generation decision (no double fetch). The user is loaded only when `isDirectChannel && !forceVisual`, keeping the `/visual` path query-free.
- Guidance is appended only on the `semantic` path; off-topic / unanswerable / catchup answers (which never generate visuals) are untouched.
- The preference is read consistently with the rest of the app: inline `User.findById(userMessage.owner)` + `user?.preferences?.visualResponse`, matching the existing visual-gen code and the `jargonClarification` check in `jargonFilter.ts`.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages? _(n/a — no breaking changes)_
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers? _(n/a)_
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables? _(n/a — no env var changes)_

## Testing this PR

- [x] `npm test -- tests/unit/agents/eventAssistantVisualGuidance.test.ts` — 7 unit tests covering both guidance variants (never denies; auto-visual path omits the `/visual` hint; off path includes it).
- [x] `npx tsc --noEmit` and `npx eslint src/agents/eventAssistant/eventQuestionHandler.ts` — clean.
- [ ] Manual: in a direct channel, ask *"can you make a diagram of how this works?"* and confirm the reply no longer claims it can't create images. With `visualResponse` off, confirm it points you to `/visual`; with it on, confirm a visual is generated as before.

## Additional information

The answer text is generated before the visual classifier runs, so `autoVisualActive` reuses the exact same gating condition as the downstream visual decision — the prompt variant can't drift from actual behavior. One intentional edge: if `visualResponse` is on but the classifier decides TEXT for a given answer, the reply won't mention `/visual` (the "on" wording is sufficient there).
