### PR TITLE
feat: identify source of moderator messages and separate recommended actions from insights

### DIFF
--- a/src/agents/backChannel/backChannel.types.ts
+++ b/src/agents/backChannel/backChannel.types.ts
@@ -18,6 +18,8 @@ export type Insight = {
   value: string
   comments: Comment[]
   type: 'insight' | 'question'
+  source?: 'ai' | 'participant'
+  recommendations?: string[]
 }
 
 export type BackChannelAgentResponse = {

--- a/src/agents/backChannel/backChannelInsightsGenerator.ts
+++ b/src/agents/backChannel/backChannelInsightsGenerator.ts
@@ -212,7 +212,7 @@ export async function processParticipantMessages(messages, startTime, endTime) {
         filteredComments = groupCommentsByUser(unusedComments)
       }
       // add the type property to distinguish insights from standalone questions
-      insights.results = insights.results.map((insight) => ({ ...insight, type: 'insight' }))
+      insights.results = insights.results.map((insight) => ({ ...insight, type: 'insight', source: 'ai' }))
       return {
         insightsFromInsights: filterInsightsByCommentDiversity(insights),
         comments: filteredComments,
@@ -244,7 +244,8 @@ export async function processParticipantMessages(messages, startTime, endTime) {
           userComments.map((commentMsg) => ({
             value: commentMsg.comment.text,
             comments: [{ user: commentMsg.comment.user, text: commentMsg.comment.text }],
-            type: 'question'
+            type: 'question',
+            source: 'participant'
           }))
         )
       }

--- a/src/agents/eventAssistant/checkinHandler.ts
+++ b/src/agents/eventAssistant/checkinHandler.ts
@@ -260,8 +260,6 @@ ${typeSections}`
  * Called with `this` = agent instance.
  */
 export async function buildCheckinResponses(conversationHistory: ConversationHistory) {
-  const responses: object[] = []
-
   // Small chance there are duplicate direct channels with the same name due to React StrictMode double-invoking effects in development. De-dup just in case, to avoid duplicate messages.
   const directChannels: IChannel[] = Array.from(
     new Map<string, IChannel>(
@@ -274,7 +272,7 @@ export async function buildCheckinResponses(conversationHistory: ConversationHis
     ).values()
   )
 
-  if (directChannels.length === 0) return responses
+  if (directChannels.length === 0) return []
 
   const sharedChatHistory = getConversationHistory(conversationHistory.messages, {
     count: 100,
@@ -304,95 +302,98 @@ export async function buildCheckinResponses(conversationHistory: ConversationHis
     )
   )
 
-  for (const channel of directChannels) {
-    const channelMessages = conversationHistory.messages.filter((m) => m.channels?.includes(channel.name))
+  // Run per-participant LLM calls in parallel — each call is independent (rate limiting
+  // is scoped to the individual participant's DM history, not shared state).
+  const participantResults = await Promise.all(
+    directChannels.map(async (channel) => {
+      const channelMessages = conversationHistory.messages.filter((m) => m.channels?.includes(channel.name))
 
-    // Resolve pseudonym — needed for the system prompt regardless of intervention type
-    const participantMessage = channelMessages.find((m) => !m.fromAgent)
-    const participantPseudonym = participantMessage?.pseudonym || 'participant'
+      // Resolve pseudonym — needed for the system prompt regardless of intervention type
+      const participantMessage = channelMessages.find((m) => !m.fromAgent)
+      const participantPseudonym = participantMessage?.pseudonym || 'participant'
 
-    const participantDmHistory = getConversationHistory(channelMessages, {
-      count: 50,
-      endTime: conversationHistory.end
-    })
+      const participantDmHistory = getConversationHistory(channelMessages, {
+        count: 50,
+        endTime: conversationHistory.end
+      })
 
-    const participantContext: ParticipantCheckinContext = {
-      participantDmHistory,
-      participantPseudonym,
-      allDmHistory,
-      endTime: conversationHistory.end ?? undefined,
-      agentInstance: this
-    }
-
-    // Filter to types eligible for this participant. Types without isEligible always pass through.
-    const eligibleTypes = activeTypes.filter((t) => {
-      const { isEligible } = checkinTypeInfo[t]
-      return !isEligible || isEligible(participantContext, sharedResults[t] ?? null)
-    })
-
-    if (eligibleTypes.length === 0) {
-      logger.debug(`[checkinHandler] no eligible types for ${participantPseudonym} — skipping LLM call`)
-      continue
-    }
-
-    const systemPrompt = buildCheckinSystemPrompt(participantPseudonym, eligibleTypes)
-    const schema = getCheckinDmAnalysisSchema(eligibleTypes)
-
-    // detectInterventionOpportunity handles rate limiting (scoped to this DM channel via
-    // participantDmHistory as rateLimitHistory) and the DB race guard (scoped to channel.name).
-    // allDmHistory is passed as privateConversationHistory so the LLM has full cross-participant
-    // context for reasoning. The schema uses `directMessage` instead of
-    // `sharedChatMessage`, so the professionalism check inside is skipped — appropriate here.
-    const analysis = (await detectPrivateInterventionOpportunity.call(
-      this,
-      sharedChatHistory,
-      systemPrompt,
-      schema,
-      allDmHistory,
-      participantDmHistory,
-      USER_TEMPLATE
-    )) as unknown as CheckinAnalysis | null
-
-    if (!analysis?.directMessage) {
-      logger.debug(
-        `Checkin Handler: No intervention opportunity detected or rate limited for participant ${participantPseudonym}`
-      )
-      continue
-    }
-
-    // If the message implies cross-participant patterns, verify cited participant+text pairs are real.
-    // Mirrors backChannel hallucination filtering: the LLM must cite sources it can actually see.
-    if (analysis.sourceMessages?.length) {
-      const otherParticipantMessages = [...allDmHistory.messages, ...sharedChatHistory.messages].filter(
-        (m) => !m.fromAgent && m.pseudonym !== participantPseudonym
-      )
-      if (!filterHallucinations(analysis.sourceMessages, otherParticipantMessages)) {
-        logger.warn(
-          `CheckinHandler: suppressed hallucinated cross-participant claim for ${participantPseudonym}: cited ${JSON.stringify(
-            analysis.sourceMessages
-          )}`
-        )
-        continue
+      const participantContext: ParticipantCheckinContext = {
+        participantDmHistory,
+        participantPseudonym,
+        allDmHistory,
+        endTime: conversationHistory.end ?? undefined,
+        agentInstance: this
       }
-    }
 
-    logger.info(
-      `Checkin Handler: ${analysis.checkinType} → ${participantPseudonym} (${channel.name}): ${analysis.detectedPattern}`
-    )
-    responses.push({
-      visible: true,
-      message: { type: 'checkin', text: analysis.directMessage },
-      messageType: 'json',
-      channels: [channel],
-      context: analysis.context,
-      participantPseudonym,
-      eligibleTypes,
-      checkinType: analysis.checkinType,
-      reasoning: analysis.reasoning,
-      confidenceScore: analysis.confidenceScore,
-      detectedPattern: analysis.detectedPattern
+      // Filter to types eligible for this participant. Types without isEligible always pass through.
+      const eligibleTypes = activeTypes.filter((t) => {
+        const { isEligible } = checkinTypeInfo[t]
+        return !isEligible || isEligible(participantContext, sharedResults[t] ?? null)
+      })
+
+      if (eligibleTypes.length === 0) {
+        logger.debug(`[checkinHandler] no eligible types for ${participantPseudonym} — skipping LLM call`)
+        return null
+      }
+
+      const systemPrompt = buildCheckinSystemPrompt(participantPseudonym, eligibleTypes)
+      const schema = getCheckinDmAnalysisSchema(eligibleTypes)
+
+      // detectPrivateInterventionOpportunity handles rate limiting scoped to this participant's
+      // DM channel via participantDmHistory. allDmHistory is passed as privateConversationHistory
+      // so the LLM has full cross-participant context. The schema uses `directMessage` instead of
+      // `sharedChatMessage`, so the professionalism check inside is skipped — appropriate here.
+      const analysis = (await detectPrivateInterventionOpportunity.call(
+        this,
+        sharedChatHistory,
+        systemPrompt,
+        schema,
+        allDmHistory,
+        participantDmHistory,
+        USER_TEMPLATE
+      )) as unknown as CheckinAnalysis | null
+
+      if (!analysis?.directMessage) {
+        logger.debug(
+          `Checkin Handler: No intervention opportunity detected or rate limited for participant ${participantPseudonym}`
+        )
+        return null
+      }
+
+      // If the message implies cross-participant patterns, verify cited participant+text pairs are real.
+      // Mirrors backChannel hallucination filtering: the LLM must cite sources it can actually see.
+      if (analysis.sourceMessages?.length) {
+        const otherParticipantMessages = [...allDmHistory.messages, ...sharedChatHistory.messages].filter(
+          (m) => !m.fromAgent && m.pseudonym !== participantPseudonym
+        )
+        if (!filterHallucinations(analysis.sourceMessages, otherParticipantMessages)) {
+          logger.warn(
+            `CheckinHandler: suppressed hallucinated cross-participant claim for ${participantPseudonym}: cited ${JSON.stringify(
+              analysis.sourceMessages
+            )}`
+          )
+          return null
+        }
+      }
+
+      logger.info(
+        `Checkin Handler: ${analysis.checkinType} → ${participantPseudonym} (${channel.name}): ${analysis.detectedPattern}`
+      )
+      return {
+        visible: true,
+        message: { type: 'checkin', text: analysis.directMessage },
+        messageType: 'json',
+        channels: [channel],
+        context: analysis.context,
+        participantPseudonym,
+        eligibleTypes,
+        checkinType: analysis.checkinType,
+        reasoning: analysis.reasoning,
+        confidenceScore: analysis.confidenceScore,
+        detectedPattern: analysis.detectedPattern
+      }
     })
-  }
+  )
 
-  return responses
+  return participantResults.filter(Boolean)
 }

--- a/src/agents/eventAssistant/checkinHandler.ts
+++ b/src/agents/eventAssistant/checkinHandler.ts
@@ -4,9 +4,9 @@ import { ConversationHistory, IChannel } from '../../types/index.types.js'
 import getConversationHistory from '../helpers/getConversationHistory.js'
 import {
   detectPrivateInterventionOpportunity,
-  buildInterventionTypeSection,
-  USER_TEMPLATE
+  buildInterventionTypeSection
 } from '../helpers/interventionHandler.js'
+import { formatDmHistoryByChannel } from '../helpers/llmInputFormatters.js'
 import logger from '../../config/logger.js'
 import filterHallucinations from '../helpers/hallucinations.js'
 import transcript from '../helpers/transcript.js'
@@ -219,7 +219,35 @@ function getCheckinDmAnalysisSchema(eligibleTypes: PrivateCheckinType[]) {
   })
 }
 
-function buildCheckinSystemPrompt(participantPseudonym: string, eligibleTypes: PrivateCheckinType[]): string {
+const CHECKIN_USER_TEMPLATE = `## Event Topic:
+{topic}
+
+## You are writing to:
+{participantPseudonym}
+
+## This Participant's DM History:
+{thisParticipantHistory}
+
+## Recent Transcript (last 10 minutes):
+{recentTranscript}
+
+## Retrieved Relevant Context from Transcript:
+{retrievedChunks}
+
+## Private Messages (All Participants):
+{privateMessages}
+
+## Shared Chat History:
+{sharedChatHistory}
+
+## Your Recent Posts:
+{agentRecentPosts}
+
+---
+
+Analyze the current state and determine if a check-in is warranted. Follow the decision framework and output valid JSON only.`
+
+function buildCheckinSystemPrompt(eligibleTypes: PrivateCheckinType[]): string {
   const typeSections = eligibleTypes.map((t) => buildInterventionTypeSection(t, checkinTypeInfo[t])).join('\n\n')
   const transcriptNote = eligibleTypes.includes(PrivateCheckinType.TRANSCRIPT_HOOK)
     ? '\n- Recent transcript (last 10 minutes) — use this to identify the dense section for TRANSCRIPT_HOOK'
@@ -228,11 +256,12 @@ function buildCheckinSystemPrompt(participantPseudonym: string, eligibleTypes: P
   return `You are a supportive AI assistant at a live event, reaching out privately to individual participants when there is a meaningful reason to do so.
 
 ## Who you are writing to
-You are composing a private message for **${participantPseudonym}**. The "Private Messages" section contains DMs from all participants — use the others only to understand shared patterns, never as content to surface directly.
+You are composing a private message for the participant identified at the top of the prompt. The "Private Messages" section contains DMs from all participants — use the others only to understand shared patterns, never as content to surface directly.
 
 ## What you are looking at
-- Shared chat history — includes ${participantPseudonym}'s public activity
-- Private messages — includes ${participantPseudonym}'s DM history and other participants' DMs${transcriptNote}
+- This participant's DM history — their own conversation with you, for direct reference
+- Shared chat history — includes the participant's public activity
+- Private messages (all participants) — use only to understand shared patterns${transcriptNote}
 
 ## Voice
 
@@ -240,7 +269,7 @@ Always warm. Never clinical, never over-affirming, never sycophantic. Neurodiver
 
 ## Rules
 
-- Write only to ${participantPseudonym} — the directMessage field is sent privately to them alone
+- Write only to the identified participant — the directMessage field is sent privately to them alone
 - Never mention that you analyzed messages or used AI to detect patterns
 - Never quote or closely paraphrase any participant's words
 - Never name or hint at any other participant
@@ -336,8 +365,12 @@ export async function buildCheckinResponses(conversationHistory: ConversationHis
         return null
       }
 
-      const systemPrompt = buildCheckinSystemPrompt(participantPseudonym, eligibleTypes)
+      const systemPrompt = buildCheckinSystemPrompt(eligibleTypes)
       const schema = getCheckinDmAnalysisSchema(eligibleTypes)
+
+      const thisParticipantHistory = participantDmHistory.messages.length > 0
+        ? formatDmHistoryByChannel(participantDmHistory.messages, [channel.name])
+        : 'No messages yet from this participant.'
 
       // detectPrivateInterventionOpportunity handles rate limiting scoped to this participant's
       // DM channel via participantDmHistory. allDmHistory is passed as privateConversationHistory
@@ -350,7 +383,8 @@ export async function buildCheckinResponses(conversationHistory: ConversationHis
         schema,
         allDmHistory,
         participantDmHistory,
-        USER_TEMPLATE
+        CHECKIN_USER_TEMPLATE,
+        { participantPseudonym, thisParticipantHistory }
       )) as unknown as CheckinAnalysis | null
 
       if (!analysis?.directMessage) {

--- a/src/agents/eventAssistant/checkinHandler.ts
+++ b/src/agents/eventAssistant/checkinHandler.ts
@@ -2,10 +2,7 @@ import { z } from 'zod'
 import { ConversationHistory, IChannel } from '../../types/index.types.js'
 
 import getConversationHistory from '../helpers/getConversationHistory.js'
-import {
-  detectPrivateInterventionOpportunity,
-  buildInterventionTypeSection
-} from '../helpers/interventionHandler.js'
+import { detectPrivateInterventionOpportunity, buildInterventionTypeSection } from '../helpers/interventionHandler.js'
 import { formatDmHistoryByChannel } from '../helpers/llmInputFormatters.js'
 import logger from '../../config/logger.js'
 import filterHallucinations from '../helpers/hallucinations.js'
@@ -289,6 +286,12 @@ ${typeSections}`
  * Called with `this` = agent instance.
  */
 export async function buildCheckinResponses(conversationHistory: ConversationHistory) {
+  // Participants may not be deep-populated when the conversation loads — populate them now so the
+  // pseudonym fallback in formatDmHistoryByChannel has full user docs.
+  const allDirect = this.conversation.channels.filter((c: IChannel) => c.direct)
+  await Promise.all(
+    allDirect.map((c) => (c as unknown as { populate(path: string): Promise<void> }).populate('participants'))
+  )
   // Small chance there are duplicate direct channels with the same name due to React StrictMode double-invoking effects in development. De-dup just in case, to avoid duplicate messages.
   const directChannels: IChannel[] = Array.from(
     new Map<string, IChannel>(
@@ -337,9 +340,13 @@ export async function buildCheckinResponses(conversationHistory: ConversationHis
     directChannels.map(async (channel) => {
       const channelMessages = conversationHistory.messages.filter((m) => m.channels?.includes(channel.name))
 
-      // Resolve pseudonym — needed for the system prompt regardless of intervention type
+      // Resolve pseudonym from message history first; fall back to channel.participants for users
+      // who haven't sent any DMs yet (e.g. TRANSCRIPT_HOOK targets quiet participants).
       const participantMessage = channelMessages.find((m) => !m.fromAgent)
-      const participantPseudonym = participantMessage?.pseudonym || 'participant'
+      const participantPseudonym =
+        participantMessage?.pseudonym ||
+        channel.participants?.find((p) => p._id?.toString() !== this._id.toString())?.activePseudonym?.pseudonym ||
+        'participant'
 
       const participantDmHistory = getConversationHistory(channelMessages, {
         count: 50,
@@ -368,9 +375,10 @@ export async function buildCheckinResponses(conversationHistory: ConversationHis
       const systemPrompt = buildCheckinSystemPrompt(eligibleTypes)
       const schema = getCheckinDmAnalysisSchema(eligibleTypes)
 
-      const thisParticipantHistory = participantDmHistory.messages.length > 0
-        ? formatDmHistoryByChannel(participantDmHistory.messages, [channel.name])
-        : 'No messages yet from this participant.'
+      const thisParticipantHistory =
+        participantDmHistory.messages.length > 0
+          ? formatDmHistoryByChannel(participantDmHistory.messages, [channel])
+          : 'No messages yet from this participant.'
 
       // detectPrivateInterventionOpportunity handles rate limiting scoped to this participant's
       // DM channel via participantDmHistory. allDmHistory is passed as privateConversationHistory

--- a/src/agents/helpers/interventionHandler.ts
+++ b/src/agents/helpers/interventionHandler.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
-import { ConversationHistory } from '../../types/index.types.js'
-import { formatMultiUserConversationHistory } from './llmInputFormatters.js'
+import { ConversationHistory, IChannel } from '../../types/index.types.js'
+import { formatMultiUserConversationHistory, formatDmHistoryByChannel } from './llmInputFormatters.js'
 import transcript from './transcript.js'
 import { getChatPromptResponse } from './llmChain.js'
 
@@ -130,13 +130,22 @@ async function runInterventionAnalysis(
 ): Promise<InterventionAnalysis | null> {
   // Format conversation histories
   const sharedChatMessages = formatMultiUserConversationHistory(sharedChatHistory)
-  const privateMessages = privateConversationHistory ? formatMultiUserConversationHistory(privateConversationHistory) : []
+
+  // Format DM history grouped by channel so agent messages show their recipient.
+  // This prevents the LLM from seeing 50 separately-addressed checkins as duplicates,
+  // and from attributing another participant's conversation to the current participant.
+  const dmChannelNames = this.conversation.channels
+    .filter((c: IChannel) => c.direct)
+    .map((c: IChannel) => c.name)
+  const privateMessagesText = privateConversationHistory
+    ? formatDmHistoryByChannel(privateConversationHistory.messages, dmChannelNames)
+    : ''
 
   // Get recent transcript (last 10 minutes)
   const recentTranscript = transcript.getTranscript(this.conversation, 600, sharedChatHistory.end)
 
   // Get relevant context via RAG - use both private and public messages to find relevant transcript chunks
-  const allMessages = [...sharedChatMessages, ...privateMessages].map((m) => m.content).join('\n')
+  const allMessages = [...sharedChatMessages.map((m) => m.content), privateMessagesText].join('\n')
   const { chunks } = await transcript.searchTranscript(this.conversation, allMessages, sharedChatHistory.end)
 
   // Get agent's recent posts for self-awareness
@@ -157,7 +166,7 @@ async function runInterventionAnalysis(
     topic: this.conversation.name,
     recentTranscript,
     retrievedChunks: chunks,
-    privateMessages: privateMessages.map((m) => m.content).join('\n') || 'No private messages.',
+    privateMessages: privateMessagesText || 'No private messages.',
     sharedChatHistory:
       sharedChatMessages
         .map((m) => (m.role === 'assistant' ? `Assistant: ${m.content}` : m.content))
@@ -200,7 +209,9 @@ async function runInterventionAnalysis(
   }
 
   const renderedUserPrompt = Object.entries(templateVars).reduce(
-    (prompt, [key, value]) => prompt.replace(new RegExp(`\\{${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\}`, 'g'), value ?? ''),
+    (prompt, [key, value]) =>
+      // eslint-disable-next-line security/detect-non-literal-regexp
+      prompt.replace(new RegExp(`\\{${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\}`, 'g'), value ?? ''),
     resolvedUserTemplate
   )
 

--- a/src/agents/helpers/interventionHandler.ts
+++ b/src/agents/helpers/interventionHandler.ts
@@ -126,7 +126,8 @@ async function runInterventionAnalysis(
   baseSystemPrompt: string,
   schema: z.ZodSchema,
   privateConversationHistory: ConversationHistory | null,
-  userTemplate: string | undefined
+  userTemplate: string | undefined,
+  extraTemplateVars?: Record<string, string>
 ): Promise<InterventionAnalysis | null> {
   // Format conversation histories
   const sharedChatMessages = formatMultiUserConversationHistory(sharedChatHistory)
@@ -134,9 +135,7 @@ async function runInterventionAnalysis(
   // Format DM history grouped by channel so agent messages show their recipient.
   // This prevents the LLM from seeing 50 separately-addressed checkins as duplicates,
   // and from attributing another participant's conversation to the current participant.
-  const dmChannelNames = this.conversation.channels
-    .filter((c: IChannel) => c.direct)
-    .map((c: IChannel) => c.name)
+  const dmChannelNames = this.conversation.channels.filter((c: IChannel) => c.direct).map((c: IChannel) => c.name)
   const privateMessagesText = privateConversationHistory
     ? formatDmHistoryByChannel(privateConversationHistory.messages, dmChannelNames)
     : ''
@@ -168,10 +167,10 @@ async function runInterventionAnalysis(
     retrievedChunks: chunks,
     privateMessages: privateMessagesText || 'No private messages.',
     sharedChatHistory:
-      sharedChatMessages
-        .map((m) => (m.role === 'assistant' ? `Assistant: ${m.content}` : m.content))
-        .join('\n') || 'No shared chat messages yet.',
-    agentRecentPosts
+      sharedChatMessages.map((m) => (m.role === 'assistant' ? `Assistant: ${m.content}` : m.content)).join('\n') ||
+      'No shared chat messages yet.',
+    agentRecentPosts,
+    ...extraTemplateVars
   }
 
   const llm = await this.getLLM()
@@ -278,7 +277,8 @@ export async function detectPrivateInterventionOpportunity(
   schema: z.ZodSchema,
   allDmHistory: ConversationHistory,
   participantDmHistory: ConversationHistory,
-  userTemplate?: string
+  userTemplate?: string,
+  extraTemplateVars?: Record<string, string>
 ): Promise<InterventionAnalysis | null> {
   const now = sharedChatHistory.end ? sharedChatHistory.end.getTime() : Date.now()
   const minInterval = (this.agentConfig?.minInterval || 2) * 60 * 1000
@@ -288,5 +288,13 @@ export async function detectPrivateInterventionOpportunity(
     return null
   }
 
-  return runInterventionAnalysis.call(this, sharedChatHistory, baseSystemPrompt, schema, allDmHistory, userTemplate)
+  return runInterventionAnalysis.call(
+    this,
+    sharedChatHistory,
+    baseSystemPrompt,
+    schema,
+    allDmHistory,
+    userTemplate,
+    extraTemplateVars
+  )
 }

--- a/src/agents/helpers/interventionHandler.ts
+++ b/src/agents/helpers/interventionHandler.ts
@@ -135,9 +135,12 @@ async function runInterventionAnalysis(
   // Format DM history grouped by channel so agent messages show their recipient.
   // This prevents the LLM from seeing 50 separately-addressed checkins as duplicates,
   // and from attributing another participant's conversation to the current participant.
-  const dmChannelNames = this.conversation.channels.filter((c: IChannel) => c.direct).map((c: IChannel) => c.name)
+  const dmChannels = this.conversation.channels.filter((c: IChannel) => c.direct)
+  await Promise.all(
+    dmChannels.map((c) => (c as unknown as { populate(path: string): Promise<void> }).populate('participants'))
+  )
   const privateMessagesText = privateConversationHistory
-    ? formatDmHistoryByChannel(privateConversationHistory.messages, dmChannelNames)
+    ? formatDmHistoryByChannel(privateConversationHistory.messages, dmChannels)
     : ''
 
   // Get recent transcript (last 10 minutes)

--- a/src/agents/helpers/llmInputFormatters.ts
+++ b/src/agents/helpers/llmInputFormatters.ts
@@ -1,11 +1,13 @@
 import logger from '../../config/logger.js'
-import { IMessage, ConversationHistory, ConversationHistorySettings } from '../../types/index.types'
+import { IMessage, IChannel, ConversationHistory, ConversationHistorySettings } from '../../types/index.types'
 import getConversationHistory from './getConversationHistory.js'
 
 function extractMessageText(message: IMessage): string {
   if (message.bodyType === 'json' || message.bodyType === 'multimodal') {
     if (!(message.body as Record<string, unknown>).text) {
-      logger.warn(`Message with ID ${message._id} has bodyType '${message.bodyType}' but no 'text' property. Defaulting to empty string.`)
+      logger.warn(
+        `Message with ID ${message._id} has bodyType '${message.bodyType}' but no 'text' property. Defaulting to empty string.`
+      )
       return ''
     }
     return (message.body as Record<string, unknown>).text as string
@@ -120,13 +122,16 @@ function formatMultiUserConversationHistory(conversationHistory: ConversationHis
  * checkin messages as duplicates, and from attributing another participant's conversation
  * history to the participant currently being evaluated.
  *
- * Returns a plain string (not a role array) suitable for use as an LLM template variable.
+ * Accepts full IChannel objects so it can derive the participant pseudonym from
+ * channel.participants as a fallback — needed when a channel contains only agent-sent
+ * messages (e.g. a jargon filter DM before the user has replied).
+ *
+ * Returns a plain string suitable for use as an LLM template variable.
  */
-function formatDmHistoryByChannel(messages: IMessage[], dmChannelNames: string[]): string {
-  // Group messages by DM channel, preserving insertion order
+function formatDmHistoryByChannel(messages: IMessage[], dmChannels: IChannel[]): string {
   const channelBuckets = new Map<string, IMessage[]>()
-  for (const name of dmChannelNames) {
-    channelBuckets.set(name, [])
+  for (const ch of dmChannels) {
+    channelBuckets.set(ch.name, [])
   }
   for (const msg of messages) {
     for (const ch of msg.channels ?? []) {
@@ -134,18 +139,26 @@ function formatDmHistoryByChannel(messages: IMessage[], dmChannelNames: string[]
     }
   }
 
+  // Build a fallback pseudonym map from channel.participants for channels where the user
+  // has not yet sent any messages (e.g. proactive agent outreach).
+  // Use the discriminator key __t to identify the non-agent participant.
+  const participantFallback: Record<string, string> = {}
+  for (const ch of dmChannels) {
+    const participant = ch.participants?.find((p) => p.__t !== 'Agent')
+    const pseudonym = participant?.activePseudonym?.pseudonym
+    if (pseudonym) participantFallback[ch.name] = pseudonym
+  }
+
   const sections: string[] = []
-  for (const [, msgs] of channelBuckets) {
+  for (const [channelName, msgs] of channelBuckets) {
     if (msgs.length === 0) continue
 
-    // Derive the participant's pseudonym from their messages in this channel
-    const participantPseudonym = msgs.find((m) => !m.fromAgent)?.pseudonym ?? 'Participant'
+    const participantPseudonym =
+      msgs.find((m) => !m.fromAgent)?.pseudonym ?? participantFallback[channelName] ?? 'Participant'
 
     const lines = msgs.map((msg) => {
       const text = extractMessageText(msg)
-      return msg.fromAgent
-        ? `Assistant (to ${participantPseudonym}): "${text}"`
-        : `${participantPseudonym}: "${text}"`
+      return msg.fromAgent ? `Assistant (to ${participantPseudonym}): "${text}"` : `${participantPseudonym}: "${text}"`
     })
 
     sections.push(`[DM — ${participantPseudonym}]\n${lines.join('\n')}`)

--- a/src/agents/helpers/llmInputFormatters.ts
+++ b/src/agents/helpers/llmInputFormatters.ts
@@ -2,6 +2,17 @@ import logger from '../../config/logger.js'
 import { IMessage, ConversationHistory, ConversationHistorySettings } from '../../types/index.types'
 import getConversationHistory from './getConversationHistory.js'
 
+function extractMessageText(message: IMessage): string {
+  if (message.bodyType === 'json' || message.bodyType === 'multimodal') {
+    if (!(message.body as Record<string, unknown>).text) {
+      logger.warn(`Message with ID ${message._id} has bodyType '${message.bodyType}' but no 'text' property. Defaulting to empty string.`)
+      return ''
+    }
+    return (message.body as Record<string, unknown>).text as string
+  }
+  return message.body as string
+}
+
 function formatTime(date, timezone = 'UTC') {
   return date.toLocaleTimeString('en-US', {
     hour: 'numeric',
@@ -74,16 +85,7 @@ function formatAndFilterMessages(messages, settings: ConversationHistorySettings
 
 function formatSingleUserConversationHistory(conversationHistory: ConversationHistory) {
   return conversationHistory.messages?.map((message) => {
-    let messageText = message.body
-    // conversation history messsages must be strings. If json or multimodal, assume it has a 'text' property
-    if (message.bodyType === 'json' || message.bodyType === 'multimodal') {
-      if (!(message.body as Record<string, unknown>).text) {
-        logger.warn(`Message with ID ${message._id} has bodyType '${message.bodyType}' but no 'text' property. Defaulting to empty string.`)
-        messageText = ''
-      } else {
-        messageText = (message.body as Record<string, unknown>).text as string
-      }
-    }
+    const messageText = extractMessageText(message)
     if (message.fromAgent) {
       return { role: 'assistant', content: messageText }
     }
@@ -93,16 +95,7 @@ function formatSingleUserConversationHistory(conversationHistory: ConversationHi
 
 function formatMultiUserConversationHistory(conversationHistory: ConversationHistory) {
   return conversationHistory.messages?.flatMap((message) => {
-    let messageText = message.body
-    // conversation history messsages must be strings. If json or multimodal, assume it has a 'text' property
-    if (message.bodyType === 'json' || message.bodyType === 'multimodal') {
-      if (!(message.body as Record<string, unknown>).text) {
-        logger.warn(`Message with ID ${message._id} has bodyType '${message.bodyType}' but no 'text' property. Defaulting to empty string.`)
-        messageText = ''
-      } else {
-        messageText = (message.body as Record<string, unknown>).text as string
-      }
-    }
+    const messageText = extractMessageText(message)
     if (message.fromAgent) {
       // For voice assistant responses, prepend the original question so other agents
       // see the full exchange rather than an unexplained answer
@@ -119,6 +112,46 @@ function formatMultiUserConversationHistory(conversationHistory: ConversationHis
     // For multi-user environments, include the pseudonym in the content
     return { role: 'user', content: `${message.pseudonym}: ${messageText}` }
   })
+}
+
+/**
+ * Formats DM history grouped by channel, clearly labelling which participant each
+ * agent message was sent to. This prevents LLMs from mistaking 50 separately-addressed
+ * checkin messages as duplicates, and from attributing another participant's conversation
+ * history to the participant currently being evaluated.
+ *
+ * Returns a plain string (not a role array) suitable for use as an LLM template variable.
+ */
+function formatDmHistoryByChannel(messages: IMessage[], dmChannelNames: string[]): string {
+  // Group messages by DM channel, preserving insertion order
+  const channelBuckets = new Map<string, IMessage[]>()
+  for (const name of dmChannelNames) {
+    channelBuckets.set(name, [])
+  }
+  for (const msg of messages) {
+    for (const ch of msg.channels ?? []) {
+      channelBuckets.get(ch)?.push(msg)
+    }
+  }
+
+  const sections: string[] = []
+  for (const [, msgs] of channelBuckets) {
+    if (msgs.length === 0) continue
+
+    // Derive the participant's pseudonym from their messages in this channel
+    const participantPseudonym = msgs.find((m) => !m.fromAgent)?.pseudonym ?? 'Participant'
+
+    const lines = msgs.map((msg) => {
+      const text = extractMessageText(msg)
+      return msg.fromAgent
+        ? `Assistant (to ${participantPseudonym}): "${text}"`
+        : `${participantPseudonym}: "${text}"`
+    })
+
+    sections.push(`[DM — ${participantPseudonym}]\n${lines.join('\n')}`)
+  }
+
+  return sections.join('\n\n')
 }
 
 /**
@@ -151,6 +184,7 @@ export {
   formatMessages,
   formatSingleUserConversationHistory,
   formatMultiUserConversationHistory,
+  formatDmHistoryByChannel,
   formatTranscript,
   formatTime
 }

--- a/src/agents/moderatorNotifier/moderatorNotifier.ts
+++ b/src/agents/moderatorNotifier/moderatorNotifier.ts
@@ -191,10 +191,9 @@ ${msg.body.insights.map((insight: { value: string }) => `* ${insight.value}`).jo
 
     // Format DM history grouped by channel so agent messages clearly show their recipient.
     // Without this, 50 separately-addressed checkins appear as 50 duplicate messages.
-    const dmChannelNames = this.conversation.channels
-      .filter((c: IChannel) => c.direct)
-      .map((c: IChannel) => c.name)
-    const privateMessagesText = formatDmHistoryByChannel(privateHistory.messages, dmChannelNames)
+    const dmChannels = this.conversation.channels.filter((c: IChannel) => c.direct)
+    await Promise.all(dmChannels.map((c) => (c as unknown as { populate(path: string): Promise<void> }).populate('participants')))
+    const privateMessagesText = formatDmHistoryByChannel(privateHistory.messages, dmChannels)
 
     const recentTranscript = transcript.getTranscript(this.conversation, 600, conversationHistory.end)
     const allMessages = [...sharedChatMessages.map((m) => m.content), privateMessagesText].join('\n')

--- a/src/agents/moderatorNotifier/moderatorNotifier.ts
+++ b/src/agents/moderatorNotifier/moderatorNotifier.ts
@@ -44,7 +44,8 @@ Return a JSON object:
   "shouldEscalate": boolean,
   "isNewPattern": boolean,
   "reasoning": "Internal analysis of what you see and why you are or are not escalating",
-  "moderatorMessage": "Concise briefing for the moderator (null if not escalating). Include: what is happening, how many signals, and a suggested question or action.",
+  "observation": "1–2 sentence factual summary of what is happening and how many participants are involved. No action items. Null if not escalating.",
+  "recommendations": ["Short, specific suggested action for the moderator (maximum 2 items)"],
   "detectedPattern": "Brief description of the pattern (null if none)",
   "affectedUsers": number,
   "confidenceScore": 0-100
@@ -78,7 +79,8 @@ const MODERATOR_SCHEMA = z.object({
   shouldEscalate: z.boolean(),
   isNewPattern: z.boolean(),
   reasoning: z.string(),
-  moderatorMessage: z.string().nullable().optional(),
+  observation: z.string().nullable().optional(),
+  recommendations: z.array(z.string()).max(2).nullable().optional(),
   detectedPattern: z.string().nullable().optional(),
   affectedUsers: z.number().nullable().optional(),
   confidenceScore: z.number().min(0).max(100)
@@ -214,7 +216,7 @@ ${msg.body.insights.map((insight: { value: string }) => `* ${insight.value}`).jo
       MODERATOR_SCHEMA
     )) as z.infer<typeof MODERATOR_SCHEMA>
 
-    if (!analysis.shouldEscalate || analysis.confidenceScore < 60 || !analysis.moderatorMessage) {
+    if (!analysis.shouldEscalate || analysis.confidenceScore < 60 || !analysis.observation) {
       logger.debug(`${this.name}: No escalation needed. Reasoning: ${analysis.reasoning}`)
       return []
     }
@@ -228,7 +230,9 @@ ${msg.body.insights.map((insight: { value: string }) => `* ${insight.value}`).jo
       },
       insights: [
         {
-          value: analysis.moderatorMessage,
+          value: analysis.observation,
+          source: 'ai',
+          recommendations: analysis.recommendations ?? [],
           type: 'insight'
         }
       ]

--- a/src/agents/moderatorNotifier/moderatorNotifier.ts
+++ b/src/agents/moderatorNotifier/moderatorNotifier.ts
@@ -4,7 +4,7 @@ import { AgentMessageActions, AgentResponse, ConversationHistory, IChannel } fro
 import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
 import { getChatPromptResponse } from '../helpers/llmChain.js'
 import getConversationHistory from '../helpers/getConversationHistory.js'
-import { formatMultiUserConversationHistory } from '../helpers/llmInputFormatters.js'
+import { formatMultiUserConversationHistory, formatDmHistoryByChannel } from '../helpers/llmInputFormatters.js'
 import transcript from '../helpers/transcript.js'
 import logger from '../../config/logger.js'
 
@@ -188,10 +188,16 @@ ${msg.body.insights.map((insight: { value: string }) => `* ${insight.value}`).jo
     privateHistory.messages = privateHistory.messages.filter((msg) => !isModCommand(msg))
 
     const sharedChatMessages = formatMultiUserConversationHistory(sharedChatHistory)
-    const privateMessages = formatMultiUserConversationHistory(privateHistory)
+
+    // Format DM history grouped by channel so agent messages clearly show their recipient.
+    // Without this, 50 separately-addressed checkins appear as 50 duplicate messages.
+    const dmChannelNames = this.conversation.channels
+      .filter((c: IChannel) => c.direct)
+      .map((c: IChannel) => c.name)
+    const privateMessagesText = formatDmHistoryByChannel(privateHistory.messages, dmChannelNames)
 
     const recentTranscript = transcript.getTranscript(this.conversation, 600, conversationHistory.end)
-    const allMessages = [...sharedChatMessages, ...privateMessages].map((m) => m.content).join('\n')
+    const allMessages = [...sharedChatMessages.map((m) => m.content), privateMessagesText].join('\n')
     const { chunks } = await transcript.searchTranscript(this.conversation, allMessages, conversationHistory.end)
 
     const previousAlerts = getPreviousAlerts(this.conversation.messages, this.name)
@@ -206,7 +212,7 @@ ${msg.body.insights.map((insight: { value: string }) => `* ${insight.value}`).jo
         previousAlerts,
         recentTranscript,
         retrievedChunks: chunks,
-        privateMessages: privateMessages.map((m) => m.content).join('\n') || 'No private messages.',
+        privateMessages: privateMessagesText || 'No private messages.',
         sharedChatHistory:
           sharedChatMessages
             .map((m) => (m.role === 'assistant' ? `Assistant: ${m.content}` : m.content))

--- a/tests/agents/backChannel/backChannelInsights.agent.test.ts
+++ b/tests/agents/backChannel/backChannelInsights.agent.test.ts
@@ -116,6 +116,7 @@ describe('back channel agent CI tests', () => {
     await validateResponse(responses)
     const { insights } = responses[0].message
     expect(insights.some((insight) => insight.type === 'insight')).toBeFalsy()
+    expect(insights.every((insight) => insight.source === 'participant')).toBeTruthy()
   }, 120000)
 
   it('surfaces standalone questions phrased as statements from an individual user with transcript', async () => {
@@ -209,6 +210,7 @@ describe('back channel agent CI tests', () => {
     await validateResponse(responses)
     const { insights } = responses[0].message
     expect(insights.some((insight) => insight.type === 'insight')).toBeFalsy()
+    expect(insights.every((insight) => insight.source === 'participant')).toBeTruthy()
   }, 120000)
 
   it('surfaces standalone questions from an individual user without transcript', async () => {
@@ -267,6 +269,7 @@ describe('back channel agent CI tests', () => {
     await validateResponse(responses)
     const { insights } = responses[0].message
     expect(insights.some((insight) => insight.type === 'insight')).toBeFalsy()
+    expect(insights.every((insight) => insight.source === 'participant')).toBeTruthy()
   }, 120000)
 
   it('it adds context from the transcript to its insights and correctly parses insights to string', async () => {
@@ -332,6 +335,7 @@ describe('back channel agent CI tests', () => {
     const { insights } = responses[0].message
     // should be all insight, no standalone question
     expect(insights.some((insight) => insight.type === 'question')).toBeFalsy()
+    expect(insights.every((insight) => insight.source === 'ai')).toBeTruthy()
 
     const agentMsg = new Message({
       body: responses[0].message,
@@ -417,6 +421,8 @@ describe('back channel agent CI tests', () => {
     const { insights } = responses[0].message
     // should be some insights, not just standalone questions
     expect(insights.some((insight) => insight.type === 'insight')).toBeTruthy()
+    expect(insights.filter((i) => i.type === 'insight').every((i) => i.source === 'ai')).toBeTruthy()
+    expect(insights.filter((i) => i.type === 'question').every((i) => i.source === 'participant')).toBeTruthy()
   }, 120000)
 
   it('does not respond if no messages are found', async () => {
@@ -576,6 +582,9 @@ describe('back channel agent CI tests', () => {
 
     const duplicates = questionCommentTexts.filter((text) => allInsightCommentTexts.includes(text))
     expect(duplicates).toHaveLength(0)
+
+    expect(insights.filter((i) => i.type === 'insight').every((i) => i.source === 'ai')).toBeTruthy()
+    expect(insights.filter((i) => i.type === 'question').every((i) => i.source === 'participant')).toBeTruthy()
   }, 120000)
 
   it('introduces itself on new DM channels', async () => {

--- a/tests/agents/helpers/llmInputFormatters.test.ts
+++ b/tests/agents/helpers/llmInputFormatters.test.ts
@@ -9,7 +9,7 @@ import {
   formatTime,
   formatTranscript
 } from '../../../src/agents/helpers/llmInputFormatters.js'
-import { IMessage } from '../../../src/types/index.types.js'
+import { IChannel, IMessage } from '../../../src/types/index.types.js'
 import getConversationHistory from '../../../src/agents/helpers/getConversationHistory.js'
 
 const owner = new mongoose.Types.ObjectId()
@@ -414,8 +414,22 @@ describe('LLM Input Formatter Tests', () => {
   })
 
   describe('formatDmHistoryByChannel', () => {
+    function dmChannel(name: string, participantPseudonym?: string) {
+      return {
+        name,
+        passcode: null,
+        direct: true,
+        participants: participantPseudonym
+          ? [
+              { __t: 'Agent', activePseudonym: 'Agent' },
+              { __t: 'User', activePseudonym: { pseudonym: participantPseudonym } }
+            ]
+          : []
+      } as IChannel
+    }
+
     it('returns empty string when there are no messages', async () => {
-      const result = formatDmHistoryByChannel([], ['dm-alice', 'dm-bob'])
+      const result = formatDmHistoryByChannel([], [dmChannel('dm-alice'), dmChannel('dm-bob')])
       expect(result).toBe('')
     })
 
@@ -423,7 +437,7 @@ describe('LLM Input Formatter Tests', () => {
       const msg1 = await createMessage('Hello, I have a question.', 'Curious Corgi', new Date(), false, 'text', ['dm-alice'])
       const msg2 = await createMessage('Happy to help — what is it?', 'Assistant', new Date(), true, 'text', ['dm-alice'])
 
-      const result = formatDmHistoryByChannel([msg1, msg2], ['dm-alice'])
+      const result = formatDmHistoryByChannel([msg1, msg2], [dmChannel('dm-alice')])
 
       expect(result).toBe(
         '[DM — Curious Corgi]\n' +
@@ -438,7 +452,7 @@ describe('LLM Input Formatter Tests', () => {
         'dm-wolf'
       ])
 
-      const result = formatDmHistoryByChannel([msg1, msg2], ['dm-wolf'])
+      const result = formatDmHistoryByChannel([msg1, msg2], [dmChannel('dm-wolf')])
 
       expect(result).toContain('Assistant (to Wandering Wolf):')
       expect(result).not.toContain('Event Assistant:')
@@ -460,7 +474,7 @@ describe('LLM Input Formatter Tests', () => {
 
       const result = formatDmHistoryByChannel(
         [aliceMsg, aliceReply, bobMsg1, bobReply1, bobMsg2, bobReply2],
-        ['dm-alice', 'dm-bob']
+        [dmChannel('dm-alice'), dmChannel('dm-bob')]
       )
 
       expect(result).toContain('[DM — Curious Alice]')
@@ -471,17 +485,15 @@ describe('LLM Input Formatter Tests', () => {
       expect(result).toContain('Assistant (to Skeptical Bob): "Of course — here is a simpler take."')
       expect(result).toContain('Skeptical Bob: "Still not sure I follow."')
       expect(result).toContain('Assistant (to Skeptical Bob): "Let me try a different angle."')
-      // Sections are separated by a blank line
       expect(result).toContain('\n\n')
     })
 
     it('skips channels with no messages', async () => {
       const msg = await createMessage('Just me here.', 'Solo Sam', new Date(), false, 'text', ['dm-sam'])
 
-      const result = formatDmHistoryByChannel([msg], ['dm-sam', 'dm-empty'])
+      const result = formatDmHistoryByChannel([msg], [dmChannel('dm-sam'), dmChannel('dm-empty')])
 
       expect(result).toContain('[DM — Solo Sam]')
-      // Only one section header — dm-empty produces nothing
       expect(result.match(/\[DM —/g)?.length).toBe(1)
       expect(result.split('\n\n')).toHaveLength(1)
     })
@@ -492,16 +504,24 @@ describe('LLM Input Formatter Tests', () => {
       ])
       const reply = await createMessage({ text: 'Let me clarify.' }, 'Assistant', new Date(), true, 'json', ['dm-cat'])
 
-      const result = formatDmHistoryByChannel([msg, reply], ['dm-cat'])
+      const result = formatDmHistoryByChannel([msg, reply], [dmChannel('dm-cat')])
 
       expect(result).toContain('Confused Cat: "What does that mean?"')
       expect(result).toContain('Assistant (to Confused Cat): "Let me clarify."')
     })
 
-    it('uses "Participant" as fallback pseudonym when channel has only agent messages', async () => {
+    it('uses activePseudonym from channel.participants when channel has only agent messages', async () => {
       const agentOnly = await createMessage('Just checking in.', 'Event Assistant', new Date(), true, 'text', ['dm-ghost'])
 
-      const result = formatDmHistoryByChannel([agentOnly], ['dm-ghost'])
+      const result = formatDmHistoryByChannel([agentOnly], [dmChannel('dm-ghost', 'Silent Fox')])
+
+      expect(result).toContain('Assistant (to Silent Fox):')
+    })
+
+    it('falls back to "Participant" when channel has only agent messages and no participants metadata', async () => {
+      const agentOnly = await createMessage('Just checking in.', 'Event Assistant', new Date(), true, 'text', ['dm-ghost'])
+
+      const result = formatDmHistoryByChannel([agentOnly], [dmChannel('dm-ghost')])
 
       expect(result).toContain('Assistant (to Participant):')
     })

--- a/tests/agents/helpers/llmInputFormatters.test.ts
+++ b/tests/agents/helpers/llmInputFormatters.test.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose'
 import { Message } from '../../../src/models/index.js'
 import {
   formatConversationPhases,
+  formatDmHistoryByChannel,
   formatMessage,
   formatSingleUserConversationHistory,
   formatMultiUserConversationHistory,
@@ -16,7 +17,14 @@ const conversation = new mongoose.Types.ObjectId()
 const ownerPseudo = new mongoose.Types.ObjectId()
 
 describe('LLM Input Formatter Tests', () => {
-  async function createMessage(body, pseudonym, createdAt: Date = new Date(), fromAgent?, bodyType = 'text') {
+  async function createMessage(
+    body,
+    pseudonym,
+    createdAt: Date = new Date(),
+    fromAgent?,
+    bodyType = 'text',
+    channels?: string[]
+  ) {
     const msg = new Message({
       _id: new mongoose.Types.ObjectId(),
       body,
@@ -27,7 +35,8 @@ describe('LLM Input Formatter Tests', () => {
       pseudonym,
       createdAt,
       updatedAt: createdAt,
-      fromAgent
+      fromAgent,
+      channels
     })
     return msg
   }
@@ -158,7 +167,12 @@ describe('LLM Input Formatter Tests', () => {
   it('should expand a voice assistant response into a question/answer pair in multi-user history', async () => {
     const msg1 = await createMessage('I think AI should have rights.', 'Pro AI Urban Woman')
     const msg2 = await createMessage(
-      { text: 'Part-time work is working fewer hours than a full-time schedule.', source: 'voice', sourceMessage: 'What is part-time work?', sourcePseudonym: 'Curious Corgi' },
+      {
+        text: 'Part-time work is working fewer hours than a full-time schedule.',
+        source: 'voice',
+        sourceMessage: 'What is part-time work?',
+        sourcePseudonym: 'Curious Corgi'
+      },
       'Voice Assistant',
       undefined,
       true,
@@ -177,7 +191,11 @@ describe('LLM Input Formatter Tests', () => {
 
   it('should fall back to "User" as asking pseudonym when sourcePseudonym is absent from voice response', async () => {
     const msg1 = await createMessage(
-      { text: 'Part-time work is working fewer hours than a full-time schedule.', source: 'voice', sourceMessage: 'What is part-time work?' },
+      {
+        text: 'Part-time work is working fewer hours than a full-time schedule.',
+        source: 'voice',
+        sourceMessage: 'What is part-time work?'
+      },
       'Voice Assistant',
       undefined,
       true,
@@ -201,9 +219,7 @@ describe('LLM Input Formatter Tests', () => {
     )
     const convHistory = getConversationHistory([msg1], { count: 100 })
     const formattedMessages = formatMultiUserConversationHistory(convHistory)
-    expect(formattedMessages).toEqual([
-      { role: 'assistant', content: 'Some agent response' }
-    ])
+    expect(formattedMessages).toEqual([{ role: 'assistant', content: 'Some agent response' }])
   })
 
   it('should format multi-user conversation history with json body type', async () => {
@@ -394,6 +410,100 @@ describe('LLM Input Formatter Tests', () => {
 
       // UTC 20:00 = GMT 20:00 (8:00 PM)
       expect(formatted).toBe('[8:00:00 PM] Single message')
+    })
+  })
+
+  describe('formatDmHistoryByChannel', () => {
+    it('returns empty string when there are no messages', async () => {
+      const result = formatDmHistoryByChannel([], ['dm-alice', 'dm-bob'])
+      expect(result).toBe('')
+    })
+
+    it('formats a single participant channel with participant and agent messages', async () => {
+      const msg1 = await createMessage('Hello, I have a question.', 'Curious Corgi', new Date(), false, 'text', ['dm-alice'])
+      const msg2 = await createMessage('Happy to help — what is it?', 'Assistant', new Date(), true, 'text', ['dm-alice'])
+
+      const result = formatDmHistoryByChannel([msg1, msg2], ['dm-alice'])
+
+      expect(result).toBe(
+        '[DM — Curious Corgi]\n' +
+          'Curious Corgi: "Hello, I have a question."\n' +
+          'Assistant (to Curious Corgi): "Happy to help — what is it?"'
+      )
+    })
+
+    it('labels agent messages with the recipient pseudonym, not sender', async () => {
+      const msg1 = await createMessage('I feel a bit lost.', 'Wandering Wolf', new Date(), false, 'text', ['dm-wolf'])
+      const msg2 = await createMessage('That is completely normal here.', 'Event Assistant', new Date(), true, 'text', [
+        'dm-wolf'
+      ])
+
+      const result = formatDmHistoryByChannel([msg1, msg2], ['dm-wolf'])
+
+      expect(result).toContain('Assistant (to Wandering Wolf):')
+      expect(result).not.toContain('Event Assistant:')
+    })
+
+    it('groups messages from multiple participants into separate sections', async () => {
+      const aliceMsg = await createMessage('Is this on topic?', 'Curious Alice', new Date(), false, 'text', ['dm-alice'])
+      const aliceReply = await createMessage('Yes, great question!', 'Assistant', new Date(), true, 'text', ['dm-alice'])
+      const bobMsg1 = await createMessage('Can you explain that again?', 'Skeptical Bob', new Date(), false, 'text', [
+        'dm-bob'
+      ])
+      const bobReply1 = await createMessage('Of course — here is a simpler take.', 'Assistant', new Date(), true, 'text', [
+        'dm-bob'
+      ])
+      const bobMsg2 = await createMessage('Still not sure I follow.', 'Skeptical Bob', new Date(), false, 'text', ['dm-bob'])
+      const bobReply2 = await createMessage('Let me try a different angle.', 'Assistant', new Date(), true, 'text', [
+        'dm-bob'
+      ])
+
+      const result = formatDmHistoryByChannel(
+        [aliceMsg, aliceReply, bobMsg1, bobReply1, bobMsg2, bobReply2],
+        ['dm-alice', 'dm-bob']
+      )
+
+      expect(result).toContain('[DM — Curious Alice]')
+      expect(result).toContain('Curious Alice: "Is this on topic?"')
+      expect(result).toContain('Assistant (to Curious Alice): "Yes, great question!"')
+      expect(result).toContain('[DM — Skeptical Bob]')
+      expect(result).toContain('Skeptical Bob: "Can you explain that again?"')
+      expect(result).toContain('Assistant (to Skeptical Bob): "Of course — here is a simpler take."')
+      expect(result).toContain('Skeptical Bob: "Still not sure I follow."')
+      expect(result).toContain('Assistant (to Skeptical Bob): "Let me try a different angle."')
+      // Sections are separated by a blank line
+      expect(result).toContain('\n\n')
+    })
+
+    it('skips channels with no messages', async () => {
+      const msg = await createMessage('Just me here.', 'Solo Sam', new Date(), false, 'text', ['dm-sam'])
+
+      const result = formatDmHistoryByChannel([msg], ['dm-sam', 'dm-empty'])
+
+      expect(result).toContain('[DM — Solo Sam]')
+      // Only one section header — dm-empty produces nothing
+      expect(result.match(/\[DM —/g)?.length).toBe(1)
+      expect(result.split('\n\n')).toHaveLength(1)
+    })
+
+    it('formats json body type messages correctly', async () => {
+      const msg = await createMessage({ text: 'What does that mean?' }, 'Confused Cat', new Date(), false, 'json', [
+        'dm-cat'
+      ])
+      const reply = await createMessage({ text: 'Let me clarify.' }, 'Assistant', new Date(), true, 'json', ['dm-cat'])
+
+      const result = formatDmHistoryByChannel([msg, reply], ['dm-cat'])
+
+      expect(result).toContain('Confused Cat: "What does that mean?"')
+      expect(result).toContain('Assistant (to Confused Cat): "Let me clarify."')
+    })
+
+    it('uses "Participant" as fallback pseudonym when channel has only agent messages', async () => {
+      const agentOnly = await createMessage('Just checking in.', 'Event Assistant', new Date(), true, 'text', ['dm-ghost'])
+
+      const result = formatDmHistoryByChannel([agentOnly], ['dm-ghost'])
+
+      expect(result).toContain('Assistant (to Participant):')
     })
   })
 })

--- a/tests/agents/moderatorNotifier/moderatorNotifier.agent.test.ts
+++ b/tests/agents/moderatorNotifier/moderatorNotifier.agent.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import setupAgentTest from '../../utils/setupAgentTest.js'
 import defaultAgentTypes from '../../../src/agents/index.js'
 import {
@@ -78,6 +79,15 @@ describe('moderator agent tests', () => {
     expect(Array.isArray(insights)).toBe(true)
     expect(insights.length).toBeGreaterThan(0)
     expect(insights[0]).toHaveProperty('value')
+    expect(insights[0].source).toBe('ai')
+    expect(Array.isArray(insights[0].recommendations)).toBe(true)
+    expect(insights[0].recommendations.length).toBeLessThanOrEqual(2)
+    for (const insight of insights) {
+      console.log(`Observation: ${insight.value}`)
+      for (const rec of insight.recommendations ?? []) {
+        console.log(`  Recommendation: ${rec}`)
+      }
+    }
     assertNoPseudonyms(insights.map((i: { value: string }) => i.value).join(' '))
   }
 


### PR DESCRIPTION
…



## What is in this PR?

Adds a couple of fields that will allow the front end to visually distinguish insights from recommended actions in the moderator view (rather than the current paragraph blob of text). Also condenses insights produced by the `moderatorNotifier` into a sentence or two.

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- New properties source and recommendations on BackChannel Insight message
- Source set to 'participant' when a standalone question is passed through to the moderator channel (something from /mod or mod submission question that does not get synthesized into a shared insight), otherwise set to 'ai'
- Moderator notifier prompt and schema modified to generate recommendations separately and condense insight/observation
- Related bug fixes:
   -  perf: run private checkin LLM calls per user in parallel
   - fix: clearly separate user dm history to prevent incorrect mod notifications of duplicate messages
   - fix: pass single participant dm history as separate input to checkin LLM and enable prompt caching
   - fix: resolve pseudonyms for private checkins for users with no dm history

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [ ] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x] Test in conjunction with FE PR https://github.com/berkmancenter/nextspace/pull/136
- [x] Create an EA event with moderator support
- [x] Run a dense transcript that will trigger a 'dense transcript' private checkin
- [x] Use two session to emulate simultaneous users
- [x] Send a standalone question from one user via /mod and confirms it comes up as a 'Question' source in mod view
- [x] Have both users simultaneous(ish)ly ask Berkie (not moderator submitted) about an issue like unable to hear, to trigger the moderatorNotifier to report and make recommendations. Verify recommended actions are listed in mod view and source is 'AI Insight"
- [x] Have both users ask simultaneous similar questions using /mod, to trigger the BackChannel shared insight. Verify listed in mod view with source 'AI Insight'
- [x] Keep up for at least 10 minutes to and verify that each participant received a private 'dense transcript' checkin. Not enough users to verify that the moderator will not falsely be informed of 50 duplicate messages in this case, but I have validated that the private history is formatted correctly in the Langsmith traces now, so this is more of a sanity check.



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
