### PR TITLE
Vibes Analyst data updates and summoning in Slack

### DIFF
--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -74,6 +74,18 @@ function markdownToMrkdwn(text: string): string {
 export default {
   name: 'slack',
   label: 'Slack',
+  /* Maps conversation property keys to the adapter config keys they should write.
+     The conversation service reads this at update time to push changed properties
+     to Slack adapter documents without needing to know which keys Slack cares about. */
+  configSyncMap: {
+    slackBotUserId: 'botUserId',
+    botName: 'botName',
+    slackBotToken: 'botToken',
+    slackSigningSecret: 'signingSecret',
+    slackChannel: 'channel',
+    slackWorkspace: 'workspace',
+    slackAppKey: 'appKey'
+  },
   async sendMessage(message, channelConfig?) {
     const channel = channelConfig?.channel ? channelConfig?.channel : this.config.channel
     // Convert markdown to Slack mrkdwn format, then convert Slack user ID mentions to Slack format.

--- a/src/adapters/zoom.ts
+++ b/src/adapters/zoom.ts
@@ -288,6 +288,13 @@ async function receiveChatMessage(data) {
 export default {
   name: 'zoom',
   label: 'Zoom',
+  /* Maps conversation property keys to the adapter config keys they should write.
+     The conversation service reads this at update time to push changed properties
+     to adapter documents without needing to know which keys each adapter type cares about. */
+  configSyncMap: {
+    zoomMeetingUrl: 'meetingUrl',
+    botName: 'botName'
+  },
   async sendMessage(message, channelConfig?) {
     if (this.config.botId === 'loadtest') {
       logger.info(`[LOAD TEST] Would send message: ${message.body}`)

--- a/src/agents/vibesAnalyst/METRICS.md
+++ b/src/agents/vibesAnalyst/METRICS.md
@@ -1,0 +1,161 @@
+# Vibes Analyst: metrics reference
+
+Every number the Vibes Analyst (VA) recap can show, what it means, how it is calculated,
+and what it cannot tell you. All of these are computed in
+[`conversationAnalytics.service.ts`](../../services/conversationAnalytics.service.ts) as a
+`ConversationMetrics` object (its shape is in
+[`index.types.ts`](../../types/index.types.ts)), then handed to the curator and the
+fact-checking critic that write the card. Keep this file in sync when a metric changes.
+
+Each metric has a plain-English meaning. The code names and formulas in `monospace` are
+there for developers; a non-technical reader can skip them.
+
+## Two trust tiers
+
+The card keeps two kinds of numbers separate, and so should a reader:
+
+- **Exact.** Counted directly from our own records, so the card states these plainly with
+  no caveat. This covers who posted, the activity timeline, the busy spikes, the public
+  versus private split, how often people called on the bot, the resource list, the event
+  platform, and the audience-reaction quotes.
+- **Estimate.** Pulled from a web-analytics tool (for example Matomo). These can run low,
+  so the card always labels them as estimates and warns that the real number may be higher.
+  This covers the visit counts and everything built on them (lurker counts, the share who
+  spoke, and the typical-event averages).
+
+## Which messages we count
+
+Most of the exact numbers below count the same group of messages: the live chat that real
+people typed during the event. We leave out three things: messages the bot itself sent,
+messages that were never shown in the open chat (hidden ones, and private notes people sent
+to the backchannel bot), and the speaker's spoken words written out as a transcript (that is
+talk, not chat). We do count replies posted inside a thread. Developers: this shared rule is
+`visibleHumanFilter` (`fromAgent: false`, `visible: true`, `channels != 'transcript'`).
+
+## Participation (exact)
+
+Source: `computeParticipation`. We count each real person once, even if they posted many
+times. When a message has no person attached to it (rare), we fall back to the display name
+it was posted under. Developers: grouped by `owner`, falling back to `pseudonymId`.
+
+| Metric                       | Meaning                                                                                                               | How it is calculated                                                                                                                                                                                                                                   | Known limitations                                                                                                                                      |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `posterCount`                | How many different people posted at least one message                                                                 | We count each distinct person across the messages described above                                                                                                                                                                                      | A signed-out guest who changes their display name mid-event can be counted as two people; only a real signed-in account fully de-duplicates one person |
+| `messageCount`               | The total number of messages those people sent                                                                        | We count all the messages that pass the filter above                                                                                                                                                                                                   | This includes replies posted inside a thread, so it can be higher than a simpler count that only tallies top-level posts                               |
+| `frequentPosterCount`        | How many people did most of the talking                                                                               | We take the busiest tenth of the people who posted, ranked by how many messages they sent. If several people are tied right at the cutoff, we include all of them, so the group can be a little larger than a strict tenth (`ceil(posterCount * 0.1)`) | With fewer than 5 posters there is no meaningful "busiest tenth", so this is reported as 0                                                             |
+| `frequentPosterMessageShare` | The slice of all messages this busiest group sent, written as a decimal: 0.4 means they sent 40 percent of everything | We add up that group's messages and divide by the total number of messages                                                                                                                                                                             | Not available when there are fewer than 5 posters, the same cutoff as the busiest-group count above                                                    |
+
+## Tracked sessions (estimate)
+
+Source: `deriveTrackedSessions`. A tracked session is one visit to the event page in a
+browser, recorded by a web-analytics tool (for example Matomo) that watches how people use
+the page. These numbers describe the people who joined the event. There is one set of
+figures per analytics tool that recorded data.
+
+| Metric                 | Meaning                                                                                  | How it is calculated                                                                                                                                          | Known limitations                                                                                                                       |
+| ---------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `trackedSessions`      | How many times someone opened the event page in a browser                                | The tool's total visit count                                                                                                                                  | This runs low: people using privacy browsers or ad and tracker blockers are not counted, so the real number is higher                   |
+| `attendeeCount`        | How many people were registered or expected                                              | The figure the analytics tool reports                                                                                                                         | This comes straight from the analytics tool. It is not something we counted from the chat                                               |
+| `avgDwellSeconds`      | On average, how long each visit to the page lasted, in seconds                           | We add up the time spent across all visits and divide by the number of visits                                                                                 | This counts visits, not people. If one person opens the page twice, that is two visits, which pulls the average toward shorter sessions |
+| `totalActions`         | How many things people did on the page in total: clicks, page loads, and similar actions | The total the analytics tool reports                                                                                                                          | This is one lumped-together number. It cannot tell you which specific buttons or links people clicked (see "What we cannot track")      |
+| `deviceBreakdown`      | How many visits came from each kind of device (phone, desktop, and so on)                | The per-device counts the analytics tool reports                                                                                                              | Runs low for the same reason visits do (blockers and privacy browsers are not counted)                                                  |
+| `trackedSessionStatus` | Whether visit data exists for this event                                                 | One of three states: data is available; no analytics tool was set up for this event (`notTracked`); or a tool was set up but recorded nothing (`unavailable`) | This is just a status, not a number. The card uses it to decide which caveat to show                                                    |
+
+## Audience engagement (estimate, derived)
+
+Source: `computeAudienceEngagement`. This section compares two kinds of numbers: the people
+we counted exactly from our own chat records, and the people the web-analytics estimate says
+joined.
+
+| Metric                         | Meaning                                                                                                                       | How it is calculated                                                                                              | Known limitations                                                                                                                                                                                                                                                               |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `participantCount`             | How many people joined, based on tracked sessions                                                                             | Taken from the tracked-session figures above                                                                      | An estimate, so it inherits the same undercount                                                                                                                                                                                                                                 |
+| `lurkerCount`                  | How many people watched without ever posting in chat (we call these lurkers)                                                  | We take the estimated number who joined and subtract the number who posted (`participantCount - posterCount`)     | Not available when more people posted than the visit estimate shows. The two numbers come from different systems (our own records for posters, the web-analytics estimate for joiners), so they do not always line up, and subtracting them would give a number we do not trust |
+| `participationRate`            | The share of the room that spoke up, written as a decimal: 0.25 means a quarter of the people who joined posted at least once | We divide the number who posted by the estimated number who joined (`posterCount / participantCount`)             | Not available in the same case as the lurker count above. It is only approximate, because the joiner count is an estimate that can run low                                                                                                                                      |
+| `postersExceedTrackedSessions` | A yes/no marker that more people posted than the visit estimate counted, which means the two numbers cannot be combined       | Yes when the number of posters is greater than the estimated number of joiners (`posterCount > participantCount`) | When this is yes, the card shows both raw numbers and some likely reasons for the gap. It does not show a lurker count or a participation share, because those would be misleading                                                                                              |
+
+When more than one analytics tool recorded data, these figures use only the first one.
+
+## Activity over time (exact)
+
+Source: `bucketMessagesOverTime` then `toActivitySeries`.
+
+| Metric           | Meaning                                                                                               | How it is calculated                                                                                                                                                                                                           | Known limitations                                                                                                                                                                                                   |
+| ---------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `activitySeries` | How many messages landed in each stretch of the event, so you can see when the room was busy or quiet | We split the event's running time (start to end) into 6 equal stretches and count the messages in each. Each stretch is labeled by its minute range from the start, so "0-9" is the first ten minutes and "10-19" the next ten | Only messages between the event's start and end are counted, so the stretches can add up to less than the total message count. If the start or end time is missing, we use the first and last message times instead |
+
+## Spikes (exact counts, with optional read quote)
+
+Source: `computeSpikes`, then `attributeSpikeSources`, then `annotateSpikes`. A spike is one
+of the activity stretches above that ran much busier than the rest.
+
+| Metric             | Meaning                                                                                                        | How it is calculated                                                                                                                                                                                                                                                                                                                                                                  | Known limitations                                                                                                                                                                       |
+| ------------------ | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spikes`           | The stretches that got noticeably busier than the rest, each with its minute range and message count           | A stretch counts as a spike when two things are both true: it had at least twice as many messages as a typical stretch, and it cleared a minimum size so a tiny burst does not qualify (at least 3 messages, or a tenth of the number of posters, whichever is larger, `max(3, ceil(posterCount * 0.1))`). The event also needs at least 3 stretches before we look for spikes at all | We look across every channel except the speaker's transcript, so a busy stretch can be driven by something other than public chat (for example a flurry of private messages to the bot) |
+| `spike.ratio`      | How much busier this stretch was than normal, as a multiple: 3 means three times as busy as a typical stretch  | We divide this stretch's message count by the average message count of all the other stretches                                                                                                                                                                                                                                                                                        | Not available when every other stretch had no messages at all, because you cannot multiply against zero. In that case the card just points to the single busiest stretch instead        |
+| `spike.source`     | Where the busy stretch came from: the public chat, the moderators, or private one-on-one messages with the bot | We look at the messages we are allowed to read and pick whichever source most of them came from. We label a stretch private only when there are no readable messages in it at all                                                                                                                                                                                                     | If a stretch is mostly private but has even one readable message, we credit that readable source instead of calling it private                                                          |
+| `spike.annotation` | A short topic for the busy stretch plus one word-for-word quote showing what it was about                      | An AI model reads the public-chat and moderator messages from the two biggest spikes and writes the topic. It keeps a quote only if the words match the chat exactly                                                                                                                                                                                                                  | Only the two biggest spikes get this. Private spikes are never read or quoted, so all you see for those is the count                                                                    |
+
+## Participation history and baseline (mixed)
+
+Source: `computeHistoryAndBaseline`, over up to 10 recent past events in the same topic (the
+recurring space these events live under).
+
+| Metric                     | Meaning                                                                                                                                                                              | How it is calculated                                                                                                              | Known limitations                                                                                                                                                                                                                                   |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `participationHistory`     | A list covering this event and recent past events in the same space. For each one it shows how many people posted and how many watched without posting (lurkers)                     | Each entry carries an exact poster count and lurker count, labeled by the event's name and date, or "Today" for the current event | The lurker count is not available for a past event that had no visit data. Two events with the same name on the same day share one label. Dates use a single global time zone (UTC), so for an event far from that zone the date can read a day off |
+| `baseline.avgPosterCount`  | The typical number of people who posted at recent events in this space. We call this the baseline: it is what "normal" looks like, so you can see whether this event ran high or low | The average poster count across the recent past events; `baseline.eventCount` is how many events went into that average           | Leaves out events marked as experimental. Not available when this is the only event in the space, since there is nothing to average                                                                                                                 |
+| `baseline.avgLurkerCount`  | The typical number of lurkers at recent events in this space                                                                                                                         | The average across only the past events that had visit data; `baseline.trackedEventCount` is how many                             | This usually covers fewer events than the poster average above, because not every event had visit data, so do not read it as the average across every past event                                                                                    |
+| `baseline.avgDwellSeconds` | The typical length of a visit at recent events in this space, in seconds                                                                                                             | The average across only the past events that had visit data (`baseline.trackedEventCount`)                                        | Covers only the same smaller set of events as the lurker average above                                                                                                                                                                              |
+
+## Channel split (exact)
+
+Source: `computeChannelSplit`.
+
+| Metric                                         | Meaning                                                                            | How it is calculated                                                                                      | Known limitations                                                                             |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `channelSplit.public` / `channelSplit.private` | How many messages went to public chat versus private one-on-one chats with the bot | A message counts as private when it was a one-on-one message to the bot; everything else counts as public | This counts messages, not people. A handful of chatty people can run up a large private total |
+
+## Bot invocations (exact)
+
+Source: `computeBotInvocations`.
+
+| Metric           | Meaning                                                       | How it is calculated                                                                                                          | Known limitations                                                                                                                                                                              |
+| ---------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `botInvocations` | The bot's name and how many times people called on it by name | We count the chat messages where someone wrote the bot's name, using the same loose matching the bot uses to recognize itself | This works by spotting the name. A misspelling or an "@" in front still counts, but if someone refers to the bot without naming it (for example "can it summarize this?"), that does not count |
+
+## Resource summary (exact)
+
+Source: `computeResourceSummary`. Counts only the resources the audience could actually see.
+
+| Metric                                                  | Meaning                                                                | How it is calculated                                                               | Known limitations                                                                                               |
+| ------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `resourceSummary.total`                                 | How many readings and reference materials the audience was able to see | We count the resources on the event that were visible to participants              | Leaves out any resource that was hidden from participants                                                       |
+| `resourceSummary.required` / `referenced` / `suggested` | The same count split by kind                                           | The visible resources sorted by their category: required, referenced, or suggested | Same visible-only scope                                                                                         |
+| `resourceSummary.withLinks`                             | How many of those visible resources had a web link                     | The visible resources that had a link attached                                     | This only tells you a link was there. It cannot tell you whether anyone clicked it (see "What we cannot track") |
+
+## Event platform (exact)
+
+Source: `deriveEventPlatform`.
+
+| Metric          | Meaning                                                   | How it is calculated                                                                  | Known limitations                                   |
+| --------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `eventPlatform` | Which platform the event ran on: Nextspace, Zoom, or both | "both" when the event lists both Nextspace and Zoom, otherwise whichever one it lists | Defaults to Nextspace when no platform was recorded |
+
+## Receptions (exact quotes, model-selected)
+
+Source: `annotateReceptions`, filled in by the agent from the messages it is allowed to read.
+
+| Metric       | Meaning                                                                                        | How it is calculated                                                                                                                                                                                                                                              | Known limitations                                                                                                       |
+| ------------ | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `receptions` | Moments where something the speaker said got the chat talking, along with how the room reacted | An AI model finds a line the speaker said and the chat replies it set off. For each one it records how many replies followed, one example reply, and whether the room mostly agreed, pushed back, or was split. It keeps quotes only when the words match exactly | These are chosen by the model. The card reports the reaction only as the model classified it, and never reinterprets it |
+
+## What we cannot track on the backend
+
+Some signals the recap would want are not available here, because only the browser sees
+them: reading-link clicks, tab clicks (Berkie, Group chat, References), and quick-guide
+clicks. The engine cannot compute them. A client like Nextspace has to record them and send them to the
+analytics provider, which the engine then reads generically. They would be estimates (the
+same undercount as tracked sessions), so they would carry the may-undercount caveat, unlike
+the exact resource counts above. Until that tracking exists on the client side, the recap can say how many
+readings and links an event had, never whether anyone opened them.

--- a/src/agents/vibesAnalyst/SETUP.md
+++ b/src/agents/vibesAnalyst/SETUP.md
@@ -2,7 +2,8 @@
 
 How to stand up the Vibes Analyst (VA) bot as its own Slack app and wire it to an
 llm_engine instance, both for local development and for production. VA posts an
-engagement summary to a private admin channel whenever a public event ends.
+engagement summary to a private admin channel whenever a public event ends, and members
+of that channel can also summon it to recap a past public event on demand (Part D).
 
 VA is a normal agent anchored to a long-lived admin Conversation, provisioned from the
 `vibesAnalyst` conversation type. It uses the per-bot Slack identity: its webhook is
@@ -44,9 +45,12 @@ Do this once per environment (one app for dev, one for prod).
    [`assets/lens-icon.svg`](assets/lens-icon.svg) (export it to PNG first; Slack icons
    want a square raster). The icon is the bot's identity in Slack and is configured on
    the app, not in any message payload.
-2. Request bot token scopes. VA only needs **`chat:write`**. It posts to channels it has
-   been invited to, so it does NOT need `chat:write.public`. Add `channels:read` only if
-   you later want it to enumerate channels (not required for posting).
+2. Request bot token scopes. For posting alone, VA only needs **`chat:write`** (not
+   `chat:write.public`, since it posts only to channels it has been invited to). To also
+   answer summons (Part D), it must receive message events from its admin channel, which
+   needs the channel-history scope Slack prompts for when you subscribe to those events:
+   **`groups:history`** for a private admin channel, or **`channels:history`** for a
+   public one. `channels:read` is only needed if you later want it to enumerate channels.
 3. Install the app to the workspace and copy the **Bot User OAuth token** (`xoxb-...`).
    Make sure it is the Bot token, not the User token.
 4. From Basic Information, copy the **Signing Secret**.
@@ -95,9 +99,10 @@ instance:
 ```
 
 `slackBotUserId` and `slackSigningSecret` are optional in the type, but set them: the
-bot user ID normalizes incoming mentions (used by Q&A later), and the signing secret is
-what makes the per-bot identity real (the handler validates VA's webhooks against this,
-not the global env var).
+bot user ID normalizes incoming `@`-mentions so the summon flow (Part D) recognizes when a
+message is addressed to VA, and the signing secret is what makes the per-bot identity real
+(the handler validates VA's webhooks against this, not the global env var). `botName` is
+also used to match the mention, so set it to the name people will type.
 
 ---
 
@@ -109,9 +114,39 @@ Now that VA's Adapter row exists in the target instance:
 2. In the Slack app's Event Subscriptions, set the Request URL to
    `https://<host>/v1/webhooks/slack/<appKey>`. Slack sends a challenge; the handler
    echoes it and the URL turns verified.
-3. Event subscriptions (`message.channels`, `message.im`, etc.) are only needed once VA
-   answers questions in Slack (a later phase). For auto-posting alone you do not need to
-   subscribe to message events, but the Request URL must still verify.
+3. For auto-posting alone you do not need to subscribe to message events, but the Request
+   URL must still verify. To enable on-demand summon (Part D), subscribe to the message
+   event for VA's admin channel: `message.groups` for a private channel, `message.channels`
+   for a public one (and `message.im` only if you allow DMs).
+
+---
+
+## Part D: Enable on-demand summon (optional)
+
+Auto-posting needs nothing here. This part is only to let people summon VA in its admin
+channel to recap a past public event on demand.
+
+What summon does: a member of VA's admin channel `@`-mentions VA with a past public
+event's name (for example "@Vibes Analyst recap the Future of Work session"). VA resolves
+the event, re-checks its public-topic read grant for that specific event, and threads the
+same engagement card under the request. If several public events match the name it lists
+them; if none match it asks for a clearer name; if the named event is on a private topic
+it declines and reads nothing.
+
+To turn it on:
+
+1. **Subscribe to the message event** for the admin channel (Part C step 3):
+   `message.groups` for a private channel, `message.channels` for a public one.
+2. **Grant the matching history scope** (Part A step 2): `groups:history` or
+   `channels:history`. Slack prompts for it when you add the event, and re-installing the
+   app may be required for the new scope to take effect.
+3. **Set `slackBotUserId` and `botName`** in provisioning (Part B). VA uses the bot user
+   ID to recognize an `@`-mention and the name to match a plain-text address.
+4. **Keep VA in the channel** (Part A step 6). It only hears messages in channels it is a
+   member of.
+
+Summon never reaches private events: it re-runs the same public-topic read check the
+auto path uses and declines anything that is not an explicitly public topic.
 
 ---
 
@@ -168,6 +203,31 @@ Block Kit renderer), which deploys with the rest of llm_engine. What does NOT ca
 is any provisioned state: every environment gets its own Slack app, Adapter row,
 Conversation, channel, and secrets.
 
+### Updating bot identity on an existing conversation
+
+If a production VA was provisioned before `slackBotUserId` was set, or you need to change
+the bot user id, name, token, or signing secret later, you do not have to re-provision or
+recreate the bot. `PUT /v1/conversations` with the conversation id and only the changed
+properties. The update merges them into the Conversation's `properties` and syncs the live
+Slack Adapter row, so the new value takes effect (summon included) without recreating the
+adapter or losing the long-lived admin Conversation and its history.
+
+`PUT <API host>/v1/conversations` with an admin bearer token for the conversation or topic
+owner:
+
+```json
+{
+  "id": "<VA conversation id>",
+  "properties": {
+    "slackBotUserId": "<bot user ID, U...>"
+  }
+}
+```
+
+Only the keys you send change; the rest of the properties are left alone. The conversation
+must be inactive, which VA's admin Conversation always is, since it never starts as an
+event.
+
 ---
 
 ## Smoke test the outbound path
@@ -195,6 +255,15 @@ End a public (non-private) event in that environment. The dispatcher matches VA'
 `allPublicTopics` read grant, fires the `conversationEvent` job, and VA posts its metrics
 card to the admin channel within a minute.
 
+## Verify summon (if you enabled Part D)
+
+In VA's admin channel, `@`-mention VA with a recent public event's name, e.g.
+"@Vibes Analyst recap the Future of Work session". VA threads its engagement card under
+your message. If several public events match it lists them; if none match it asks for a
+clearer name; if the named event is on a private topic it declines without reading
+anything. Nothing happens if you only set up auto-posting and skipped Part D, since VA
+never received the message event.
+
 ## Gotchas, in one place
 
 - Provision (create the Adapter row) BEFORE setting the Slack Request URL, or challenge
@@ -208,3 +277,8 @@ card to the admin channel within a minute.
 - VA must be invited to its admin channel.
 - VA reacts only to non-private topics (its `allPublicTopics` grant). private/dev events
   are ignored by design.
+- Summon (Part D) needs a message-event subscription (`message.groups` for a private admin
+  channel, `message.channels` for a public one) and the matching history scope. Auto-posting
+  alone needs neither.
+- Summon recaps public events only. it re-checks the read grant per request and declines
+  private topics, so it can never recap a private event even by name.

--- a/src/agents/vibesAnalyst/agent.ts
+++ b/src/agents/vibesAnalyst/agent.ts
@@ -2,22 +2,14 @@ import verify from '../helpers/verify.js'
 import { defaultLLMModel, defaultLLMPlatform, getModelChat } from '../helpers/getModelChat.js'
 import Conversation from '../../models/conversation.model.js'
 import access from '../../auth/access.js'
-import { LlmPlatforms } from '../../types/index.types.js'
-import conversationAnalyticsService from '../../services/conversationAnalytics.service.js'
+import { AgentMessageActions, LlmPlatforms } from '../../types/index.types.js'
 import analyticsSources from '../../services/analyticsSources/index.js'
 import logger from '../../config/logger.js'
-import curateVibesCard from './curate.js'
-import verifyCuratedCard from './verifyCuration.js'
+import { checkBotIntent, matchBotMention, normalizeBotMention } from '../helpers/intentChecks.js'
+import buildVibesSummary from './buildSummary.js'
+import handleSummon from './summon.js'
 import { HELLO_MESSAGE } from './prompt.js'
 import defaultTriggers from './triggers.js'
-
-/* How long the event ran, in whole minutes, for the card footer. Returns 0 when
-   either timestamp is missing so the card still renders. */
-function eventDurationMinutes(startTime?: Date, endTime?: Date): number {
-  if (!startTime || !endTime) return 0
-  const elapsedMs = endTime.getTime() - startTime.getTime()
-  return Math.max(0, Math.round(elapsedMs / 60000))
-}
 
 export default verify({
   name: 'Vibes Analyst',
@@ -51,6 +43,32 @@ export default verify({
     ]
   },
 
+  // Summon path: people can @mention the analyst in its channel to recap a past event.
+  // Mirror the chatbot's gate. Normalize the mention so respond sees a clean address;
+  // the real decision to act, and which event, happens in respond.
+  async evaluate(userMessage) {
+    const words = userMessage?.body?.trim().split(/\s+/) ?? []
+    const modifiedMessage = matchBotMention(words, this.agentConfig.botName)
+      ? { ...userMessage, body: normalizeBotMention(userMessage.body, this.agentConfig.botName) }
+      : userMessage
+    return {
+      userMessage: modifiedMessage,
+      action: AgentMessageActions.CONTRIBUTE,
+      userContributionVisible: true,
+      suggestion: undefined
+    }
+  },
+
+  // Answers a summon, but only when the message is actually addressed to the analyst.
+  // Hands off to the summon handler, which resolves the event and posts (or declines)
+  // its recap. The conversation history is unused: a summon names its own event.
+  async respond(_conversationHistory, userMessage) {
+    if (!userMessage) return []
+    const llm = await this.getLLM()
+    if (!(await checkBotIntent(llm, this.agentConfig.botName, userMessage))) return []
+    return handleSummon(this, userMessage, llm)
+  },
+
   // Fires when a public event stops (the dispatcher matches VA's allPublicTopics
   // read grant). Posts one engagement-metrics card into VA's own admin channel.
   async onConversationEvent(evt) {
@@ -59,14 +77,16 @@ export default verify({
     const conversation = await Conversation.findById(evt.conversationId).populate('topic')
     if (!conversation) return []
 
-    // Re-check read access at the read site even though the dispatcher gated it,
-    // so least privilege stays explicit. Private topics are not readable.
+    // Re-check read access here even though the dispatcher already gated it, so
+    // least privilege stays explicit at the read site. Fail closed: anything but
+    // an explicit `private: false` counts as private, so an unpopulated or deleted
+    // topic is never read as public.
     const topic = conversation.topic as { _id?: { toString(): string }; private?: boolean } | undefined
     access.assertCanRead(this, {
       type: 'conversation',
       id: evt.conversationId,
       topicId: topic?._id?.toString(),
-      topicIsPrivate: topic?.private === true
+      topicIsPrivate: topic?.private !== false
     })
 
     /* Pull external tracked-session snapshots (e.g. Matomo) now, from inside this
@@ -86,17 +106,11 @@ export default verify({
       )
     }
 
-    // Build the evidence bundle from Mongo (participation, activity, history) plus
-    // the stored tracked-session snapshots, then let the analyst model write the card
-    // and a second model fact-check it before anything is posted.
-    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+    // Build the verified engagement card from the shared pipeline (compute metrics,
+    // annotate from the allowed channels, curate, then fact-check). The snapshot fetch
+    // above is the only event-stop-specific step; the rest is reused by the summon path.
     const llm = await getModelChat(defaultLLMPlatform as LlmPlatforms, defaultLLMModel)
-    const eventMeta = {
-      eventName: conversation.name,
-      durationMinutes: eventDurationMinutes(conversation.startTime, conversation.endTime)
-    }
-    const draftCard = await curateVibesCard(metrics, eventMeta, llm)
-    const renderData = await verifyCuratedCard(draftCard, metrics, llm)
+    const renderData = await buildVibesSummary(conversation, llm)
 
     return [
       {

--- a/src/agents/vibesAnalyst/buildSummary.ts
+++ b/src/agents/vibesAnalyst/buildSummary.ts
@@ -1,0 +1,79 @@
+import conversationAnalyticsService from '../../services/conversationAnalytics.service.js'
+import logger from '../../config/logger.js'
+import curateVibesCard from './curate.js'
+import verifyCuratedCard from './verifyCuration.js'
+import annotateSpikes from './spikeAnnotation.js'
+import annotateReceptions from './quoteReception.js'
+import { loadReadableMessages } from './capabilities.js'
+import { CuratedVibesData } from '../../types/index.types.js'
+
+/* How long the event ran, in whole minutes, for the card footer. Returns 0 when
+   either timestamp is missing so the card still renders. */
+function eventDurationMinutes(startTime?: Date, endTime?: Date): number {
+  if (!startTime || !endTime) return 0
+  const elapsedMs = endTime.getTime() - startTime.getTime()
+  return Math.max(0, Math.round(elapsedMs / 60000))
+}
+
+/**
+ * Builds the verified engagement card for one event. It computes the metrics, adds spike
+ * and reception annotations from the channels the VA is allowed to read, then has the
+ * curator write the card and the critic fact-check it.
+ *
+ * Shared by the event-stop auto path and the on-demand summon path so both produce an
+ * identical card from one pipeline. The content annotations are best-effort: a failure
+ * in either leaves the card with its numbers and still returns. This does NOT fetch
+ * external tracked-session snapshots; that is an event-stop concern the caller handles.
+ */
+export default async function buildVibesSummary(conversation, llm): Promise<CuratedVibesData> {
+  const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+
+  /* Read message text once, only from the channels the VA is allowed to (see
+     loadReadableMessages). This is the one place the recap reads content, so the access
+     boundary stays visible here. */
+  let readableMessages
+  try {
+    readableMessages = await loadReadableMessages(conversation._id)
+  } catch (error: unknown) {
+    logger.error(
+      `Vibes Analyst could not read messages for ${conversation._id}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+
+  if (readableMessages) {
+    /* Label the busiest spikes with what was said then. Needs the event start to map a
+       spike's minute window back to real times. */
+    if (metrics.spikes.length > 0 && conversation.startTime) {
+      try {
+        metrics.spikes = await annotateSpikes(readableMessages, conversation.startTime, metrics.spikes, llm)
+      } catch (error: unknown) {
+        logger.error(
+          `Vibes Analyst could not annotate spikes for ${conversation._id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      }
+    }
+
+    /* Surface speaker moments that drew a chat reaction, and how the room responded.
+       Independent of spikes, so it runs whether or not chat volume ever surged. */
+    try {
+      metrics.receptions = await annotateReceptions(readableMessages, metrics.participation.posterCount, llm)
+    } catch (error: unknown) {
+      logger.error(
+        `Vibes Analyst could not annotate receptions for ${conversation._id}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+    }
+  }
+
+  const eventMeta = {
+    eventName: conversation.name,
+    durationMinutes: eventDurationMinutes(conversation.startTime, conversation.endTime)
+  }
+  const draftCard = await curateVibesCard(metrics, eventMeta, llm)
+  return verifyCuratedCard(draftCard, metrics, llm)
+}

--- a/src/agents/vibesAnalyst/capabilities.ts
+++ b/src/agents/vibesAnalyst/capabilities.ts
@@ -1,4 +1,5 @@
-import { AgentCapabilities } from '../../types/index.types.js'
+import Message from '../../models/message.model.js'
+import { AgentCapabilities, IMessage } from '../../types/index.types.js'
 
 /**
  * The vibes analyst reacts to every public event that ends, so it reads all
@@ -9,4 +10,34 @@ export default function (): AgentCapabilities {
     read: [{ type: 'allPublicTopics' as const }],
     write: [{ type: 'ownConversation' as const }]
   }
+}
+
+/**
+ * Channels the Vibes Analyst may read message text from. An allowlist, so any
+ * channel not named here is excluded by default, the same fail-closed stance as
+ * the topic privacy gate above.
+ *
+ * These cover the shared event content an attendee or moderator already saw: the
+ * `transcript`, the public `chat`, and the `moderator` backchannel (the recap
+ * posts to the VA's admin channel, where moderator visibility already exists).
+ * One-to-one `direct` DM channels are left out; they carry generated names, so a
+ * private DM never matches the allowlist.
+ */
+export const VA_READABLE_CHANNELS = ['transcript', 'chat', 'moderator'] as const
+
+/**
+ * Loads the messages the Vibes Analyst may read for content analysis: every
+ * message in an allowlisted channel, oldest first. The one guarded entry point
+ * for VA content reads, so the channel boundary lives in a single auditable place.
+ *
+ * Agent messages are included so callers can count agent activity (for example,
+ * how many times a configured bot was invoked); filter by `fromAgent` as needed.
+ */
+export async function loadReadableMessages(conversationId): Promise<IMessage[]> {
+  return Message.find({
+    conversation: conversationId,
+    channels: { $in: [...VA_READABLE_CHANNELS] }
+  })
+    .select('body bodyType pseudonym fromAgent createdAt channels visible')
+    .sort({ createdAt: 1 })
 }

--- a/src/agents/vibesAnalyst/eventResolution.ts
+++ b/src/agents/vibesAnalyst/eventResolution.ts
@@ -1,0 +1,149 @@
+import * as fuzzball from 'fuzzball'
+import { z } from 'zod'
+import Conversation from '../../models/conversation.model.js'
+import { getChatPromptResponse } from '../helpers/llmChain.js'
+import { VIBES_EVENT_REFERENCE_SYSTEM_PROMPT, VIBES_EVENT_REFERENCE_USER_TEMPLATE } from './prompt.js'
+
+/* One past public event the summon could resolve to. */
+export interface EventCandidate {
+  id: string
+  name: string
+  topicName: string
+  endTime: Date
+}
+
+/* What the user asked for, extracted from their summon message: the text naming the
+   event (a title, or a topic when they want its latest), and which "most recent" shortcut
+   they used, if any. latestInTopic means the newest event in a named topic; latestOverall
+   means the single newest event with no event or topic named ("the last event"). */
+export interface EventReference {
+  eventQuery: string
+  latestInTopic: boolean
+  latestOverall?: boolean
+}
+
+/* The outcome of matching a reference against the public events on offer. */
+export type EventResolution =
+  | { status: 'resolved'; event: EventCandidate }
+  | { status: 'ambiguous'; candidates: EventCandidate[] }
+  | { status: 'notFound' }
+
+/* A title has to score at least this (fuzzy, 0-100) to count as a match at all. */
+const MATCH_THRESHOLD = 70
+/* When two titles both clear the threshold, the top one wins outright only if it leads
+   the runner-up by this much; otherwise the result is ambiguous and the caller asks. */
+const AMBIGUITY_MARGIN = 15
+/* At most this many options are offered back when a summon is ambiguous. */
+const MAX_AMBIGUOUS = 5
+
+/* Scores how well a query matches a title. token_set_ratio is forgiving of word order
+   and of a query that is a subset of the full title ("Town Hall" vs "Spring Town Hall
+   2026"), which is how people tend to refer to events. */
+function titleScore(query: string, name: string): number {
+  return fuzzball.token_set_ratio(query, name)
+}
+
+/* Resolves "the latest in a topic": the most recent event whose topic matches the
+   query. No ambiguity here, since the newest one always wins. */
+function resolveLatestInTopic(query: string, candidates: EventCandidate[]): EventResolution {
+  const inTopic = candidates.filter((candidate) => titleScore(query, candidate.topicName) >= MATCH_THRESHOLD)
+  if (inTopic.length === 0) return { status: 'notFound' }
+
+  const newest = inTopic.reduce((latest, candidate) => (candidate.endTime > latest.endTime ? candidate : latest))
+  return { status: 'resolved', event: newest }
+}
+
+/**
+ * Matches a summon reference against the public events on offer. For a titled request
+ * it fuzzy-ranks candidates by name: a single clear winner resolves, several close
+ * matches come back as ambiguous (so the caller can ask which), and nothing close
+ * enough is notFound. For a "latest in [topic]" request it returns the most recent
+ * event in the matching topic.
+ */
+export function resolveSummonedEvent(reference: EventReference, candidates: EventCandidate[]): EventResolution {
+  if (reference.latestOverall) {
+    if (candidates.length === 0) return { status: 'notFound' }
+    const newest = candidates.reduce((latest, candidate) => (candidate.endTime > latest.endTime ? candidate : latest))
+    return { status: 'resolved', event: newest }
+  }
+  if (reference.latestInTopic) return resolveLatestInTopic(reference.eventQuery, candidates)
+
+  const ranked = candidates
+    .map((candidate) => ({ candidate, score: titleScore(reference.eventQuery, candidate.name) }))
+    .filter((scored) => scored.score >= MATCH_THRESHOLD)
+    .sort((a, b) => b.score - a.score)
+
+  if (ranked.length === 0) return { status: 'notFound' }
+  if (ranked.length === 1 || ranked[0].score - ranked[1].score >= AMBIGUITY_MARGIN) {
+    return { status: 'resolved', event: ranked[0].candidate }
+  }
+
+  return { status: 'ambiguous', candidates: ranked.slice(0, MAX_AMBIGUOUS).map((scored) => scored.candidate) }
+}
+
+/* At most this many recent public events are pulled as candidates. The summon matches
+   by name in memory, so this bounds the work; very old events past the window are not
+   summonable, which is an acceptable first cut. */
+const MAX_CANDIDATES = 500
+
+/**
+ * Keeps only the events a summon is allowed to resolve to, and shapes them for matching.
+ * An event qualifies when its topic populated and is explicitly public and it has ended.
+ * Failing closed on the topic matters here: a private or unresolved topic is dropped, so
+ * a private event's title can never surface in a disambiguation prompt.
+ */
+export function toPublicCandidates(
+  conversations: {
+    _id: { toString(): string }
+    name: string
+    endTime?: Date
+    topic?: { name?: string; private?: boolean }
+  }[]
+): EventCandidate[] {
+  return conversations
+    .filter((conversation) => conversation.topic?.private === false && conversation.endTime instanceof Date)
+    .map((conversation) => ({
+      id: conversation._id.toString(),
+      name: conversation.name,
+      topicName: conversation.topic?.name ?? '',
+      endTime: conversation.endTime as Date
+    }))
+}
+
+/* Loads the recent public, ended events the summon can resolve to. The privacy filter
+   lives in toPublicCandidates so it stays unit-tested; this just supplies the rows. */
+export async function findCandidatePublicEvents(): Promise<EventCandidate[]> {
+  const conversations = await Conversation.find({ endTime: { $ne: null } })
+    .populate('topic')
+    .select('name endTime topic')
+    .sort({ endTime: -1 })
+    .limit(MAX_CANDIDATES)
+
+  return toPublicCandidates(conversations as Parameters<typeof toPublicCandidates>[0])
+}
+
+/* The shape the summon parser returns: the identifying words and whether the user asked
+   for the latest in a topic. Re-validated against real events afterward. */
+const EventReferenceSchema = z.object({
+  eventQuery: z
+    .string()
+    .describe('Only the words that name the event or its topic, with the assistant mention and filler removed'),
+  latestInTopic: z
+    .boolean()
+    .describe('True when they asked for the most recent event in a named topic rather than a specific named one'),
+  latestOverall: z
+    .boolean()
+    .describe('True when they asked for the single most recent event overall, naming no event or topic')
+})
+
+/* Asks the model which past event a summon message is referring to. */
+export async function extractEventReference(message: string, llm): Promise<EventReference> {
+  return (await getChatPromptResponse(
+    llm,
+    VIBES_EVENT_REFERENCE_SYSTEM_PROMPT,
+    VIBES_EVENT_REFERENCE_USER_TEMPLATE,
+    { message },
+    undefined,
+    EventReferenceSchema
+  )) as EventReference
+}

--- a/src/agents/vibesAnalyst/prompt.ts
+++ b/src/agents/vibesAnalyst/prompt.ts
@@ -196,6 +196,7 @@ You are given one line a speaker said, and the chat messages people posted right
 # Hard rules
 - Copy both quotes verbatim from the text provided. Do not paraphrase, shorten, fix, or combine messages, and never write a quote that is not there.
 - The sparkQuote must come from the speaker line. The reactionQuote must come from the chat messages.
+- Do not include a speaker name or pseudonym prefix in the reactionQuote. Copy only the message text itself, not any leading "name:" label.
 - Judge the sentiment only from the chat messages shown. If they do not clearly lean one way, use "mixed".`
 
 /* The per-event input for the reception labeler. The speaker line and the chat that

--- a/src/agents/vibesAnalyst/prompt.ts
+++ b/src/agents/vibesAnalyst/prompt.ts
@@ -25,6 +25,8 @@ Hosts receive this recap immediately after their event ends. They need a quick, 
 
 Relate the two when it reveals something, but never blend them into one number. The gap between them is often the most useful insight: for example, many tracked sessions but few messages points to a listening or lurking crowd. Name both figures side by side, with the undercount caveat on the tracked one. Do not average or combine them into a single score or rating, which would hide which figure is exact and which is an estimate.
 
+The event may also have an AI assistant participants can summon by name. metrics.botInvocations gives that assistant's configured name and the exact number of times participants called on it. Treat the count as precise, and surface it when the number stands out (the assistant was leaned on heavily, or barely used).
+
 # Instructions
 
 Finding what matters
@@ -38,6 +40,21 @@ Writing the points
 - The bold takeaway is a plain-language read of the numbers in the same point, not a separate claim, so it must not say more than those numbers show.
 - For any tracked-session figure, note inline that it may undercount, for example: "~420 tracked sessions (may undercount actual visits)".
 - Be concrete and plain. No filler, no hedging beyond the required undercount note.
+
+Spikes
+- metrics.spikes lists windows where participant activity jumped above the rest of the event. Each gives its minute window, message count, how many times the other windows' average it ran (ratio; null when the rest of the event was silent), and a source naming where the burst happened: "chat" (the public chat), "moderator" (the moderator backchannel), or "private" (one-to-one messages with the bot).
+- Describe a spike by its source. A "chat" spike is the public room lighting up; a "moderator" spike is the backchannel. A "private" spike is a burst of private one-to-one messages with the bot, so report it by its count alone (for example "a flurry of private questions to the bot") and never quote or guess what was said, since those messages are never read.
+- A "chat" or "moderator" spike may carry an annotation with a topic and a verbatim quote from that window. You may feature the most notable spike as a standout: name when it happened and how busy it got, and you may include the annotation's exact quote in quotation marks to show what drove it. Only ever quote text that appears in a spike's annotation, and never change its wording. If a spike has no annotation, describe it with its numbers alone. A "private" spike never carries a quote.
+
+Receptions
+- metrics.receptions lists speaker moments that drew a chat reaction. Each gives what the speaker said (sparkQuote), how many public chat messages followed (reactionVolume), one representative reply (reactionQuote), and how the room leaned (sentiment: agreement, pushback, or mixed).
+- You may feature a reception as a standout: say what the speaker said and how the room responded, and you may include the sparkQuote and the reactionQuote in quotation marks. Report the sentiment only as it is given, never your own read of it.
+- Only ever quote text that appears in a reception's sparkQuote or reactionQuote, word for word. If receptions is empty, do not describe any audience reaction to a speaker.
+
+Readings and platform
+- metrics.resourceSummary counts the event's readings and references that participants could see: total, required (assigned readings), referenced, suggested, and withLinks (how many carry a link). These are exact, first-party counts; treat them as precise, with no undercount caveat. Surface them when they stand out, for example a reading-heavy event, or several required readings paired with a quiet chat that suggests they went undiscussed.
+- The data shows how many readings existed and how many had links, never whether anyone opened a reading or clicked a link. Never claim a reading was read or a link was clicked.
+- metrics.eventPlatform is where the event ran: "nextspace", "zoom", or "both". Use it only as light scene-setting context, for example in the framing line; it is not a headline on its own.
 
 Charts
 - Attach a chart to a standout whenever one of the provided charts genuinely illustrates it, and prefer showing the chart over describing the numbers in prose.
@@ -95,14 +112,24 @@ You are given the event's computed numbers as a JSON object and a numbered list 
 - It describes a direction or trend (up, down, higher, lower) that the JSON data does not show.
 - It overstates the size of a change beyond what the numbers show.
 - It cites a tracked-session figure (visits, dwell time, devices) without an inline caveat that the figure may undercount.
+- It puts text in quotation marks that does not appear, word for word, as a quote inside one of the spikes (its annotation) or one of the receptions (sparkQuote or reactionQuote) in the JSON data.
+- It describes how the audience received a speaker's point (agreement, pushback, applause, praise, and so on) without a reception in the JSON data whose sentiment matches that description.
 
 # A line is SUPPORTED only if all of the following are true for every individual claim within it
 - Every number in the line is either present in the JSON data or correctly derived from it (for example, a percentage computed from the counts).
 - Any direction, comparison, or trend matches the JSON data exactly.
 - Any tracked-session figure includes the may-undercount caveat.
+- Any quoted text matches, word for word, a quote carried by one of the spikes or receptions in the JSON data.
+- Any claim about how the audience received a speaker's point matches the sentiment of a reception in the JSON data.
 
 # The opening takeaway
 Each standout opens with a short plain-language takeaway in bold, for example "*Big lurking crowd.*" or "*Small but engaged room.*". Treat that takeaway as SUPPORTED when it faithfully characterizes the numbers in the same line, even though it is not itself a number: a "lurking crowd" when lurkers outnumber posters, or "front-loaded" when the early activity buckets are larger. It does not need its own number. Still mark the line UNSUPPORTED if the takeaway overstates what the numbers show or asserts a direction the data contradicts.
+
+# Spikes and their source
+Each spike in the JSON carries a source: "chat", "moderator", or "private". Treat a line that characterizes a spike by its source as SUPPORTED when it matches the source, even though the source is a label and not a number: calling a "private"-source spike a burst of private or one-to-one messages with the bot, or a "moderator"-source spike backchannel activity. A "private" spike has no readable content, so mark a line about it UNSUPPORTED if it quotes those messages or states what they said.
+
+# Readings and platform
+metrics.resourceSummary (total, required, referenced, suggested, withLinks) and metrics.eventPlatform are exact, first-party values. Treat a line that cites them as SUPPORTED when the number or platform matches the JSON, with no undercount caveat needed. The data shows only how many readings and links existed, never whether anyone opened them, so mark a line UNSUPPORTED if it claims a reading was read or a link was clicked.
 
 # The posters-exceed-tracked-sessions case
 When audienceEngagement.postersExceedTrackedSessions is true in the JSON data, more people posted than were recorded as tracked sessions, and audienceEngagement.lurkerCount and audienceEngagement.participationRate are null. For lines about this mismatch, treat the following as SUPPORTED:
@@ -127,3 +154,89 @@ Draft standout lines to check (JSON list, each with an index and its text):
 {standoutsJson}
 
 Return a verdict for every line.`
+
+/* The instructions for the spike-labeling model. It sees the messages from one busy
+   window and returns a short topic plus one message quoted word for word. The quote
+   is later checked against the same messages, so a paraphrase or invention is dropped
+   before it can reach the card. */
+export const VIBES_SPIKE_SYSTEM_PROMPT = `# Role
+You explain why an online event's chat suddenly got busy. You are given the messages people sent during one short burst of activity.
+
+# Task
+Return two things:
+- topic: a short, plain phrase naming what the burst was about.
+- quote: one of the messages, copied word for word exactly as it appears, that best captures the burst.
+
+# Hard rules
+- Copy the quote verbatim from the messages provided. Do not paraphrase, shorten, fix, or combine messages, and never write a quote that is not there.
+- Pick the single message that best represents the burst and copy it in full.
+- Keep the topic specific and free of hype.`
+
+/* The per-event input for the spike labeler. The window's messages are passed as a
+   preformatted block, one "name: message" per line. */
+export const VIBES_SPIKE_USER_TEMPLATE = `Messages sent during the burst, one per line:
+{windowMessages}
+
+Return the topic and a verbatim quote.`
+
+/* The instructions for the reception labeler. It sees one line a speaker said and the
+   chat that followed, and returns the verbatim part of the line that drew the reaction,
+   one verbatim chat reply, and how the room leaned. Both quotes are checked against
+   the source afterward, so a paraphrase or invention is dropped before it reaches the
+   card, and the sentiment only rides on a quote that survives that check. */
+export const VIBES_RECEPTION_SYSTEM_PROMPT = `# Role
+You read how an online event's chat reacted to something a speaker just said.
+
+# Task
+You are given one line a speaker said, and the chat messages people posted right after it. Return three things:
+- sparkQuote: the part of the speaker's line that drew the reaction, copied word for word from the line.
+- reactionQuote: one chat message, copied word for word exactly as it appears, that best captures how people responded.
+- sentiment: one of "agreement" (the chat mostly backed the point), "pushback" (the chat mostly challenged it), or "mixed" (both showed up).
+
+# Hard rules
+- Copy both quotes verbatim from the text provided. Do not paraphrase, shorten, fix, or combine messages, and never write a quote that is not there.
+- The sparkQuote must come from the speaker line. The reactionQuote must come from the chat messages.
+- Judge the sentiment only from the chat messages shown. If they do not clearly lean one way, use "mixed".`
+
+/* The per-event input for the reception labeler. The speaker line and the chat that
+   followed are passed as preformatted text, the chat one "name: message" per line. */
+export const VIBES_RECEPTION_USER_TEMPLATE = `The speaker said:
+{sparkLine}
+
+The chat right after, one message per line:
+{reactionMessages}
+
+Return the spark quote, one reaction quote, and the sentiment.`
+
+/* The instructions for the summon parser. When someone asks the Vibes Analyst in chat
+   to recap a past event, this pulls out which event they mean: the identifying words
+   (a title or a topic) and whether they want the most recent one in that topic. The
+   result is matched against real events afterward, so this only has to extract intent,
+   not guess at an exact title. */
+export const VIBES_EVENT_REFERENCE_SYSTEM_PROMPT = `# Role
+You read a short message where someone asks an assistant to recap a past event, and you pull out which event they mean.
+
+# Task
+Return three fields:
+- eventQuery: the name of the event or its topic, as the user referred to it, with the assistant's name and filler words removed. Keep only the words that identify the event. Leave it empty when they named no event or topic.
+- latestInTopic: true if the user asked for the most recent, latest, or newest event in a named series or topic rather than a specific named event; false otherwise.
+- latestOverall: true if the user asked for the single most recent or last event without naming any event or topic; false otherwise.
+
+# Examples
+- "@Vibes recap the Spring Town Hall" gives eventQuery "Spring Town Hall", latestInTopic false, latestOverall false
+- "@Vibes how did the latest AI Ethics session go?" gives eventQuery "AI Ethics", latestInTopic true, latestOverall false
+- "summarize our most recent standup" gives eventQuery "standup", latestInTopic true, latestOverall false
+- "@Vibes tell me about the last event" gives eventQuery "", latestInTopic false, latestOverall true
+- "what was our most recent session like?" gives eventQuery "", latestInTopic false, latestOverall true
+
+# Hard rules
+- eventQuery must be only the identifying words. Strip the assistant mention, verbs like recap or summarize, and articles.
+- Set latestInTopic true only when the user named a topic or series and asked for its newest one.
+- Set latestOverall true only when the user asked for the single most recent event and named no event or topic.
+- For a request about several past events or a trend across events (for example "the past 2 events"), set both flags false and leave the identifying words in eventQuery.`
+
+/* The per-message input for the summon parser. */
+export const VIBES_EVENT_REFERENCE_USER_TEMPLATE = `The message:
+{message}
+
+Return the event query, whether they want the latest in a named topic, and whether they want the single most recent event overall.`

--- a/src/agents/vibesAnalyst/quoteReception.ts
+++ b/src/agents/vibesAnalyst/quoteReception.ts
@@ -114,15 +114,31 @@ function isValidSentiment(value: string): value is ReceptionSentiment {
  * followed, and the sentiment must be one of the known labels. Anything the model
  * invented or mislabeled is dropped, so a sentiment never reaches the card on the back
  * of words no one said.
+ *
+ * The reaction quote is checked against both the raw message body and the
+ * "pseudonym: body" format the model sees, since the model sometimes copies the name
+ * prefix along with the text.
  */
 export function groundReception(
-  candidate: { sparkMessage: { body?: unknown }; reactionVolume: number; reactionChat: { body?: unknown }[] },
+  candidate: {
+    sparkMessage: { body?: unknown }
+    reactionVolume: number
+    reactionChat: { body?: unknown; pseudonym?: string }[]
+  },
   result: { sparkQuote: string; reactionQuote: string; sentiment: string }
 ): QuoteReception | null {
   const { sentiment } = result
   if (!isValidSentiment(sentiment)) return null
   if (!quoteAppearsIn(result.sparkQuote, [candidate.sparkMessage])) return null
-  if (!quoteAppearsIn(result.reactionQuote, candidate.reactionChat)) return null
+
+  const reactionChatFormatted = candidate.reactionChat.map((m) => ({
+    body: m.pseudonym ? `${m.pseudonym}: ${m.body}` : m.body
+  }))
+  if (
+    !quoteAppearsIn(result.reactionQuote, candidate.reactionChat) &&
+    !quoteAppearsIn(result.reactionQuote, reactionChatFormatted)
+  )
+    return null
 
   return {
     sparkQuote: result.sparkQuote.trim(),

--- a/src/agents/vibesAnalyst/quoteReception.ts
+++ b/src/agents/vibesAnalyst/quoteReception.ts
@@ -1,0 +1,209 @@
+import { z } from 'zod'
+import { getChatPromptResponse } from '../helpers/llmChain.js'
+import { quoteAppearsIn } from './spikeAnnotation.js'
+import { VIBES_RECEPTION_SYSTEM_PROMPT, VIBES_RECEPTION_USER_TEMPLATE } from './prompt.js'
+import { QuoteReception, ReceptionSentiment } from '../../types/index.types.js'
+
+/* A message the reception logic can read: the text, who said it, when, and which
+   channel it belongs to (so transcript speaker lines and chat replies stay separate). */
+export interface ReceptionMessage {
+  body?: unknown
+  pseudonym?: string
+  fromAgent?: boolean
+  createdAt?: Date
+  channels?: string[]
+}
+
+/* A speaker line that cleared the reaction floor, paired with the chat that followed
+   it. The model later turns this into a QuoteReception; until then it is just the raw
+   window of evidence. */
+export interface SparkCandidate {
+  sparkMessage: ReceptionMessage
+  reactionVolume: number
+  reactionChat: ReceptionMessage[]
+}
+
+/* At most this many receptions per event. A recap rarely shows more than two standouts,
+   so pulling the two strongest is enough and keeps model calls low. */
+export const MAX_RECEPTIONS = 2
+
+/* How long after a speaker line we still count chat as a reaction to it. Three minutes
+   captures the immediate response without bleeding into the next topic. */
+export const REACTION_WINDOW_MINUTES = 3
+
+/* The reaction floor scales with the room: a tenth of the posters, but never fewer
+   than this many, so a handful of replies in a tiny event can still count while a
+   couple of stray messages in a large one cannot. Mirrors the spike floor from #13. */
+const RECEPTION_FLOOR_FRACTION = 0.1
+const RECEPTION_ABSOLUTE_FLOOR = 3
+
+const VALID_SENTIMENTS: ReceptionSentiment[] = ['agreement', 'pushback', 'mixed']
+
+/* A message counts toward a reaction only when a participant wrote real text. Bot
+   replies and non-text bodies are not the audience reacting. */
+function isParticipantText(message: ReceptionMessage): boolean {
+  return !message.fromAgent && typeof message.body === 'string'
+}
+
+function reactionFloor(posterCount: number): number {
+  return Math.max(RECEPTION_ABSOLUTE_FLOOR, Math.ceil(posterCount * RECEPTION_FLOOR_FRACTION))
+}
+
+/* The participant chat sent in the window just after a spark line: from the line's
+   time (inclusive) to REACTION_WINDOW_MINUTES later (exclusive). */
+function reactionDuring(sparkTime: Date, chatMessages: ReceptionMessage[]): ReceptionMessage[] {
+  const windowStart = sparkTime.getTime()
+  const windowEnd = windowStart + REACTION_WINDOW_MINUTES * 60 * 1000
+
+  return chatMessages.filter((message) => {
+    if (!isParticipantText(message) || !(message.createdAt instanceof Date)) return false
+    const sentAt = message.createdAt.getTime()
+    return sentAt >= windowStart && sentAt < windowEnd
+  })
+}
+
+/**
+ * Picks the speaker lines that drew the biggest chat reactions. Each transcript line
+ * is scored by how much participant chat landed in the window after it; lines that
+ * clear the room-scaled floor become candidates. Candidates are taken strongest
+ * first, and any that overlaps an already-picked line's window is skipped so the same
+ * burst of chat is never credited to two lines. The result is capped at MAX_RECEPTIONS.
+ */
+export function selectSparkCandidates(
+  transcriptMessages: ReceptionMessage[],
+  chatMessages: ReceptionMessage[],
+  posterCount: number
+): SparkCandidate[] {
+  const floor = reactionFloor(posterCount)
+
+  const candidates: SparkCandidate[] = transcriptMessages
+    .filter((message) => isParticipantText(message) && message.createdAt instanceof Date)
+    .map((sparkMessage) => {
+      const reactionChat = reactionDuring(sparkMessage.createdAt as Date, chatMessages)
+      return { sparkMessage, reactionVolume: reactionChat.length, reactionChat }
+    })
+    .filter((candidate) => candidate.reactionVolume >= floor)
+
+  // Strongest reaction first; ties broken by the earlier line so selection is stable.
+  candidates.sort((a, b) => {
+    if (b.reactionVolume !== a.reactionVolume) return b.reactionVolume - a.reactionVolume
+    return (a.sparkMessage.createdAt as Date).getTime() - (b.sparkMessage.createdAt as Date).getTime()
+  })
+
+  const windowMs = REACTION_WINDOW_MINUTES * 60 * 1000
+  const selected: SparkCandidate[] = []
+  for (const candidate of candidates) {
+    if (selected.length >= MAX_RECEPTIONS) break
+    const sparkTime = (candidate.sparkMessage.createdAt as Date).getTime()
+    const overlapsSelected = selected.some(
+      (chosen) => Math.abs(sparkTime - (chosen.sparkMessage.createdAt as Date).getTime()) < windowMs
+    )
+    if (!overlapsSelected) selected.push(candidate)
+  }
+
+  return selected
+}
+
+function isValidSentiment(value: string): value is ReceptionSentiment {
+  return (VALID_SENTIMENTS as string[]).includes(value)
+}
+
+/**
+ * The trust gate for one reception. The model's spark quote must be verbatim text
+ * from the speaker line, the reaction quote must be verbatim text from the chat that
+ * followed, and the sentiment must be one of the known labels. Anything the model
+ * invented or mislabeled is dropped, so a sentiment never reaches the card on the back
+ * of words no one said.
+ */
+export function groundReception(
+  candidate: { sparkMessage: { body?: unknown }; reactionVolume: number; reactionChat: { body?: unknown }[] },
+  result: { sparkQuote: string; reactionQuote: string; sentiment: string }
+): QuoteReception | null {
+  const { sentiment } = result
+  if (!isValidSentiment(sentiment)) return null
+  if (!quoteAppearsIn(result.sparkQuote, [candidate.sparkMessage])) return null
+  if (!quoteAppearsIn(result.reactionQuote, candidate.reactionChat)) return null
+
+  return {
+    sparkQuote: result.sparkQuote.trim(),
+    reactionVolume: candidate.reactionVolume,
+    reactionQuote: result.reactionQuote.trim(),
+    sentiment
+  }
+}
+
+/* What the reception labeler returns: a verbatim spark phrase, a verbatim reaction
+   quote, and a sentiment. Both quotes are re-checked against the source before they
+   are trusted, so the schema only shapes the model's reply. */
+const ReceptionSchema = z.object({
+  sparkQuote: z.string().describe('The exact words from the speaker line that drew the reaction, copied verbatim'),
+  reactionQuote: z.string().describe('One chat reply copied word for word, exactly as it appears'),
+  sentiment: z.enum(['agreement', 'pushback', 'mixed']).describe('How the chat responded to the speaker line')
+})
+
+function sparkText(message: ReceptionMessage): string {
+  return typeof message.body === 'string' ? message.body : ''
+}
+
+/* Renders the reaction chat as one "name: text" line each, the form the labeler reads.
+   Only text bodies are shown, since a quote can only come from text. */
+function formatReactionMessages(messages: ReceptionMessage[]): string {
+  return messages
+    .filter((message) => typeof message.body === 'string')
+    .map((message) => `${message.pseudonym ?? 'someone'}: ${message.body as string}`)
+    .join('\n')
+}
+
+/* Asks the model how the chat received one speaker line. */
+async function requestReception(
+  candidate: SparkCandidate,
+  llm
+): Promise<{ sparkQuote: string; reactionQuote: string; sentiment: string }> {
+  return (await getChatPromptResponse(
+    llm,
+    VIBES_RECEPTION_SYSTEM_PROMPT,
+    VIBES_RECEPTION_USER_TEMPLATE,
+    { sparkLine: sparkText(candidate.sparkMessage), reactionMessages: formatReactionMessages(candidate.reactionChat) },
+    undefined,
+    ReceptionSchema
+  )) as { sparkQuote: string; reactionQuote: string; sentiment: string }
+}
+
+function onChannel(message: ReceptionMessage, channel: string): boolean {
+  return Array.isArray(message.channels) && message.channels.includes(channel)
+}
+
+/**
+ * Finds the speaker moments that drew a chat reaction and labels how the room
+ * responded. It splits the readable messages into transcript speaker lines and chat
+ * replies, picks the strongest spark candidates, and for each asks the model for a
+ * spark quote, a reaction quote, and a sentiment. Only receptions whose quotes are
+ * verbatim and whose sentiment is recognized survive the grounding gate; a model
+ * failure on one candidate never aborts the rest. Returns an empty list when no
+ * speaker line cleared the reaction floor.
+ */
+export default async function annotateReceptions(
+  messages: ReceptionMessage[],
+  posterCount: number,
+  llm
+): Promise<QuoteReception[]> {
+  const transcriptMessages = messages.filter((message) => onChannel(message, 'transcript'))
+  const chatMessages = messages.filter((message) => onChannel(message, 'chat'))
+
+  const candidates = selectSparkCandidates(transcriptMessages, chatMessages, posterCount)
+  if (candidates.length === 0) return []
+
+  const receptions = await Promise.all(
+    candidates.map(async (candidate) => {
+      let result: { sparkQuote: string; reactionQuote: string; sentiment: string }
+      try {
+        result = await requestReception(candidate, llm)
+      } catch {
+        return null
+      }
+      return groundReception(candidate, result)
+    })
+  )
+
+  return receptions.filter((reception): reception is QuoteReception => reception !== null)
+}

--- a/src/agents/vibesAnalyst/spikeAnnotation.ts
+++ b/src/agents/vibesAnalyst/spikeAnnotation.ts
@@ -1,0 +1,187 @@
+import { z } from 'zod'
+import { getChatPromptResponse } from '../helpers/llmChain.js'
+import { VIBES_SPIKE_SYSTEM_PROMPT, VIBES_SPIKE_USER_TEMPLATE } from './prompt.js'
+import { ChatSpike, SpikeAnnotation, SpikeSource } from '../../types/index.types.js'
+
+/* A message the spike labeler can read: who said it, the text, and when. */
+interface ReadableMessage {
+  body?: unknown
+  pseudonym?: string
+  fromAgent?: boolean
+  createdAt?: Date
+  channels?: string[]
+}
+
+/* At most this many spikes are sent to the model for a topic label. A recap shows
+   only two or three standouts, so labeling the busiest one or two is plenty and
+   keeps the number of model calls per event small. */
+const MAX_ANNOTATED_SPIKES = 2
+
+/* Collapses whitespace, trims, and lowercases so a quote and a message body can be
+   compared without tripping over spacing or capitalization the model may have
+   changed. */
+function normalize(text: string): string {
+  return text.trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+/**
+ * Keeps the messages whose timestamp lands inside a spike's window. The window runs
+ * from startMinute (inclusive) to endMinute (exclusive) past the event start, the
+ * same boundaries the activity buckets use, so a message on a window edge lands in
+ * exactly one window. Messages without a real timestamp are dropped.
+ */
+export function messagesDuringSpike<T extends { createdAt?: Date }>(messages: T[], eventStart: Date, spike: ChatSpike): T[] {
+  const windowStart = eventStart.getTime() + spike.startMinute * 60 * 1000
+  const windowEnd = eventStart.getTime() + spike.endMinute * 60 * 1000
+
+  return messages.filter((message) => {
+    if (!(message.createdAt instanceof Date)) return false
+    const sentAt = message.createdAt.getTime()
+    return sentAt >= windowStart && sentAt < windowEnd
+  })
+}
+
+/**
+ * Reports whether a quote is verbatim text from one of the given messages. This is
+ * the trust gate for a spike annotation: a quote only earns a place on the card if
+ * it really was said in the window. Matching ignores whitespace and case but nothing
+ * else, so the model cannot smuggle in words no one wrote. An empty quote never
+ * matches, and non-text bodies (images, structured payloads) are skipped.
+ */
+export function quoteAppearsIn(quote: string, messages: { body?: unknown }[]): boolean {
+  const needle = normalize(quote)
+  if (needle.length === 0) return false
+
+  return messages.some((message) => typeof message.body === 'string' && normalize(message.body).includes(needle))
+}
+
+/* Ranks two spikes for labeling, most significant first. computeSpikes returns either a
+   single zero-baseline spike (null ratio) or a set of finite-ratio spikes, never a mix,
+   so in practice this just sorts finite ratios highest-first. The null handling is a
+   guard for if those ever meet: a finite ratio outranks a null one, because a null ratio
+   is the absence of a comparison rather than an infinitely strong one, and two nulls fall
+   back to raw message count. */
+function compareSignificance(a: ChatSpike, b: ChatSpike): number {
+  if (a.ratio === null && b.ratio === null) return b.messageCount - a.messageCount
+  if (a.ratio === null) return 1
+  if (b.ratio === null) return -1
+  return b.ratio - a.ratio
+}
+
+/**
+ * Picks the most significant spikes to label, capped so a busy event does not fan
+ * out into many model calls. Returns them strongest first; the caller keeps the full
+ * spike list in time order and only annotates these.
+ */
+export function topSpikesBySignificance(spikes: ChatSpike[], limit: number = MAX_ANNOTATED_SPIKES): ChatSpike[] {
+  return [...spikes].sort(compareSignificance).slice(0, limit)
+}
+
+/**
+ * The trust gate for one spike's label: a model-proposed topic and quote only become
+ * an annotation when the quote is verbatim text from the window and the topic is not
+ * blank. Anything the model invented is dropped, so the spike falls back to its
+ * numbers rather than carrying words no one said.
+ */
+export function groundAnnotation(
+  candidate: { topic: string; quote: string },
+  windowMessages: { body?: unknown }[]
+): SpikeAnnotation | null {
+  const topic = candidate.topic?.trim() ?? ''
+  if (topic.length === 0) return null
+  if (!quoteAppearsIn(candidate.quote, windowMessages)) return null
+
+  return { topic, quote: candidate.quote.trim() }
+}
+
+/* What the spike labeler returns: a short topic and one verbatim quote. The quote is
+   checked against the window before it is trusted, so the schema only shapes the
+   model's reply. */
+const SpikeTopicSchema = z.object({
+  topic: z.string().describe('A short, plain phrase naming what the burst of messages was about'),
+  quote: z.string().describe('One message copied word for word, exactly as it appears in the provided messages')
+})
+
+/* Renders the window's messages as one "name: text" line each, the form the labeler
+   reads. Only text bodies are shown, since a quote can only come from text. */
+function formatWindowMessages(messages: ReadableMessage[]): string {
+  return messages
+    .filter((message) => typeof message.body === 'string')
+    .map((message) => `${message.pseudonym ?? 'someone'}: ${message.body as string}`)
+    .join('\n')
+}
+
+/* Asks the model for a topic and a verbatim quote describing one spike window. */
+async function requestSpikeTopic(messages: ReadableMessage[], llm): Promise<{ topic: string; quote: string }> {
+  return (await getChatPromptResponse(
+    llm,
+    VIBES_SPIKE_SYSTEM_PROMPT,
+    VIBES_SPIKE_USER_TEMPLATE,
+    { windowMessages: formatWindowMessages(messages) },
+    undefined,
+    SpikeTopicSchema
+  )) as { topic: string; quote: string }
+}
+
+/* A message eligible to be a chat spike's quote: a participant (non-agent) line in the
+   public chat, not a transcript speaker line or the moderator backchannel the reader also
+   returns. */
+export function isQuotableChat(message: ReadableMessage): boolean {
+  return !message.fromAgent && Array.isArray(message.channels) && message.channels.includes('chat')
+}
+
+/* A message eligible to be a moderator spike's quote: a participant (non-agent) line in
+   the moderator backchannel, used when the burst happened there rather than in the public
+   chat. */
+export function isQuotableModerator(message: ReadableMessage): boolean {
+  return !message.fromAgent && Array.isArray(message.channels) && message.channels.includes('moderator')
+}
+
+/* The messages a spike may be quoted from, chosen by where the burst happened. A 'chat'
+   spike quotes the public chat and a 'moderator' spike the backchannel, both channels the
+   analyst is allowed to read. A 'private' spike is one-to-one messages with the bot, which
+   the analyst never reads, so it has no quote pool and appears on the card by count alone. */
+export function spikeQuotePool(messages: ReadableMessage[], source: SpikeSource): ReadableMessage[] {
+  if (source === 'private') return []
+  return messages.filter(source === 'moderator' ? isQuotableModerator : isQuotableChat)
+}
+
+/**
+ * Labels the busiest spikes with what drove them. For each of the most significant
+ * spikes, it reads the participant messages sent during that window, asks the model
+ * for a topic and a quote, and keeps the result only when the quote is verbatim
+ * window text. Every other spike, and any whose quote fails that check, comes back
+ * with its numbers and no annotation. Spikes come back in their original time order,
+ * and a model failure on one never aborts the rest. A spike is quoted from
+ * the channel that drove it (its source): the public chat or the moderator backchannel.
+ * A private spike, a burst of one-to-one messages with the bot, is never read, so it
+ * keeps its numbers and no quote.
+ */
+export default async function annotateSpikes(
+  messages: ReadableMessage[],
+  eventStart: Date,
+  spikes: ChatSpike[],
+  llm
+): Promise<ChatSpike[]> {
+  if (spikes.length === 0) return spikes
+  const selected = new Set(topSpikesBySignificance(spikes))
+
+  return Promise.all(
+    spikes.map(async (spike) => {
+      if (!selected.has(spike)) return spike
+
+      const windowMessages = spikeQuotePool(messagesDuringSpike(messages, eventStart, spike), spike.source)
+      if (windowMessages.length === 0) return spike
+
+      let candidate: { topic: string; quote: string }
+      try {
+        candidate = await requestSpikeTopic(windowMessages, llm)
+      } catch {
+        return spike
+      }
+
+      const annotation = groundAnnotation(candidate, windowMessages)
+      return annotation ? { ...spike, annotation } : spike
+    })
+  )
+}

--- a/src/agents/vibesAnalyst/summon.ts
+++ b/src/agents/vibesAnalyst/summon.ts
@@ -1,0 +1,97 @@
+import Conversation from '../../models/conversation.model.js'
+import access from '../../auth/access.js'
+import logger from '../../config/logger.js'
+import { AgentResponse } from '../../types/index.types.js'
+import buildVibesSummary from './buildSummary.js'
+import { extractEventReference, findCandidatePublicEvents, resolveSummonedEvent, EventCandidate } from './eventResolution.js'
+
+/* The channel the vibes analyst lives in and answers summons from. */
+const SUMMON_CHANNEL = 'vibesAnalyst'
+
+/* How many recent public events to offer back when nothing matched, so the reply gives
+   the asker something to pick from instead of a dead end. */
+const MAX_RECENT_SUGGESTIONS = 5
+
+/* The reply when nothing public matches what was asked for. When there are recent public
+   events to suggest, it lists them so the asker can pick one or ask for the latest, rather
+   than guessing at an exact title. */
+export function notFoundMessage(query: string, recent: EventCandidate[]): string {
+  if (recent.length === 0) {
+    return `I couldn't find a public event matching "${query}", and I don't have any public events to recap yet.`
+  }
+  const list = recent.map((candidate) => `• ${candidate.name}`).join('\n')
+  return `I couldn't find a public event matching "${query}", and I recap one event at a time. Recent public events:\n${list}\nReply with one of these names, or ask for "the latest" and I'll take the most recent.`
+}
+
+/* The reply when several public events match and the asker needs to pick one. */
+export function ambiguousMessage(candidates: EventCandidate[]): string {
+  const list = candidates.map((candidate) => `• ${candidate.name}`).join('\n')
+  return `A few public events match that. Which one did you mean?\n${list}`
+}
+
+/* Builds a reply that threads under the summoning message, in the channel it came from.
+   Threading keeps each recap attached to the question that asked for it. An optional
+   card turns the plain reply into the rendered engagement summary. */
+function reply(
+  context,
+  parent: AgentResponse<string>['parent'],
+  message: string,
+  card?: { responseKind: string; renderData: unknown }
+): AgentResponse<string> {
+  const channels = context.conversation.channels.filter((channel) => channel.name === SUMMON_CHANNEL)
+  return { visible: true, message, messageType: 'text', channels, parent, ...card }
+}
+
+/**
+ * Handles one on-demand summon. Works out which past public event the message refers to,
+ * then either posts that event's engagement card or replies asking for a clearer name.
+ * The candidate set is privacy-filtered, and access is re-checked on the resolved event
+ * before its content is read, so a summon can never recap a private event. Every reply
+ * threads under the summoning message in the channel it came from.
+ */
+export default async function handleSummon(context, userMessage, llm): Promise<AgentResponse<string>[]> {
+  const parent = userMessage._id
+
+  const reference = await extractEventReference(userMessage.body ?? '', llm)
+  const candidates = await findCandidatePublicEvents()
+  const resolution = resolveSummonedEvent(reference, candidates)
+
+  // Newest first, capped, so a miss can suggest real recent events instead of dead-ending.
+  const recent = [...candidates].sort((a, b) => b.endTime.getTime() - a.endTime.getTime()).slice(0, MAX_RECENT_SUGGESTIONS)
+
+  if (resolution.status === 'notFound') {
+    return [reply(context, parent, notFoundMessage(reference.eventQuery, recent))]
+  }
+  if (resolution.status === 'ambiguous') {
+    return [reply(context, parent, ambiguousMessage(resolution.candidates))]
+  }
+
+  const conversation = await Conversation.findById(resolution.event.id).populate('topic')
+  if (!conversation) {
+    return [reply(context, parent, notFoundMessage(reference.eventQuery, recent))]
+  }
+
+  // Re-check read access on the resolved event before reading it. Fail closed, same as
+  // the auto path: anything but an explicit public topic is refused, not recapped.
+  const topic = conversation.topic as { _id?: { toString(): string }; private?: boolean } | undefined
+  try {
+    access.assertCanRead(context, {
+      type: 'conversation',
+      id: conversation._id.toString(),
+      topicId: topic?._id?.toString(),
+      topicIsPrivate: topic?.private !== false
+    })
+  } catch (error: unknown) {
+    logger.warn(
+      `Vibes Analyst refused summon for ${conversation._id}: ${error instanceof Error ? error.message : String(error)}`
+    )
+    return [reply(context, parent, `I can only recap public events, and "${conversation.name}" isn't one I can share.`)]
+  }
+
+  const renderData = await buildVibesSummary(conversation, llm)
+  // Fallback text for adapters that do not render the card (e.g. zoom); the card itself
+  // rides along as responseKind + renderData for adapters that do (Slack).
+  return [
+    reply(context, parent, `Vibes summary for *${conversation.name}*`, { responseKind: 'curatedVibesSummary', renderData })
+  ]
+}

--- a/src/agents/vibesAnalyst/triggers.ts
+++ b/src/agents/vibesAnalyst/triggers.ts
@@ -1,10 +1,13 @@
 import { Triggers } from '../../types/index.types.js'
 
 /**
- * No automatic chat triggers yet. The vibes analyst reacts only to the
- * conversation-stopped event (wired in a later phase), so it stays silent to
- * chat for now. Per-message Q&A triggers arrive in Phase 5.
+ * The vibes analyst posts automatically when a public event stops (its
+ * conversation-stopped handler). This per-message trigger additionally lets people
+ * summon it in its own channel to recap a past public event on demand. It listens only
+ * on its own channel; gating to genuine requests happens in evaluate and respond.
  */
-const defaultTriggers: Triggers = {}
+const defaultTriggers: Triggers = {
+  perMessage: { channels: ['vibesAnalyst'] }
+}
 
 export default defaultTriggers

--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -309,6 +309,35 @@ const updateConversation = async (conversationBody, user) => {
       }
     }
 
+    /* The Slack adapter's identity and routing fields are rendered from properties once at
+       creation, like the Zoom config above. They don't resync on a later properties change,
+       so adding slackBotUserId to turn on summon (or rotating the token or signing secret)
+       would update properties but never reach the live adapter. Map any changed Slack
+       properties to their adapter config keys and push them. */
+    const slackPropertyToConfigKey: Record<string, string> = {
+      slackBotUserId: 'botUserId',
+      botName: 'botName',
+      slackBotToken: 'botToken',
+      slackSigningSecret: 'signingSecret',
+      slackChannel: 'channel',
+      slackWorkspace: 'workspace',
+      slackAppKey: 'appKey'
+    }
+    const slackConfigUpdates: Record<string, unknown> = {}
+    for (const [property, configKey] of Object.entries(slackPropertyToConfigKey)) {
+      if (incomingProperties[property] !== undefined) {
+        slackConfigUpdates[configKey] = incomingProperties[property]
+      }
+    }
+    if (Object.keys(slackConfigUpdates).length > 0) {
+      const slackAdapters = await Adapter.find({ conversation: conversationDoc._id, type: 'slack' })
+      for (const adapter of slackAdapters) {
+        adapter.config = { ...adapter.config, ...slackConfigUpdates }
+        adapter.markModified('config')
+        await adapter.save()
+      }
+    }
+
     /* Agents get their llmModel and llmPlatform baked in at creation time via $ref
        resolution. They don't pick up property changes automatically, so push any
        model update to Agent documents now. */

--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -14,6 +14,7 @@ import adapterService from '../adapter.service.js'
 import channelService from '../channel.service.js'
 import { ConversationDocument } from '../../models/conversation.model.js'
 import { getConversationType } from '../../conversations/index.js'
+import adapterTypes from '../../adapters/index.js'
 import resolveConversationType from '../../conversations/resolver.js'
 import { supportedModels } from '../../agents/helpers/getEmbeddings.js'
 import transcript from '../../agents/helpers/transcript.js'
@@ -290,51 +291,26 @@ const updateConversation = async (conversationBody, user) => {
     conversationDoc.properties = { ...conversationDoc.properties, ...incomingProperties }
     conversationDoc.markModified('properties') // Mongoose won't detect changes inside a Mixed field without this
 
-    /* The Zoom adapter's meetingUrl and botName are set once at creation from Handlebars
-       templates. They don't sync automatically when the conversation's properties change,
-       so we update the adapter config here too. */
-    const adapterConfigUpdates: Record<string, unknown> = {}
-    if (incomingProperties.zoomMeetingUrl !== undefined) {
-      adapterConfigUpdates.meetingUrl = incomingProperties.zoomMeetingUrl
-    }
-    if (incomingProperties.botName !== undefined) {
-      adapterConfigUpdates.botName = incomingProperties.botName
-    }
-    if (Object.keys(adapterConfigUpdates).length > 0) {
-      const zoomAdapters = await Adapter.find({ conversation: conversationDoc._id, type: 'zoom' })
-      for (const adapter of zoomAdapters) {
-        adapter.config = { ...adapter.config, ...adapterConfigUpdates }
-        adapter.markModified('config')
-        await adapter.save()
+    /* Adapter config fields rendered from conversation properties at creation time don't
+       resync automatically when properties change later. Each adapter type declares a
+       configSyncMap from conversation property keys to adapter config keys; any changed
+       property that appears in a map is pushed to that type's adapter documents now. */
+    for (const [adapterType, adapterDef] of Object.entries(adapterTypes)) {
+      const syncMap = (adapterDef as { configSyncMap?: Record<string, string> }).configSyncMap
+      if (!syncMap) continue
+      const configUpdates: Record<string, unknown> = {}
+      for (const [convKey, configKey] of Object.entries(syncMap)) {
+        if (incomingProperties[convKey] !== undefined) {
+          configUpdates[configKey] = incomingProperties[convKey]
+        }
       }
-    }
-
-    /* The Slack adapter's identity and routing fields are rendered from properties once at
-       creation, like the Zoom config above. They don't resync on a later properties change,
-       so adding slackBotUserId to turn on summon (or rotating the token or signing secret)
-       would update properties but never reach the live adapter. Map any changed Slack
-       properties to their adapter config keys and push them. */
-    const slackPropertyToConfigKey: Record<string, string> = {
-      slackBotUserId: 'botUserId',
-      botName: 'botName',
-      slackBotToken: 'botToken',
-      slackSigningSecret: 'signingSecret',
-      slackChannel: 'channel',
-      slackWorkspace: 'workspace',
-      slackAppKey: 'appKey'
-    }
-    const slackConfigUpdates: Record<string, unknown> = {}
-    for (const [property, configKey] of Object.entries(slackPropertyToConfigKey)) {
-      if (incomingProperties[property] !== undefined) {
-        slackConfigUpdates[configKey] = incomingProperties[property]
-      }
-    }
-    if (Object.keys(slackConfigUpdates).length > 0) {
-      const slackAdapters = await Adapter.find({ conversation: conversationDoc._id, type: 'slack' })
-      for (const adapter of slackAdapters) {
-        adapter.config = { ...adapter.config, ...slackConfigUpdates }
-        adapter.markModified('config')
-        await adapter.save()
+      if (Object.keys(configUpdates).length > 0) {
+        const adapters = await Adapter.find({ conversation: conversationDoc._id, type: adapterType })
+        for (const adapter of adapters) {
+          adapter.config = { ...adapter.config, ...configUpdates }
+          adapter.markModified('config')
+          await adapter.save()
+        }
       }
     }
 

--- a/src/services/conversationAnalytics.service.ts
+++ b/src/services/conversationAnalytics.service.ts
@@ -2,13 +2,20 @@ import Message from '../models/message.model.js'
 import Channel from '../models/channel.model.js'
 import Conversation from '../models/conversation.model.js'
 import ConversationAnalytics from '../models/conversationAnalytics.model.js'
+import { matchBotMention } from '../agents/helpers/intentChecks.js'
+import config from '../config/config.js'
 import {
   ActivityBucket,
   AudienceEngagement,
+  BotInvocations,
+  ChatSpike,
   ConversationMetrics,
+  EventPlatform,
   ParticipationHistoryPoint,
   ParticipationMetrics,
+  ResourceSummary,
   SameTopicBaseline,
+  SpikeSource,
   TrackedSessionMetrics,
   TrackedSessionStatus
 } from '../types/index.types.js'
@@ -35,9 +42,39 @@ const ACTIVITY_BUCKET_COUNT = 6
    still a message a participant sent, and an engagement recap should reflect every one. */
 const visibleHumanFilter = { fromAgent: false, visible: true, channels: { $ne: 'transcript' } }
 
+/* A chat spike is a window holding at least this many times the messages of the
+   average other window. The other-windows average is the baseline, so a single
+   busy window never inflates the bar it is judged against. */
+const SPIKE_MULTIPLE = 2
+
+/* The spike floor scales with how many people posted: a window must hold at least
+   this share of the poster count to count, so a busy minute in a small room still
+   registers while idle chatter in a large one does not. */
+const SPIKE_FLOOR_FRACTION = 0.1
+
+/* The floor never drops below this, so a two-message blip is never a spike even in
+   a tiny event. */
+const SPIKE_ABSOLUTE_FLOOR = 3
+
+/* Below three windows there is no meaningful baseline to stand out from, so a very
+   short event reports no spikes rather than a shaky one. */
+const MIN_BUCKETS_FOR_SPIKE = 3
+
+/* A time window with its message count, carrying the minute offsets from the event
+   start so a later step can pull the messages sent during it. */
+export interface TimedActivityBucket {
+  startMinute: number
+  endMinute: number
+  messageCount: number
+}
+
 /* The baseline averages at most this many recent past events in the same topic, so
    a long-running series is compared to its recent average rather than all of it. */
 const BASELINE_EVENT_LIMIT = 10
+
+/* A handful of posters. Below this, naming a "few voices dominated" share is
+   meaningless, so the frequent-poster share is reported as null instead. */
+const FREQUENT_POSTER_MIN_POSTERS = 5
 
 function average(values: number[]): number {
   return values.reduce((sum, value) => sum + value, 0) / values.length
@@ -52,22 +89,37 @@ function average(values: number[]): number {
    We group by owner (the BaseUser ref, the actual person) rather than pseudonym. A
    person's pseudonym can rotate during an event: addPseudonym flips the old one
    inactive and assigns a new active one, and each message stores whatever pseudonym was
-   active when it was sent. Grouping by pseudonym would therefore count one person who
-   renamed mid-event as several distinct posters and overcount the room. owner is
-   required:false on the schema, so we fall back to pseudonym when it is missing. */
+   active when it was sent. Grouping by the pseudonym string would therefore count one
+   person who rotated mid-event as several posters. owner is required:false on the schema,
+   so for the rare owner-less message we fall back to pseudonymId, the id of the pseudonym
+   that sent it. That id is steadier than the display string (which can differ for the
+   same pseudonym), though only owner ties a guest together across a rename. */
 async function computeParticipation(conversationId): Promise<ParticipationMetrics> {
   const byPoster: { _id: string; count: number }[] = await Message.aggregate([
     { $match: { conversation: conversationId, ...visibleHumanFilter } },
-    { $group: { _id: { $ifNull: ['$owner', '$pseudonym'] }, count: { $sum: 1 } } },
+    { $group: { _id: { $ifNull: ['$owner', '$pseudonymId'] }, count: { $sum: 1 } } },
     { $sort: { count: -1 } }
   ])
 
   const posterCount = byPoster.length
   const messageCount = byPoster.reduce((sum, poster) => sum + poster.count, 0)
 
-  // Top 10% of posters, rounded up, but always at least one once anyone has posted.
-  const frequentPosterCount = posterCount > 0 ? Math.max(1, Math.ceil(posterCount * 0.1)) : 0
-  const frequentPosterMessages = byPoster.slice(0, frequentPosterCount).reduce((sum, poster) => sum + poster.count, 0)
+  /* Below a handful of posters a "few voices dominated" share is meaningless, so report
+     no frequent posters and a null share rather than a misleading one. */
+  if (posterCount < FREQUENT_POSTER_MIN_POSTERS) {
+    return { posterCount, frequentPosterCount: 0, frequentPosterMessageShare: null, messageCount }
+  }
+
+  /* Top 10% of posters by message volume, rounded up. byPoster is sorted by count
+     descending, so the cutoff is the count of the last poster in that top slice. */
+  const topSlice = Math.max(1, Math.ceil(posterCount * 0.1))
+  const cutoffCount = byPoster[topSlice - 1].count
+
+  /* Include every poster tied at the cutoff count, not just the first topSlice of them,
+     so a boundary tie is resolved by message volume rather than arbitrary sort order. */
+  const frequentPosters = byPoster.filter((poster) => poster.count >= cutoffCount)
+  const frequentPosterCount = frequentPosters.length
+  const frequentPosterMessages = frequentPosters.reduce((sum, poster) => sum + poster.count, 0)
   const frequentPosterMessageShare = messageCount > 0 ? frequentPosterMessages / messageCount : 0
 
   return { posterCount, frequentPosterCount, frequentPosterMessageShare, messageCount }
@@ -100,9 +152,10 @@ function deriveTrackedSessions(snapshot): TrackedSessionMetrics {
    post-event goodbye would otherwise clamp onto an edge bucket and overstate how
    busy the room was at the very start or end of the talk. When start and end fall
    back to the first and last message times, every message is in window by
-   definition, so nothing is dropped. Returns [] when no messages land in the
+   definition, so nothing is dropped. Each window keeps its minute offsets so a later
+   step can pull the messages sent during it. Returns [] when no messages land in the
    window. */
-function computeActivitySeries(messages: { createdAt?: Date }[], startTime?: Date, endTime?: Date): ActivityBucket[] {
+function bucketMessagesOverTime(messages: { createdAt?: Date }[], startTime?: Date, endTime?: Date): TimedActivityBucket[] {
   const dated = messages.filter((message): message is { createdAt: Date } => message.createdAt instanceof Date)
   if (dated.length === 0) return []
 
@@ -119,16 +172,16 @@ function computeActivitySeries(messages: { createdAt?: Date }[], startTime?: Dat
 
   // A zero-length window (all messages in one minute) collapses to a single bucket.
   if (totalMinutes === 0) {
-    return [{ label: '0-0', messageCount: inWindow.length }]
+    return [{ startMinute: 0, endMinute: 0, messageCount: inWindow.length }]
   }
 
   const bucketSizeMinutes = Math.ceil(totalMinutes / ACTIVITY_BUCKET_COUNT)
-  const buckets: ActivityBucket[] = []
+  const buckets: TimedActivityBucket[] = []
   for (let index = 0; index < ACTIVITY_BUCKET_COUNT; index += 1) {
-    const bucketStart = index * bucketSizeMinutes
-    if (bucketStart >= totalMinutes) break
-    const bucketEnd = Math.min(bucketStart + bucketSizeMinutes, totalMinutes)
-    buckets.push({ label: `${bucketStart}-${bucketEnd}`, messageCount: 0 })
+    const startMinute = index * bucketSizeMinutes
+    if (startMinute >= totalMinutes) break
+    const endMinute = Math.min(startMinute + bucketSizeMinutes, totalMinutes)
+    buckets.push({ startMinute, endMinute, messageCount: 0 })
   }
 
   for (const message of inWindow) {
@@ -140,18 +193,93 @@ function computeActivitySeries(messages: { createdAt?: Date }[], startTime?: Dat
   return buckets
 }
 
-/* Counts people's messages as either public chat or private (one-to-one with the
-   bot). A message is private when it was sent in a "direct" channel, which is how
-   the database marks a private 1:1 channel between a person and the agent. */
-async function computeChannelSplit(conversationId): Promise<{ public: number; private: number }> {
-  const messages = await Message.find({
-    conversation: conversationId,
-    ...visibleHumanFilter
-  }).select('channels')
-  const channelNames = [...new Set(messages.flatMap((message) => message.channels ?? []))]
-  const directChannels = await Channel.find({ name: { $in: channelNames }, direct: true }).select('name')
-  const directNames = new Set(directChannels.map((channel) => channel.name))
+/* Builds the chart label for one window. A window runs from startMinute up to but not
+   including endMinute, so its last whole minute is endMinute - 1. Labeling by that
+   inclusive range ('0-9', '10-19') keeps adjacent windows from sharing a boundary
+   number the way '0-10' and '10-20' both claimed minute 10, so a reader can tell which
+   window owns any given minute. A one-minute window and a zero-length window (start and
+   end equal, all messages in one minute) collapse to a single number. */
+function bucketLabel(startMinute: number, endMinute: number): string {
+  const lastMinute = Math.max(startMinute, endMinute - 1)
+  return lastMinute === startMinute ? `${startMinute}` : `${startMinute}-${lastMinute}`
+}
 
+/* Maps the timed buckets to the chart-ready series the card renders: a minute-range
+   label and a count per window. */
+function toActivitySeries(buckets: TimedActivityBucket[]): ActivityBucket[] {
+  return buckets.map((bucket) => ({
+    label: bucketLabel(bucket.startMinute, bucket.endMinute),
+    messageCount: bucket.messageCount
+  }))
+}
+
+/**
+ * Flags the windows where chat volume stood out from the rest of the event. A
+ * window is a spike when it clears two bars at once: it holds at least SPIKE_MULTIPLE
+ * times the average of the other windows, and it clears a floor that scales with the
+ * poster count. The relative test catches a genuine burst; the floor stops a tiny
+ * absolute jump from reading as one in a quiet room. Spikes come back in chronological
+ * order, each carrying its window and how far above baseline it ran, so the recap can
+ * name when the room lit up and a later step can read what was said then.
+ */
+export function computeSpikes(buckets: TimedActivityBucket[], posterCount: number): ChatSpike[] {
+  if (buckets.length < MIN_BUCKETS_FOR_SPIKE) return []
+
+  const floor = Math.max(SPIKE_ABSOLUTE_FLOOR, Math.ceil(posterCount * SPIKE_FLOOR_FRACTION))
+  const totalMessages = buckets.reduce((sum, bucket) => sum + bucket.messageCount, 0)
+
+  const toSpike = (bucket: TimedActivityBucket, baselineAverage: number): ChatSpike => ({
+    label: bucketLabel(bucket.startMinute, bucket.endMinute),
+    startMinute: bucket.startMinute,
+    endMinute: bucket.endMinute,
+    messageCount: bucket.messageCount,
+    baselineAverage,
+    ratio: baselineAverage > 0 ? bucket.messageCount / baselineAverage : null,
+    // Detection works on counts alone and cannot see channels; attributeSpikeSources
+    // overwrites this from the window's messages once the spikes are known.
+    source: 'chat'
+  })
+
+  /* When every window but the busiest is empty, the busiest window's baseline (the
+     average of the others) is zero, and the multiple test count >= SPIKE_MULTIPLE * 0
+     passes any non-empty window on the floor alone. The multiple is meaningless against
+     a zero baseline, so fall back to raw counts: pick only the single window with the
+     most messages, and only if it clears the floor. */
+  const busiest = buckets.reduce((top, bucket) => (bucket.messageCount > top.messageCount ? bucket : top), buckets[0])
+  const busiestBaseline = (totalMessages - busiest.messageCount) / (buckets.length - 1)
+  if (busiestBaseline === 0) {
+    return busiest.messageCount >= floor ? [toSpike(busiest, 0)] : []
+  }
+
+  const spikes: ChatSpike[] = []
+  for (const bucket of buckets) {
+    const baselineAverage = (totalMessages - bucket.messageCount) / (buckets.length - 1)
+    const clearsRelative = bucket.messageCount >= SPIKE_MULTIPLE * baselineAverage
+    const clearsFloor = bucket.messageCount >= floor
+    if (!clearsRelative || !clearsFloor) continue
+
+    spikes.push(toSpike(bucket, baselineAverage))
+  }
+
+  return spikes
+}
+
+/* Resolves which of the given channel names are private 1:1 channels with the agent. The
+   database marks those with direct:true; every other channel (public chat, the moderator
+   backchannel, the no-channel main feed) is treated as public. Shared by the channel split
+   and the spike attribution so both read "private" the same way from one lookup. */
+async function resolveDirectNames(channelNames: string[]): Promise<Set<string>> {
+  const directChannels = await Channel.find({ name: { $in: channelNames }, direct: true }).select('name')
+  return new Set(directChannels.map((channel) => channel.name))
+}
+
+/* Counts people's messages as either public chat or private (one-to-one with the bot). A
+   message is private when it was sent in a direct channel. Pure over the already-fetched
+   messages and the resolved direct-channel names. */
+function computeChannelSplit(
+  messages: { channels?: string[] }[],
+  directNames: Set<string>
+): { public: number; private: number } {
   let publicCount = 0
   let privateCount = 0
   for (const message of messages) {
@@ -159,6 +287,94 @@ async function computeChannelSplit(conversationId): Promise<{ public: number; pr
     else publicCount += 1
   }
   return { public: publicCount, private: privateCount }
+}
+
+/* Sorts one message into the channel category a spike is attributed by: a private 1:1 with
+   the bot, the moderator backchannel, or the public chat (the default for any other
+   channel, including the no-channel main feed). */
+export function spikeSourceForChannels(channels: string[] | undefined, directNames: Set<string>): SpikeSource {
+  const names = channels ?? []
+  if (names.some((name) => directNames.has(name))) return 'private'
+  if (names.includes('moderator')) return 'moderator'
+  return 'chat'
+}
+
+/* Stamps each spike with the channel that drove it, read from the messages in its window.
+   A spike is 'private' only when its window holds no readable (chat or moderator) messages
+   at all, meaning the burst was entirely one-to-one with the bot; that spike is surfaced
+   by count alone, since the analyst never reads those messages. Otherwise it is attributed
+   to the dominant readable channel, so a later quote always comes from content the analyst
+   may read, and a chat-vs-moderator tie favors the public chat. The window runs from
+   startMinute (inclusive) to endMinute (exclusive) past the event start, the same bounds
+   the activity buckets use. */
+export function attributeSpikeSources(
+  spikes: ChatSpike[],
+  messages: { createdAt?: Date; channels?: string[] }[],
+  startTime: Date | undefined,
+  directNames: Set<string>
+): ChatSpike[] {
+  if (spikes.length === 0) return spikes
+  const dated = messages.filter(
+    (message): message is { createdAt: Date; channels?: string[] } => message.createdAt instanceof Date
+  )
+  const startMs = (startTime ?? dated[0]?.createdAt)?.getTime()
+  if (startMs === undefined) return spikes
+
+  return spikes.map((spike) => {
+    const windowStart = startMs + spike.startMinute * 60 * 1000
+    const windowEnd = startMs + spike.endMinute * 60 * 1000
+    let chat = 0
+    let moderator = 0
+    for (const message of dated) {
+      const sentAt = message.createdAt.getTime()
+      if (sentAt < windowStart || sentAt >= windowEnd) continue
+      const source = spikeSourceForChannels(message.channels, directNames)
+      if (source === 'chat') chat += 1
+      else if (source === 'moderator') moderator += 1
+    }
+    if (chat === 0 && moderator === 0) return { ...spike, source: 'private' }
+    return { ...spike, source: chat >= moderator ? 'chat' : 'moderator' }
+  })
+}
+
+/* Counts how many times participants called on the event's configured assistant by
+   name. It reads people's chat messages, the channel where the assistant is summoned,
+   and matches each against the bot name the same fuzzy way the assistant itself does,
+   so a misspelled or @-prefixed name still counts. The name comes from the event's
+   configuration and falls back to the platform default, so a renamed assistant is
+   still counted correctly. */
+/* Pulls the human-readable text out of a message body. A plain chat message stores a
+   string body; a rich or multimodal one stores an object whose typed text lives under
+   `text`, the same shape report.service reads. Returns '' for anything without text
+   (an image-only body, say), so a mention check never runs over a non-text payload. */
+function messageText(body: unknown): string {
+  if (typeof body === 'string') return body
+  if (body && typeof body === 'object') {
+    const { text } = body as Record<string, unknown>
+    if (typeof text === 'string') return text
+  }
+  return ''
+}
+
+async function computeBotInvocations(conversation): Promise<BotInvocations> {
+  const botName = conversation.properties?.botName || config.conversationBotName
+  /* visible:true matches every other human count (see visibleHumanFilter): a hidden or
+     backchannel message is not a summon a participant made in the open. */
+  const messages = await Message.find({
+    conversation: conversation._id,
+    fromAgent: false,
+    visible: true,
+    channels: 'chat'
+  }).select('body')
+
+  let count = 0
+  for (const message of messages) {
+    const text = messageText(message.body)
+    if (text.length === 0) continue
+    if (matchBotMention(text.trim().split(/\s+/), botName)) count += 1
+  }
+
+  return { botName, count }
 }
 
 /* Bridges the exact poster count with the estimated participant count (unique
@@ -206,8 +422,25 @@ function computeAudienceEngagement(posterCount: number, sources: TrackedSessionM
   }
 }
 
+/* Month abbreviations for a compact event date label, indexed by getUTCMonth(). */
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+/* A history point's label: the event's own name plus a short date, e.g. "Future of Work
+   (Jun 3)". A topic's events often share a name (a recurring series), so the date sets
+   most of them apart and reads better than an opaque "E1". Two same-named events on the
+   same day still share a label, which is rare enough to accept. Falls back to the date
+   alone when an event has no name. The date is the UTC calendar day, so it is
+   deterministic but can read a day off for a viewer in a far timezone. */
+function eventHistoryLabel(name: string | undefined, endTime: Date | undefined): string {
+  const date = endTime ? `${MONTHS[endTime.getUTCMonth()]} ${endTime.getUTCDate()}` : ''
+  const trimmedName = name?.trim()
+  if (trimmedName && date) return `${trimmedName} (${date})`
+  return trimmedName || date || 'Past event'
+}
+
 /* Looks at up to the 10 most recent past events in the same topic and builds two
-   things: a chart-ready history (oldest is "E1", this event is "Today") and a baseline
+   things: a chart-ready history (each past event labeled by its name and date, this
+   event labeled "Today") and a baseline
    that averages their poster counts, lurker counts, and dwell time. A past event's
    lurker count and dwell only count when it has stored tracked-session data AND its
    participation reconciles, meaning its poster count did not exceed its tracked visitor
@@ -238,7 +471,7 @@ async function computeHistoryAndBaseline(
   })
     .sort({ endTime: -1 })
     .limit(BASELINE_EVENT_LIMIT)
-    .select('_id')
+    .select('_id name endTime')
 
   const oldestFirst = [...recentPast].reverse()
   const participationHistory: ParticipationHistoryPoint[] = []
@@ -246,7 +479,7 @@ async function computeHistoryAndBaseline(
   const pastLurkerCounts: number[] = []
   const pastDwells: number[] = []
 
-  for (const [index, pastEvent] of oldestFirst.entries()) {
+  for (const pastEvent of oldestFirst) {
     const { posterCount } = await computeParticipation(pastEvent._id)
     pastPosterCounts.push(posterCount)
 
@@ -266,7 +499,7 @@ async function computeHistoryAndBaseline(
        lurker and dwell baselines over one identical span of past events (trackedEventCount). */
     if (reconciles) pastDwells.push((snapshot.totalDwellSeconds ?? 0) / snapshot.totalVisits)
 
-    participationHistory.push({ label: `E${index + 1}`, posterCount, lurkerCount })
+    participationHistory.push({ label: eventHistoryLabel(pastEvent.name, pastEvent.endTime), posterCount, lurkerCount })
   }
   participationHistory.push({ label: 'Today', posterCount: current.posterCount, lurkerCount: current.lurkerCount })
 
@@ -306,6 +539,36 @@ function trackedSessionStatusFor(sources: TrackedSessionMetrics[], conversation)
  * undercount. trackedSessionStatus tells the card whether missing session data
  * means "nothing was tracked" or "not available yet".
  */
+/* Counts the event's readings and references from what participants could see. Only
+   participant-visible resources count, since the recap is about the audience's experience;
+   participantVisible defaults to true, so a resource counts unless it is explicitly hidden.
+   The counts cover how many readings existed and how many carried a link, never whether
+   anyone opened them. Resources are embedded on the conversation, so this needs no query. */
+export function computeResourceSummary(conversation: {
+  resources?: { category?: string; url?: string; participantVisible?: boolean }[]
+}): ResourceSummary {
+  const visible = (conversation.resources ?? []).filter((resource) => resource.participantVisible !== false)
+  return {
+    total: visible.length,
+    required: visible.filter((resource) => resource.category === 'required').length,
+    referenced: visible.filter((resource) => resource.category === 'referenced').length,
+    suggested: visible.filter((resource) => resource.category === 'suggested').length,
+    withLinks: visible.filter((resource) => typeof resource.url === 'string' && resource.url.trim().length > 0).length
+  }
+}
+
+/* Derives which platform(s) the event ran on from the conversation's platforms list, the
+   source of truth set at creation. 'both' when Nextspace and Zoom ran together. Defaults to
+   'nextspace' when nothing is recorded, since that is where the recap is read. */
+export function deriveEventPlatform(conversation: { platforms?: string[] }): EventPlatform {
+  const platforms = conversation.platforms ?? []
+  const hasZoom = platforms.includes('zoom')
+  const hasNextspace = platforms.includes('nextspace')
+  if (hasZoom && hasNextspace) return 'both'
+  if (hasZoom) return 'zoom'
+  return 'nextspace'
+}
+
 async function computeConversationMetrics(conversation): Promise<ConversationMetrics> {
   const participation = await computeParticipation(conversation._id)
   const snapshots = await ConversationAnalytics.find({ conversationId: conversation._id })
@@ -315,9 +578,19 @@ async function computeConversationMetrics(conversation): Promise<ConversationMet
     conversation: conversation._id,
     ...visibleHumanFilter
   })
-    .select('createdAt')
+    .select('createdAt channels')
     .sort({ createdAt: 1 })
-  const channelSplit = await computeChannelSplit(conversation._id)
+  const channelNames = [...new Set(humanMessages.flatMap((message) => message.channels ?? []))]
+  const directNames = await resolveDirectNames(channelNames)
+  const activityBuckets = bucketMessagesOverTime(humanMessages, conversation.startTime, conversation.endTime)
+  const channelSplit = computeChannelSplit(humanMessages, directNames)
+  const spikes = attributeSpikeSources(
+    computeSpikes(activityBuckets, participation.posterCount),
+    humanMessages,
+    conversation.startTime,
+    directNames
+  )
+  const botInvocations = await computeBotInvocations(conversation)
   const { participationHistory, baseline } = await computeHistoryAndBaseline(conversation, {
     posterCount: participation.posterCount,
     lurkerCount: audienceEngagement ? audienceEngagement.lurkerCount : null
@@ -328,10 +601,16 @@ async function computeConversationMetrics(conversation): Promise<ConversationMet
     trackedSessionSources,
     trackedSessionStatus: trackedSessionStatusFor(trackedSessionSources, conversation),
     audienceEngagement,
-    activitySeries: computeActivitySeries(humanMessages, conversation.startTime, conversation.endTime),
+    activitySeries: toActivitySeries(activityBuckets),
+    spikes,
     participationHistory,
     baseline,
-    channelSplit
+    channelSplit,
+    botInvocations,
+    resourceSummary: computeResourceSummary(conversation),
+    eventPlatform: deriveEventPlatform(conversation),
+    // Filled by the Vibes Analyst from message content; the service leaves it empty.
+    receptions: []
   }
 }
 

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -507,14 +507,16 @@ export interface AnalyticsSnapshot {
 
 /* Participation, taken from our own database, so it is exact. posterCount is the
    number of distinct people who sent at least one message; messageCount is the total
-   non-bot messages. frequentPosterCount is the top 10% of posters by message volume
-   (at least one once anyone has posted), and frequentPosterMessageShare is the fraction
-   of all messages those frequent posters sent (0 to 1), so the card can say whether a
-   few people dominated the conversation. */
+   non-bot messages. frequentPosterCount is the top 10% of posters by message volume,
+   widened to include everyone tied at the cutoff so a boundary tie is not split by sort
+   order. frequentPosterMessageShare is the fraction of all messages those frequent
+   posters sent (0 to 1), so the card can say whether a few people dominated. Below a
+   handful of posters a dominance share is meaningless, so frequentPosterMessageShare is
+   null and frequentPosterCount is 0 there. */
 export interface ParticipationMetrics {
   posterCount: number
   frequentPosterCount: number
-  frequentPosterMessageShare: number
+  frequentPosterMessageShare: number | null
   messageCount: number
 }
 
@@ -565,6 +567,41 @@ export interface ActivityBucket {
   messageCount: number
 }
 
+/* One detected chat spike: a time window whose message volume stood out from the
+   rest of the event. startMinute/endMinute are offsets from the event start, so a
+   later step can pull the messages sent during the window. baselineAverage is the
+   mean message count across the other windows; ratio is messageCount over that
+   average, or null when the rest of the event was silent and there is no baseline
+   to compare against. */
+/* A short, grounded label for what drove a spike. quote is verbatim text from a
+   message sent during the spike window, so the card never attributes words no one
+   wrote; topic is a brief phrase summarizing it. Present only when a quote was
+   confirmed against the window's messages. */
+export interface SpikeAnnotation {
+  topic: string
+  quote: string
+}
+
+/* Which channel category drove a spike. 'chat' and 'moderator' are channels the analyst
+   is allowed to read, so those spikes can carry a quote. 'private' is a burst of
+   one-to-one messages with the bot, which the analyst never reads, so it is surfaced by
+   its count alone. */
+export type SpikeSource = 'chat' | 'moderator' | 'private'
+
+export interface ChatSpike {
+  label: string
+  startMinute: number
+  endMinute: number
+  messageCount: number
+  baselineAverage: number
+  ratio: number | null
+  // Stamped by the service from the window's messages, before any content is read, so the
+  // analyst can label a private or backchannel burst without opening those messages.
+  source: SpikeSource
+  // Filled after detection, once a window quote is confirmed; absent otherwise.
+  annotation?: SpikeAnnotation
+}
+
 /* One point on the engagement-history chart: a past event in the same topic (or
    "Today"), with how many people posted and how many lurked (watched without posting).
    lurkerCount is null when that event had no tracked-session data, since lurkers can
@@ -596,6 +633,33 @@ export interface SameTopicBaseline {
   avgDwellSeconds: number | null
 }
 
+/* How many times participants called on the event's configured assistant by name.
+   botName is the name set at event creation (or the default); count is how many
+   participant chat messages addressed it, matched the same fuzzy way the assistant
+   itself detects a mention. */
+export interface BotInvocations {
+  botName: string
+  count: number
+}
+
+/* How the room received one speaker moment. agreement: the chat backed it up;
+   pushback: the chat challenged it; mixed: both showed up. The model reads the
+   reaction and labels it, but the label only stands when a real reaction quote and
+   the volume support it. */
+export type ReceptionSentiment = 'agreement' | 'pushback' | 'mixed'
+
+/* A speaker line that drew a visible chat reaction, with how the room responded.
+   sparkQuote is verbatim from the transcript; reactionQuote is a verbatim chat reply
+   that typifies the response; reactionVolume is how many public chat messages landed
+   in the window just after the line. Both quotes are confirmed against their source
+   before a reception is kept, so the sentiment never rides on invented words. */
+export interface QuoteReception {
+  sparkQuote: string
+  reactionVolume: number
+  reactionQuote: string
+  sentiment: ReceptionSentiment
+}
+
 /* Whether web-analytics data exists for this event. notTracked: no analytics source
    is set on the event, so nothing was ever tracked. unavailable: a source is set
    but no data has been stored yet (the fetch failed or has not run). available: at
@@ -616,13 +680,40 @@ export interface ConversationMetrics {
   audienceEngagement: AudienceEngagement | null
   // People's messages per time window; empty when the event had no messages.
   activitySeries: ActivityBucket[]
+  // Time windows whose message volume stood out from the rest; empty when none.
+  spikes: ChatSpike[]
   // This event plus recent past events in the same topic; just this event if new.
   participationHistory: ParticipationHistoryPoint[]
   // The topic's recent average, or null when this is the topic's only event.
   baseline: SameTopicBaseline | null
   // Counts of people's messages: public chat vs private one-to-one with the bot.
   channelSplit: { public: number; private: number }
+  // The configured assistant's name and how many times participants called on it.
+  botInvocations: BotInvocations
+  // Speaker moments that drew a chat reaction, with how the room responded; empty when none.
+  receptions: QuoteReception[]
+  // The event's readings and references, counted from participant-visible resources only.
+  resourceSummary: ResourceSummary
+  // Which platform(s) the event ran on: Nextspace, Zoom, or both.
+  eventPlatform: EventPlatform
 }
+
+/* The event's readings and references, counted only from what participants could see
+   (participant-visible resources). These are exact, first-party counts, like
+   participation. required, referenced, and suggested are the resource categories;
+   withLinks is how many of those visible resources carry a link. The counts say how many
+   readings existed and how many had links, never whether anyone opened them. */
+export interface ResourceSummary {
+  total: number
+  required: number
+  referenced: number
+  suggested: number
+  withLinks: number
+}
+
+/* Which platform(s) the event ran on, derived from the conversation's platforms list.
+   'both' when it ran on Nextspace and Zoom together. */
+export type EventPlatform = 'nextspace' | 'zoom' | 'both'
 
 /* One point on a bar/line/area chart: an x-axis category and its y value. */
 export interface VibesChartDataPoint {

--- a/tests/agents/vibesAnalyst/curate.test.ts
+++ b/tests/agents/vibesAnalyst/curate.test.ts
@@ -38,6 +38,7 @@ function negativeEventMetrics(): ConversationMetrics {
       { label: '40-50', messageCount: 6 },
       { label: '50-58', messageCount: 4 }
     ],
+    spikes: [],
     participationHistory: [
       { label: 'E1', posterCount: 29, lurkerCount: 60 },
       { label: 'E2', posterCount: 30, lurkerCount: 58 },
@@ -47,7 +48,18 @@ function negativeEventMetrics(): ConversationMetrics {
       { label: 'Today', posterCount: 17, lurkerCount: 23 }
     ],
     baseline: { eventCount: 5, trackedEventCount: 5, avgPosterCount: 29.8, avgLurkerCount: 59, avgDwellSeconds: 1440 },
-    channelSplit: { public: 26, private: 38 }
+    channelSplit: { public: 26, private: 38 },
+    botInvocations: { botName: 'Berkie', count: 4 },
+    receptions: [
+      {
+        sparkQuote: 'remote work is here to stay',
+        reactionVolume: 9,
+        reactionQuote: 'finally someone said it out loud',
+        sentiment: 'agreement'
+      }
+    ],
+    resourceSummary: { total: 0, required: 0, referenced: 0, suggested: 0, withLinks: 0 },
+    eventPlatform: 'nextspace'
   }
 }
 

--- a/tests/agents/vibesAnalyst/eventResolution.test.ts
+++ b/tests/agents/vibesAnalyst/eventResolution.test.ts
@@ -1,0 +1,35 @@
+import { extractEventReference } from '../../../src/agents/vibesAnalyst/eventResolution.js'
+import { getModelChat, supportedModels } from '../../../src/agents/helpers/getModelChat.js'
+import { LlmPlatforms } from '../../../src/types/index.types.js'
+
+jest.setTimeout(45000) // LLM calls can be slow
+
+describe('extractEventReference', () => {
+  let llm
+
+  beforeAll(async () => {
+    const llmPlatform = process.env.TEST_LLM_PLATFORM || supportedModels[0].llmPlatform
+    const llmModel = process.env.TEST_LLM_MODEL || supportedModels[0].llmModel
+    llm = await getModelChat(llmPlatform as LlmPlatforms, llmModel)
+  })
+
+  it('extracts a specific event title and does not flag latest', async () => {
+    const reference = await extractEventReference('@Vibes can you recap the Spring Town Hall for me?', llm)
+
+    expect(reference.latestInTopic).toBe(false)
+    expect(reference.eventQuery.toLowerCase()).toContain('town hall')
+  })
+
+  it('flags a request for the most recent event in a topic', async () => {
+    const reference = await extractEventReference('@Vibes how did the latest AI Ethics session go?', llm)
+
+    expect(reference.latestInTopic).toBe(true)
+    expect(reference.eventQuery.toLowerCase()).toContain('ethics')
+  })
+
+  it('flags a request for the single most recent event with no topic named', async () => {
+    const reference = await extractEventReference('@Vibes tell me about the last event', llm)
+
+    expect(reference.latestOverall).toBe(true)
+  })
+})

--- a/tests/agents/vibesAnalyst/quoteReception.test.ts
+++ b/tests/agents/vibesAnalyst/quoteReception.test.ts
@@ -1,0 +1,82 @@
+import annotateReceptions from '../../../src/agents/vibesAnalyst/quoteReception.js'
+import { quoteAppearsIn } from '../../../src/agents/vibesAnalyst/spikeAnnotation.js'
+import { getModelChat, supportedModels } from '../../../src/agents/helpers/getModelChat.js'
+import { LlmPlatforms } from '../../../src/types/index.types.js'
+
+jest.setTimeout(45000) // LLM calls can be slow
+
+const EVENT_START = new Date('2026-06-10T10:00:00.000Z')
+const at = (minutes: number) => new Date(EVENT_START.getTime() + minutes * 60 * 1000)
+
+/* One speaker line on the transcript, then a clearly oppositional burst of chat right
+   after it: a spark and a pushback reaction the labeler should be able to read. */
+const sparkLine = {
+  body: 'we should ban gas stoves entirely',
+  pseudonym: 'Speaker',
+  fromAgent: false,
+  createdAt: at(5),
+  channels: ['transcript']
+}
+const reactionChat = [
+  { body: 'no way, gas is better for cooking', pseudonym: 'ana', fromAgent: false, createdAt: at(5.5), channels: ['chat'] },
+  { body: 'my landlord would never replace it', pseudonym: 'bo', fromAgent: false, createdAt: at(6), channels: ['chat'] },
+  {
+    body: 'that feels like government overreach honestly',
+    pseudonym: 'cy',
+    fromAgent: false,
+    createdAt: at(6.5),
+    channels: ['chat']
+  },
+  {
+    body: 'induction is just not the same for a wok',
+    pseudonym: 'di',
+    fromAgent: false,
+    createdAt: at(7),
+    channels: ['chat']
+  }
+]
+
+describe('annotateReceptions', () => {
+  let llm
+
+  beforeAll(async () => {
+    const llmPlatform = process.env.TEST_LLM_PLATFORM || supportedModels[0].llmPlatform
+    const llmModel = process.env.TEST_LLM_MODEL || supportedModels[0].llmModel
+    llm = await getModelChat(llmPlatform as LlmPlatforms, llmModel)
+  })
+
+  it('labels a speaker moment with verbatim spark and reaction quotes and a sentiment', async () => {
+    const receptions = await annotateReceptions([sparkLine, ...reactionChat], 10, llm)
+
+    expect(receptions).toHaveLength(1)
+    const [reception] = receptions
+
+    // Both quotes must be verbatim text from their source, the spark from the transcript
+    // line and the reaction from the chat that followed.
+    expect(quoteAppearsIn(reception.sparkQuote, [sparkLine])).toBe(true)
+    expect(quoteAppearsIn(reception.reactionQuote, reactionChat)).toBe(true)
+    expect(reception.reactionVolume).toBe(reactionChat.length)
+    expect(['agreement', 'pushback', 'mixed']).toContain(reception.sentiment)
+  })
+
+  it('returns nothing when no speaker line drew a reaction, without calling the model', async () => {
+    const quietLine = {
+      body: 'a quiet aside',
+      pseudonym: 'Speaker',
+      fromAgent: false,
+      createdAt: at(30),
+      channels: ['transcript']
+    }
+    const loneReply = { body: 'ok', pseudonym: 'ana', fromAgent: false, createdAt: at(30.5), channels: ['chat'] }
+    // Throws if the model is ever invoked; selection should short-circuit before that.
+    const poisonLlm = {
+      invoke: () => {
+        throw new Error('model should not be called when nothing cleared the floor')
+      }
+    }
+
+    const receptions = await annotateReceptions([quietLine, loneReply], 10, poisonLlm)
+
+    expect(receptions).toEqual([])
+  })
+})

--- a/tests/agents/vibesAnalyst/spikeAnnotation.test.ts
+++ b/tests/agents/vibesAnalyst/spikeAnnotation.test.ts
@@ -1,0 +1,126 @@
+import annotateSpikes, { quoteAppearsIn } from '../../../src/agents/vibesAnalyst/spikeAnnotation.js'
+import { getModelChat, supportedModels } from '../../../src/agents/helpers/getModelChat.js'
+import { ChatSpike, LlmPlatforms } from '../../../src/types/index.types.js'
+
+jest.setTimeout(45000) // LLM calls can be slow
+
+const EVENT_START = new Date('2026-06-10T10:00:00.000Z')
+const at = (minutes: number) => new Date(EVENT_START.getTime() + minutes * 60 * 1000)
+
+/* A burst of participant chat messages on one clear topic, with a bot line mixed in so
+   the test can confirm the quote comes from a participant and never the bot. */
+const windowMessages = [
+  {
+    body: 'Wait, the new policy bans remote work entirely?',
+    pseudonym: 'ana',
+    fromAgent: false,
+    channels: ['chat'],
+    createdAt: at(21)
+  },
+  {
+    body: 'Yeah, everyone has to be back in the office by September.',
+    pseudonym: 'bo',
+    fromAgent: false,
+    channels: ['chat'],
+    createdAt: at(22)
+  },
+  {
+    body: 'That is going to push a lot of people to quit.',
+    pseudonym: 'cy',
+    fromAgent: false,
+    channels: ['chat'],
+    createdAt: at(23)
+  },
+  {
+    body: 'BeepBot here, I can summarize the policy if that helps.',
+    pseudonym: 'beep',
+    fromAgent: true,
+    channels: ['chat'],
+    createdAt: at(23)
+  },
+  {
+    body: 'No way I can do a two hour commute again.',
+    pseudonym: 'di',
+    fromAgent: false,
+    channels: ['chat'],
+    createdAt: at(24)
+  }
+]
+
+const messages = [
+  { body: 'morning everyone', pseudonym: 'ana', fromAgent: false, channels: ['chat'], createdAt: at(2) },
+  ...windowMessages,
+  { body: 'thanks all, see you next time', pseudonym: 'bo', fromAgent: false, channels: ['chat'], createdAt: at(45) }
+]
+
+const spike: ChatSpike = {
+  label: '20-30',
+  startMinute: 20,
+  endMinute: 30,
+  messageCount: 4,
+  baselineAverage: 0.5,
+  ratio: 8,
+  source: 'chat'
+}
+
+describe('annotateSpikes', () => {
+  let llm
+
+  beforeAll(async () => {
+    const llmPlatform = process.env.TEST_LLM_PLATFORM || supportedModels[0].llmPlatform
+    const llmModel = process.env.TEST_LLM_MODEL || supportedModels[0].llmModel
+    llm = await getModelChat(llmPlatform as LlmPlatforms, llmModel)
+  })
+
+  it('labels a spike with a topic and a participant quote that was really said', async () => {
+    const annotated = await annotateSpikes(messages, EVENT_START, [spike], llm)
+
+    expect(annotated).toHaveLength(1)
+    const [result] = annotated
+    expect(result.startMinute).toBe(20)
+    expect(result.annotation).toBeDefined()
+    expect(result.annotation!.topic.length).toBeGreaterThan(0)
+
+    // The quote must be verbatim text from a participant message in the window.
+    const participantWindow = windowMessages.filter((message) => !message.fromAgent)
+    expect(quoteAppearsIn(result.annotation!.quote, participantWindow)).toBe(true)
+    expect(result.annotation!.quote.toLowerCase()).not.toContain('beepbot')
+  })
+
+  it('leaves a spike unannotated when only a bot spoke during it, without calling the model', async () => {
+    const botSpike: ChatSpike = {
+      label: '40-50',
+      startMinute: 40,
+      endMinute: 50,
+      messageCount: 3,
+      baselineAverage: 1,
+      ratio: 3,
+      source: 'chat'
+    }
+    const botOnly = [
+      { body: 'automated reminder', pseudonym: 'beep', fromAgent: true, channels: ['chat'], createdAt: at(41) }
+    ]
+
+    const annotated = await annotateSpikes(botOnly, EVENT_START, [botSpike], llm)
+
+    expect(annotated[0].annotation).toBeUndefined()
+  })
+
+  it('leaves a private-source spike unannotated, never reading its messages or calling the model', async () => {
+    const privateSpike: ChatSpike = {
+      label: '20-30',
+      startMinute: 20,
+      endMinute: 30,
+      messageCount: 4,
+      baselineAverage: 0.5,
+      ratio: 8,
+      source: 'private'
+    }
+
+    // Even with quotable chat text in the window, a private spike is surfaced by count
+    // alone, so it comes back with no annotation.
+    const annotated = await annotateSpikes(messages, EVENT_START, [privateSpike], llm)
+
+    expect(annotated[0].annotation).toBeUndefined()
+  })
+})

--- a/tests/agents/vibesAnalyst/verifyCuration.test.ts
+++ b/tests/agents/vibesAnalyst/verifyCuration.test.ts
@@ -21,13 +21,25 @@ function metricsFixture(): ConversationMetrics {
       { label: '40-50', messageCount: 3 },
       { label: '50-58', messageCount: 1 }
     ],
+    spikes: [],
     participationHistory: [
       { label: 'E1', posterCount: 30, lurkerCount: null },
       { label: 'E2', posterCount: 30, lurkerCount: null },
       { label: 'Today', posterCount: 16, lurkerCount: null }
     ],
     baseline: { eventCount: 2, trackedEventCount: 0, avgPosterCount: 30, avgLurkerCount: null, avgDwellSeconds: null },
-    channelSplit: { public: 40, private: 20 }
+    channelSplit: { public: 40, private: 20 },
+    botInvocations: { botName: 'Berkie', count: 0 },
+    receptions: [
+      {
+        sparkQuote: 'we should ban gas stoves entirely',
+        reactionVolume: 7,
+        reactionQuote: 'no way, gas is better for cooking',
+        sentiment: 'pushback'
+      }
+    ],
+    resourceSummary: { total: 0, required: 0, referenced: 0, suggested: 0, withLinks: 0 },
+    eventPlatform: 'nextspace'
   }
 }
 
@@ -71,5 +83,36 @@ describe('verifyCuratedCard critic', () => {
     const survivingText = result.standouts.map((standout) => standout.text)
     expect(survivingText).toContain('Only 16 people posted today, well below the topic recent average of about 30.')
     expect(survivingText).not.toContain('Posting surged to a record high today, the best this topic has ever seen.')
+  })
+
+  it('keeps a reception standout backed by a matching reception', async () => {
+    const card: CuratedVibesData = {
+      header: 'A divisive moment',
+      standouts: [
+        {
+          text: 'When a speaker said "we should ban gas stoves entirely", the room pushed back, one reply being "no way, gas is better for cooking".'
+        }
+      ],
+      durationMinutes: 58
+    }
+
+    const result = await verifyCuratedCard(card, metricsFixture(), llm)
+
+    expect(result.standouts).toHaveLength(1)
+  })
+
+  it('drops a reception standout whose sentiment the metrics contradict', async () => {
+    const card: CuratedVibesData = {
+      header: 'A crowd-pleaser',
+      standouts: [
+        // The reception's sentiment is pushback, so claiming agreement is unsupported.
+        { text: 'The room loved the call to "ban gas stoves entirely", cheering it on with near-universal agreement.' }
+      ],
+      durationMinutes: 58
+    }
+
+    const result = await verifyCuratedCard(card, metricsFixture(), llm)
+
+    expect(result.standouts).toHaveLength(0)
   })
 })

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -38,6 +38,11 @@ const testAdapterTypes = {
     start: mockAdapterStart,
     stop: mockAdapterStop,
     getUniqueKeys: mockGetUniqueKeys
+  },
+  slack: {
+    start: mockAdapterStart,
+    stop: mockAdapterStop,
+    getUniqueKeys: mockGetUniqueKeys
   }
 }
 
@@ -1602,6 +1607,45 @@ describe('Conversation service methods', () => {
 
       const agentsAfter = await Agent.find({ conversation: featureConv._id })
       expect(agentsAfter.map((a) => a.agentType)).not.toContain('eventMediator')
+    })
+
+    test('syncs slackBotUserId into the slack adapter config on a properties update', async () => {
+      /* A Slack-backed bot (the Vibes Analyst) renders its bot user id into the adapter
+         config once at creation. Adding or changing slackBotUserId later has to reach that
+         adapter, or summon never recognizes the bot's @-mentions. */
+      await Adapter.create({
+        type: 'slack',
+        conversation: conversation._id,
+        config: { botUserId: 'UOLD', botName: 'OriginalBot', channel: 'C123' }
+      })
+
+      await conversationService.updateConversation(
+        { id: conversation._id.toString(), properties: { slackBotUserId: 'UNEW' } },
+        registeredUser
+      )
+
+      const [updated] = await Adapter.find({ conversation: conversation._id, type: 'slack' })
+      expect(updated.config.botUserId).toBe('UNEW')
+      // Only the changed key is touched; unrelated config is left alone.
+      expect(updated.config.botName).toBe('OriginalBot')
+      expect(updated.config.channel).toBe('C123')
+    })
+
+    test('syncs botName into the slack adapter config on a properties update', async () => {
+      await Adapter.create({
+        type: 'slack',
+        conversation: conversation._id,
+        config: { botUserId: 'U123', botName: 'OldName' }
+      })
+
+      await conversationService.updateConversation(
+        { id: conversation._id.toString(), properties: { botName: 'NewName' } },
+        registeredUser
+      )
+
+      const [updated] = await Adapter.find({ conversation: conversation._id, type: 'slack' })
+      expect(updated.config.botName).toBe('NewName')
+      expect(updated.config.botUserId).toBe('U123')
     })
   })
 

--- a/tests/unit/agents/vibesAnalyst/capabilities.test.ts
+++ b/tests/unit/agents/vibesAnalyst/capabilities.test.ts
@@ -1,4 +1,38 @@
-import capabilities from '../../../../src/agents/vibesAnalyst/capabilities.js'
+import mongoose from 'mongoose'
+import setupIntTest from '../../../utils/setupIntTest.js'
+import { Message } from '../../../../src/models/index.js'
+import capabilities, {
+  VA_READABLE_CHANNELS,
+  loadReadableMessages
+} from '../../../../src/agents/vibesAnalyst/capabilities.js'
+
+setupIntTest()
+
+const ownerId = new mongoose.Types.ObjectId()
+const EVENT_START = new Date('2026-06-10T10:00:00.000Z')
+
+/* A timestamp N minutes into the event, so message ordering in these tests reads
+   in plain minutes instead of raw millisecond math. */
+function minutesIn(minutes: number): Date {
+  return new Date(EVENT_START.getTime() + minutes * 60 * 1000)
+}
+
+/* Seeds one message in the given channels at a fixed createdAt so ordering is
+   deterministic. timestamps:true stamps createdAt at insert and marks it
+   immutable, so the offset is forced through the native driver, which bypasses
+   Mongoose casting and the immutable guard. */
+async function seedMessage(
+  conversationId: mongoose.Types.ObjectId,
+  channels: string[] | undefined,
+  body: string,
+  createdAt: Date,
+  fromAgent = false
+) {
+  const [message] = await Message.create([
+    { body, conversation: conversationId, owner: ownerId, pseudonymId: ownerId, pseudonym: 'ana', fromAgent, channels }
+  ])
+  await Message.collection.updateOne({ _id: message._id }, { $set: { createdAt } })
+}
 
 describe('vibesAnalyst capabilities', () => {
   it('reads all public topics so it can react to every public event', () => {
@@ -9,5 +43,71 @@ describe('vibesAnalyst capabilities', () => {
   it('writes only to its own conversation', () => {
     const result = capabilities()
     expect(result.write).toEqual([{ type: 'ownConversation' }])
+  })
+})
+
+describe('VA_READABLE_CHANNELS', () => {
+  it('allowlists the shared event channels and nothing else', () => {
+    expect([...VA_READABLE_CHANNELS]).toEqual(['transcript', 'chat', 'moderator'])
+  })
+})
+
+describe('loadReadableMessages', () => {
+  it('returns only messages in allowlisted channels, oldest first', async () => {
+    const conversationId = new mongoose.Types.ObjectId()
+
+    await seedMessage(conversationId, ['transcript'], 'speaker line', minutesIn(1))
+    await seedMessage(conversationId, ['chat'], 'audience reply', minutesIn(2))
+    await seedMessage(conversationId, ['moderator'], 'mod backchannel note', minutesIn(3))
+
+    const messages = await loadReadableMessages(conversationId)
+
+    expect(messages.map((m) => m.body)).toEqual(['speaker line', 'audience reply', 'mod backchannel note'])
+  })
+
+  it('excludes 1:1 direct DM channels (generated names are not on the allowlist)', async () => {
+    const conversationId = new mongoose.Types.ObjectId()
+
+    await seedMessage(conversationId, ['chat'], 'public', minutesIn(1))
+    await seedMessage(conversationId, ['dm-7f3a9c2b'], 'private DM with the bot', minutesIn(2))
+
+    const messages = await loadReadableMessages(conversationId)
+
+    expect(messages.map((m) => m.body)).toEqual(['public'])
+  })
+
+  it('excludes messages with no channel or an unknown channel', async () => {
+    const conversationId = new mongoose.Types.ObjectId()
+
+    await seedMessage(conversationId, ['chat'], 'public', minutesIn(1))
+    await seedMessage(conversationId, undefined, 'channelless', minutesIn(2))
+    await seedMessage(conversationId, ['image-gen'], 'other channel', minutesIn(3))
+
+    const messages = await loadReadableMessages(conversationId)
+
+    expect(messages.map((m) => m.body)).toEqual(['public'])
+  })
+
+  it('includes agent messages so callers can count agent activity', async () => {
+    const conversationId = new mongoose.Types.ObjectId()
+
+    await seedMessage(conversationId, ['chat'], 'human asks Berkie', minutesIn(1), false)
+    await seedMessage(conversationId, ['chat'], 'Berkie answers', minutesIn(2), true)
+
+    const messages = await loadReadableMessages(conversationId)
+
+    expect(messages.map((m) => m.fromAgent)).toEqual([false, true])
+  })
+
+  it('scopes to the given conversation only', async () => {
+    const conversationId = new mongoose.Types.ObjectId()
+    const otherConversationId = new mongoose.Types.ObjectId()
+
+    await seedMessage(conversationId, ['chat'], 'ours', minutesIn(1))
+    await seedMessage(otherConversationId, ['chat'], 'theirs', minutesIn(2))
+
+    const messages = await loadReadableMessages(conversationId)
+
+    expect(messages.map((m) => m.body)).toEqual(['ours'])
   })
 })

--- a/tests/unit/agents/vibesAnalyst/curate.test.ts
+++ b/tests/unit/agents/vibesAnalyst/curate.test.ts
@@ -14,12 +14,17 @@ function metricsFixture(overrides: Partial<ConversationMetrics> = {}): Conversat
       { label: '0-10', messageCount: 5 },
       { label: '10-20', messageCount: 15 }
     ],
+    spikes: [],
     participationHistory: [
       { label: 'E1', posterCount: 18, lurkerCount: null },
       { label: 'Today', posterCount: 20, lurkerCount: null }
     ],
     baseline: { eventCount: 3, trackedEventCount: 0, avgPosterCount: 18, avgLurkerCount: null, avgDwellSeconds: null },
     channelSplit: { public: 30, private: 20 },
+    botInvocations: { botName: 'Berkie', count: 0 },
+    receptions: [],
+    resourceSummary: { total: 0, required: 0, referenced: 0, suggested: 0, withLinks: 0 },
+    eventPlatform: 'nextspace',
     ...overrides
   }
 }

--- a/tests/unit/agents/vibesAnalyst/eventResolution.test.ts
+++ b/tests/unit/agents/vibesAnalyst/eventResolution.test.ts
@@ -1,0 +1,124 @@
+import {
+  resolveSummonedEvent,
+  toPublicCandidates,
+  EventResolution
+} from '../../../../src/agents/vibesAnalyst/eventResolution.js'
+
+/* A candidate public event the summon could resolve to. endMinutesAgo lets a test
+   make one event more recent than another for the latest-in-topic case. */
+function ev(id: string, name: string, topicName: string, endMinutesAgo = 0) {
+  return { id, name, topicName, endTime: new Date(Date.parse('2026-06-01T00:00:00.000Z') - endMinutesAgo * 60 * 1000) }
+}
+
+function asAmbiguous(result: EventResolution) {
+  if (result.status !== 'ambiguous') throw new Error(`expected ambiguous, got ${result.status}`)
+  return result
+}
+
+describe('resolveSummonedEvent', () => {
+  it('resolves a clear title match', () => {
+    const candidates = [
+      ev('1', 'Spring Town Hall 2026', 'Town Halls'),
+      ev('2', 'Q3 Budget Review', 'Finance'),
+      ev('3', 'Engineering Standup', 'Eng')
+    ]
+
+    const result = resolveSummonedEvent({ eventQuery: 'Spring Town Hall', latestInTopic: false }, candidates)
+
+    expect(result).toEqual({ status: 'resolved', event: candidates[0] })
+  })
+
+  it('returns notFound when no title is close enough', () => {
+    const candidates = [ev('1', 'Spring Town Hall 2026', 'Town Halls'), ev('2', 'Q3 Budget Review', 'Finance')]
+
+    const result = resolveSummonedEvent({ eventQuery: 'Annual Holiday Gala', latestInTopic: false }, candidates)
+
+    expect(result).toEqual({ status: 'notFound' })
+  })
+
+  it('flags ambiguity when two titles match closely', () => {
+    const candidates = [
+      ev('1', 'Spring Town Hall', 'Town Halls'),
+      ev('2', 'Fall Town Hall', 'Town Halls'),
+      ev('3', 'Q3 Budget Review', 'Finance')
+    ]
+
+    const result = resolveSummonedEvent({ eventQuery: 'Town Hall', latestInTopic: false }, candidates)
+
+    expect(
+      asAmbiguous(result)
+        .candidates.map((candidate) => candidate.id)
+        .sort()
+    ).toEqual(['1', '2'])
+  })
+
+  it('picks the most recent event when asked for the latest in a topic', () => {
+    const candidates = [
+      ev('1', 'AI Ethics Session 1', 'AI Ethics', 1000),
+      ev('2', 'AI Ethics Session 2', 'AI Ethics', 10), // most recent
+      ev('3', 'Budget Review', 'Finance', 5)
+    ]
+
+    const result = resolveSummonedEvent({ eventQuery: 'AI Ethics', latestInTopic: true }, candidates)
+
+    expect(result).toEqual({ status: 'resolved', event: candidates[1] })
+  })
+
+  it('returns notFound for latest-in-topic when no topic matches', () => {
+    const candidates = [ev('1', 'AI Ethics Session 1', 'AI Ethics', 1000)]
+
+    const result = resolveSummonedEvent({ eventQuery: 'Climate Policy', latestInTopic: true }, candidates)
+
+    expect(result).toEqual({ status: 'notFound' })
+  })
+
+  it('resolves the single most recent event overall when asked for the latest with no topic', () => {
+    const candidates = [
+      ev('1', 'Spring Town Hall', 'Town Halls', 1000),
+      ev('2', 'Budget Review', 'Finance', 5), // most recent
+      ev('3', 'Engineering Standup', 'Eng', 500)
+    ]
+
+    const result = resolveSummonedEvent({ eventQuery: '', latestInTopic: false, latestOverall: true }, candidates)
+
+    expect(result).toEqual({ status: 'resolved', event: candidates[1] })
+  })
+
+  it('returns notFound for latest-overall when there are no candidates', () => {
+    const result = resolveSummonedEvent({ eventQuery: '', latestInTopic: false, latestOverall: true }, [])
+
+    expect(result).toEqual({ status: 'notFound' })
+  })
+})
+
+describe('toPublicCandidates', () => {
+  const conversation = (over: Record<string, unknown> = {}) => ({
+    _id: 'x',
+    name: 'An Event',
+    endTime: new Date('2026-01-01T00:00:00.000Z'),
+    topic: { name: 'A Topic', private: false },
+    ...over
+  })
+
+  it('keeps public ended events and maps them to candidates', () => {
+    const result = toPublicCandidates([
+      conversation({ _id: 'a', name: 'Spring Town Hall', topic: { name: 'Town Halls', private: false } })
+    ])
+
+    expect(result).toEqual([
+      { id: 'a', name: 'Spring Town Hall', topicName: 'Town Halls', endTime: new Date('2026-01-01T00:00:00.000Z') }
+    ])
+  })
+
+  it('drops events on a private topic so their titles never leak', () => {
+    expect(toPublicCandidates([conversation({ topic: { name: 'Secret', private: true } })])).toEqual([])
+  })
+
+  it('drops events whose topic did not populate, failing closed', () => {
+    expect(toPublicCandidates([conversation({ topic: undefined })])).toEqual([])
+  })
+
+  it('drops events that never ended', () => {
+    expect(toPublicCandidates([conversation({ endTime: undefined })])).toEqual([])
+  })
+})

--- a/tests/unit/agents/vibesAnalyst/quoteReception.test.ts
+++ b/tests/unit/agents/vibesAnalyst/quoteReception.test.ts
@@ -166,4 +166,24 @@ describe('groundReception', () => {
 
     expect(result).toBeNull()
   })
+
+  it('keeps a reception when the model included the pseudonym prefix in the reaction quote', () => {
+    const candidateWithPseudonym = {
+      sparkMessage: { body: 'We should ban gas stoves entirely.', channels: ['transcript'] },
+      reactionVolume: 4,
+      reactionChat: [
+        { body: 'No way, gas is better for cooking', pseudonym: 'ana' },
+        { body: 'agreed, electric is the future', pseudonym: 'bo' }
+      ]
+    }
+
+    const result = groundReception(candidateWithPseudonym, {
+      sparkQuote: 'ban gas stoves',
+      reactionQuote: 'ana: No way, gas is better for cooking',
+      sentiment: 'pushback'
+    })
+
+    expect(result).not.toBeNull()
+    expect(result?.reactionQuote).toBe('ana: No way, gas is better for cooking')
+  })
 })

--- a/tests/unit/agents/vibesAnalyst/quoteReception.test.ts
+++ b/tests/unit/agents/vibesAnalyst/quoteReception.test.ts
@@ -1,0 +1,169 @@
+import {
+  selectSparkCandidates,
+  groundReception,
+  MAX_RECEPTIONS
+} from '../../../../src/agents/vibesAnalyst/quoteReception.js'
+
+/* All test messages hang off this base time. The reaction window is 3 minutes, so
+   chat placed within 3 minutes after a transcript line counts as its reaction. */
+const BASE = new Date('2026-06-10T10:00:00.000Z').getTime()
+function at(minute: number): Date {
+  return new Date(BASE + minute * 60 * 1000)
+}
+
+function transcriptLine(minute: number, body: string, pseudonym = 'Speaker') {
+  return { body, pseudonym, fromAgent: false, createdAt: at(minute), channels: ['transcript'] }
+}
+
+function chatMessage(minute: number, body: string, options: { fromAgent?: boolean } = {}) {
+  return { body, pseudonym: 'ana', fromAgent: options.fromAgent ?? false, createdAt: at(minute), channels: ['chat'] }
+}
+
+describe('selectSparkCandidates', () => {
+  // posterCount 10 keeps the floor at its absolute minimum of 3 reactions.
+  const posterCount = 10
+
+  it('selects a transcript line that drew enough chat reaction', () => {
+    const transcript = [transcriptLine(5, 'We should ban gas stoves entirely.')]
+    const chat = [
+      chatMessage(5.5, 'No way, gas is better for cooking'),
+      chatMessage(6, 'agreed, electric is the future'),
+      chatMessage(6.5, 'my landlord would never'),
+      chatMessage(7, 'induction is amazing actually')
+    ]
+
+    const candidates = selectSparkCandidates(transcript, chat, posterCount)
+
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].sparkMessage.body).toBe('We should ban gas stoves entirely.')
+    expect(candidates[0].reactionVolume).toBe(4)
+    expect(candidates[0].reactionChat).toHaveLength(4)
+  })
+
+  it('ignores a line whose reaction stays below the floor', () => {
+    const transcript = [transcriptLine(30, 'A minor aside no one picked up.')]
+    const chat = [chatMessage(31, 'ok')]
+
+    const candidates = selectSparkCandidates(transcript, chat, posterCount)
+
+    expect(candidates).toEqual([])
+  })
+
+  it('suppresses an overlapping nearby line, keeping the stronger one', () => {
+    const transcript = [
+      transcriptLine(5, 'The strong claim that set people off.'),
+      transcriptLine(6, 'A follow-up a minute later.')
+    ]
+    const chat = [
+      chatMessage(5.5, 'whoa really'),
+      chatMessage(6, 'I do not buy that'),
+      chatMessage(6.5, 'say more'),
+      chatMessage(7, 'this changes everything')
+    ]
+
+    const candidates = selectSparkCandidates(transcript, chat, posterCount)
+
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].sparkMessage.body).toBe('The strong claim that set people off.')
+    expect(candidates[0].reactionVolume).toBe(4)
+  })
+
+  it('caps the number of receptions, keeping the strongest', () => {
+    const transcript = [
+      transcriptLine(5, 'First big moment.'),
+      transcriptLine(20, 'Second big moment.'),
+      transcriptLine(40, 'Third moment, a bit weaker.')
+    ]
+    const chat = [
+      chatMessage(5.2, 'a'),
+      chatMessage(5.4, 'b'),
+      chatMessage(5.6, 'c'),
+      chatMessage(5.8, 'd'),
+      chatMessage(6, 'e'),
+      chatMessage(20.2, 'f'),
+      chatMessage(20.4, 'g'),
+      chatMessage(20.6, 'h'),
+      chatMessage(20.8, 'i'),
+      chatMessage(40.2, 'j'),
+      chatMessage(40.4, 'k'),
+      chatMessage(40.6, 'l')
+    ]
+
+    const candidates = selectSparkCandidates(transcript, chat, posterCount)
+
+    expect(candidates).toHaveLength(MAX_RECEPTIONS)
+    expect(candidates.map((candidate) => candidate.reactionVolume)).toEqual([5, 4])
+  })
+
+  it('counts only participant messages in the reaction, not the bot', () => {
+    const transcript = [transcriptLine(5, 'Something that drew people in.')]
+    const chat = [
+      chatMessage(5.3, 'I have a question about that'),
+      chatMessage(5.6, 'me too'),
+      chatMessage(5.9, 'same here'),
+      chatMessage(5.5, 'Great question! Here is my take.', { fromAgent: true }),
+      chatMessage(6.1, 'Happy to expand on that.', { fromAgent: true })
+    ]
+
+    const candidates = selectSparkCandidates(transcript, chat, posterCount)
+
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].reactionVolume).toBe(3)
+    expect(candidates[0].reactionChat.every((message) => !message.fromAgent)).toBe(true)
+  })
+})
+
+describe('groundReception', () => {
+  function candidate() {
+    return {
+      sparkMessage: { body: 'We should ban gas stoves entirely.', channels: ['transcript'] },
+      reactionVolume: 4,
+      reactionChat: [{ body: 'No way, gas is better for cooking' }, { body: 'agreed, electric is the future' }]
+    }
+  }
+
+  it('keeps a reception when both quotes are real and the sentiment is valid', () => {
+    const result = groundReception(candidate(), {
+      sparkQuote: 'ban gas stoves',
+      reactionQuote: 'No way, gas is better for cooking',
+      sentiment: 'pushback'
+    })
+
+    expect(result).toEqual({
+      sparkQuote: 'ban gas stoves',
+      reactionVolume: 4,
+      reactionQuote: 'No way, gas is better for cooking',
+      sentiment: 'pushback'
+    })
+  })
+
+  it('drops a reception whose spark quote is not in the transcript line', () => {
+    const result = groundReception(candidate(), {
+      sparkQuote: 'tax carbon heavily',
+      reactionQuote: 'No way, gas is better for cooking',
+      sentiment: 'pushback'
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('drops a reception whose reaction quote was never said', () => {
+    const result = groundReception(candidate(), {
+      sparkQuote: 'ban gas stoves',
+      reactionQuote: 'this is totally made up',
+      sentiment: 'agreement'
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('drops a reception with an unrecognized sentiment label', () => {
+    const result = groundReception(candidate(), {
+      sparkQuote: 'ban gas stoves',
+      reactionQuote: 'No way, gas is better for cooking',
+      sentiment: 'angry'
+    })
+
+    expect(result).toBeNull()
+  })
+})

--- a/tests/unit/agents/vibesAnalyst/spikeAnnotation.test.ts
+++ b/tests/unit/agents/vibesAnalyst/spikeAnnotation.test.ts
@@ -1,0 +1,173 @@
+import {
+  groundAnnotation,
+  isQuotableChat,
+  isQuotableModerator,
+  messagesDuringSpike,
+  quoteAppearsIn,
+  spikeQuotePool,
+  topSpikesBySignificance
+} from '../../../../src/agents/vibesAnalyst/spikeAnnotation.js'
+import { ChatSpike, SpikeSource } from '../../../../src/types/index.types.js'
+
+const EVENT_START = new Date('2026-06-10T10:00:00.000Z')
+const at = (minutes: number) => new Date(EVENT_START.getTime() + minutes * 60 * 1000)
+
+function spike(startMinute: number, messageCount: number, ratio: number | null, source: SpikeSource = 'chat'): ChatSpike {
+  return {
+    label: `${startMinute}-${startMinute + 10}`,
+    startMinute,
+    endMinute: startMinute + 10,
+    messageCount,
+    baselineAverage: ratio === null ? 0 : messageCount / ratio,
+    ratio,
+    source
+  }
+}
+
+describe('messagesDuringSpike', () => {
+  const windowSpike = spike(20, 5, 5)
+
+  it('keeps only messages whose timestamp falls inside the spike window', () => {
+    const messages = [
+      { body: 'before', createdAt: at(19) },
+      { body: 'at start', createdAt: at(20) },
+      { body: 'inside', createdAt: at(25) },
+      { body: 'at end', createdAt: at(30) },
+      { body: 'after', createdAt: at(31) }
+    ]
+
+    const inWindow = messagesDuringSpike(messages, EVENT_START, windowSpike)
+
+    // Start is inclusive, end is exclusive, matching how buckets are assigned.
+    expect(inWindow.map((m) => m.body)).toEqual(['at start', 'inside'])
+  })
+})
+
+describe('isQuotableChat', () => {
+  it('keeps a participant line posted in the public chat', () => {
+    expect(isQuotableChat({ body: 'hi', fromAgent: false, channels: ['chat'] })).toBe(true)
+  })
+
+  it('rejects a transcript speaker line, so a chat spike never quotes the transcript', () => {
+    expect(isQuotableChat({ body: 'hi', fromAgent: false, channels: ['transcript'] })).toBe(false)
+  })
+
+  it('rejects a moderator backchannel line', () => {
+    expect(isQuotableChat({ body: 'hi', fromAgent: false, channels: ['moderator'] })).toBe(false)
+  })
+
+  it('rejects a bot message even when it is on the chat channel', () => {
+    expect(isQuotableChat({ body: 'hi', fromAgent: true, channels: ['chat'] })).toBe(false)
+  })
+
+  it('rejects a message with no channel', () => {
+    expect(isQuotableChat({ body: 'hi', fromAgent: false })).toBe(false)
+  })
+})
+
+describe('isQuotableModerator', () => {
+  it('keeps a participant line in the moderator backchannel', () => {
+    expect(isQuotableModerator({ body: 'hi', fromAgent: false, channels: ['moderator'] })).toBe(true)
+  })
+
+  it('rejects a public chat line, so a moderator spike never quotes the chat', () => {
+    expect(isQuotableModerator({ body: 'hi', fromAgent: false, channels: ['chat'] })).toBe(false)
+  })
+
+  it('rejects a bot message even when it is on the moderator channel', () => {
+    expect(isQuotableModerator({ body: 'hi', fromAgent: true, channels: ['moderator'] })).toBe(false)
+  })
+})
+
+describe('spikeQuotePool', () => {
+  const chatLine = { body: 'public', fromAgent: false, channels: ['chat'] }
+  const moderatorLine = { body: 'backchannel', fromAgent: false, channels: ['moderator'] }
+  const messages = [chatLine, moderatorLine]
+
+  it('offers only the chat lines for a chat-source spike', () => {
+    expect(spikeQuotePool(messages, 'chat')).toEqual([chatLine])
+  })
+
+  it('offers only the moderator lines for a moderator-source spike', () => {
+    expect(spikeQuotePool(messages, 'moderator')).toEqual([moderatorLine])
+  })
+
+  it('offers nothing for a private-source spike, whose messages are never read', () => {
+    expect(spikeQuotePool(messages, 'private')).toEqual([])
+  })
+})
+
+describe('quoteAppearsIn', () => {
+  const messages = [
+    { body: 'The layoffs hit the whole team at once.', createdAt: at(21) },
+    { body: { kind: 'image', url: 'x' }, createdAt: at(22) }
+  ]
+
+  it('matches a verbatim quote', () => {
+    expect(quoteAppearsIn('The layoffs hit the whole team at once.', messages)).toBe(true)
+  })
+
+  it('matches despite whitespace and case differences', () => {
+    expect(quoteAppearsIn('the LAYOFFS   hit the whole team', messages)).toBe(true)
+  })
+
+  it('rejects a quote that is not present', () => {
+    expect(quoteAppearsIn('we doubled revenue this quarter', messages)).toBe(false)
+  })
+
+  it('rejects an empty quote so it cannot trivially match', () => {
+    expect(quoteAppearsIn('   ', messages)).toBe(false)
+  })
+
+  it('ignores non-text message bodies', () => {
+    expect(quoteAppearsIn('image', messages)).toBe(false)
+  })
+})
+
+describe('groundAnnotation', () => {
+  const windowMessages = [{ body: 'The layoffs hit the whole team at once.', createdAt: at(21) }]
+
+  it('keeps a topic when its quote is verbatim window text', () => {
+    const annotation = groundAnnotation(
+      { topic: 'reaction to the layoffs', quote: 'The layoffs hit the whole team at once.' },
+      windowMessages
+    )
+
+    expect(annotation).toEqual({ topic: 'reaction to the layoffs', quote: 'The layoffs hit the whole team at once.' })
+  })
+
+  it('drops an annotation whose quote was never said', () => {
+    expect(groundAnnotation({ topic: 'good news', quote: 'we tripled revenue this quarter' }, windowMessages)).toBeNull()
+  })
+
+  it('drops an annotation with an empty topic', () => {
+    expect(groundAnnotation({ topic: '   ', quote: 'The layoffs hit the whole team at once.' }, windowMessages)).toBeNull()
+  })
+})
+
+describe('topSpikesBySignificance', () => {
+  const early = spike(0, 6, 2)
+  const middle = spike(20, 18, 9)
+  const silentBaseline = spike(40, 9, null)
+
+  it('ranks finite-ratio spikes above a zero-baseline spike, not below it', () => {
+    // silentBaseline has a null ratio (the rest of the event was silent). A null ratio
+    // must not be treated as infinitely significant, so both measured spikes outrank it
+    // and the highest ratio leads.
+    const ranked = topSpikesBySignificance([early, middle, silentBaseline], 3)
+    expect(ranked.map((s) => s.startMinute)).toEqual([20, 0, 40])
+  })
+
+  it('ranks a louder zero-baseline spike above a quieter one by raw message count', () => {
+    const quietSilent = spike(0, 4, null)
+    const loudSilent = spike(30, 12, null)
+
+    const top = topSpikesBySignificance([quietSilent, loudSilent], 1)
+    expect(top.map((s) => s.startMinute)).toEqual([30])
+  })
+
+  it('returns every spike when the cap exceeds the count', () => {
+    const top = topSpikesBySignificance([early, middle], 5)
+    expect(top).toHaveLength(2)
+  })
+})

--- a/tests/unit/agents/vibesAnalyst/summon.test.ts
+++ b/tests/unit/agents/vibesAnalyst/summon.test.ts
@@ -1,0 +1,146 @@
+import { jest } from '@jest/globals'
+
+/* Event resolution (LLM extraction, candidate lookup, fuzzy matching) and the card
+   pipeline are each tested in their own files. Here we mock them to drive handleSummon
+   through its branches and check the wiring: which event it reads, what it replies, and
+   that the access re-check stops a private event from ever being read. The access gate
+   itself is the real one. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockExtract = jest.fn<(...args: any[]) => Promise<any>>()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFindCandidates = jest.fn<(...args: any[]) => Promise<any>>()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockResolve = jest.fn<(...args: any[]) => any>()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockBuildSummary = jest.fn<(...args: any[]) => Promise<any>>()
+
+jest.unstable_mockModule('../src/agents/vibesAnalyst/eventResolution.js', () => ({
+  extractEventReference: mockExtract,
+  findCandidatePublicEvents: mockFindCandidates,
+  resolveSummonedEvent: mockResolve
+}))
+jest.unstable_mockModule('../src/agents/vibesAnalyst/buildSummary.js', () => ({
+  default: mockBuildSummary
+}))
+
+const {
+  default: handleSummon,
+  notFoundMessage,
+  ambiguousMessage
+} = await import('../../../../src/agents/vibesAnalyst/summon.js')
+const { default: Conversation } = await import('../../../../src/models/conversation.model.js')
+
+describe('handleSummon', () => {
+  const vibesChannel = { name: 'vibesAnalyst' }
+  const fakeLlm = { fakeLlm: true }
+  const summonMessage = { _id: 'summon-msg', body: '@Vibes recap the Spring Town Hall' }
+
+  // A fake agent context: __t marks it as an Agent for the access check, and the
+  // allPublicTopics read grant covers any public event but no private one. The extra
+  // channel proves the reply is filtered to the analyst's own channel.
+  function buildContext() {
+    return {
+      __t: 'Agent',
+      capabilities: { read: [{ type: 'allPublicTopics' }], write: [{ type: 'ownConversation' }] },
+      conversation: { _id: 'va-conv', channels: [vibesChannel, { name: 'noise' }] }
+    }
+  }
+
+  function mockResolvedConversation(topicPrivate: boolean) {
+    jest.spyOn(Conversation, 'findById').mockReturnValue({
+      populate: jest.fn<() => Promise<unknown>>().mockResolvedValue({
+        _id: 'c1',
+        name: 'Spring Town Hall',
+        topic: { _id: 't1', private: topicPrivate }
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+  }
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    mockExtract.mockReset()
+    mockExtract.mockResolvedValue({ eventQuery: 'Spring Town Hall', latestInTopic: false })
+    mockFindCandidates.mockReset()
+    mockFindCandidates.mockResolvedValue([])
+    mockResolve.mockReset()
+    mockBuildSummary.mockReset()
+    mockBuildSummary.mockResolvedValue({ header: 'Recap' })
+  })
+
+  it('posts the engagement card threaded under the summon when the event resolves', async () => {
+    mockResolve.mockReturnValue({ status: 'resolved', event: { id: 'c1', name: 'Spring Town Hall' } })
+    mockResolvedConversation(false)
+    const verifiedCard = { header: 'Recap', standouts: [] }
+    mockBuildSummary.mockResolvedValue(verifiedCard)
+
+    const responses = await handleSummon(buildContext(), summonMessage, fakeLlm)
+
+    // Reads the message the user sent, then builds the card from the resolved event.
+    expect(mockExtract).toHaveBeenCalledWith(summonMessage.body, fakeLlm)
+    expect(mockBuildSummary).toHaveBeenCalledWith(expect.objectContaining({ _id: 'c1' }), fakeLlm)
+
+    expect(responses).toHaveLength(1)
+    const [response] = responses
+    expect(response.responseKind).toBe('curatedVibesSummary')
+    expect(response.renderData).toBe(verifiedCard)
+    expect(response.parent).toBe('summon-msg') // threads under the question
+    expect(response.channels).toEqual([vibesChannel]) // only the analyst's own channel
+    expect(response.message).toContain('Spring Town Hall')
+  })
+
+  it('asks for a clearer name and reads nothing when no public event matches', async () => {
+    mockResolve.mockReturnValue({ status: 'notFound' })
+
+    const responses = await handleSummon(buildContext(), summonMessage, fakeLlm)
+
+    expect(responses).toHaveLength(1)
+    expect(responses[0].message).toBe(notFoundMessage('Spring Town Hall', []))
+    expect(responses[0].parent).toBe('summon-msg')
+    expect(responses[0].responseKind).toBeUndefined()
+    expect(mockBuildSummary).not.toHaveBeenCalled()
+  })
+
+  it('lists recent public events when nothing matches but there are events to suggest', async () => {
+    mockExtract.mockResolvedValue({ eventQuery: 'past 2 events', latestInTopic: false, latestOverall: false })
+    mockFindCandidates.mockResolvedValue([
+      { id: '1', name: 'Mushrooms and the Future', topicName: 'Regenerative Futures', endTime: new Date('2026-06-10') },
+      { id: '2', name: 'Soil Health 101', topicName: 'Regenerative Futures', endTime: new Date('2026-06-03') }
+    ])
+    mockResolve.mockReturnValue({ status: 'notFound' })
+
+    const responses = await handleSummon(buildContext(), summonMessage, fakeLlm)
+
+    expect(responses[0].message).toContain('Mushrooms and the Future')
+    expect(responses[0].message).toContain('Soil Health 101')
+    expect(mockBuildSummary).not.toHaveBeenCalled()
+  })
+
+  it('lists the options when several public events match', async () => {
+    const candidates = [
+      { id: '1', name: 'Spring Town Hall' },
+      { id: '2', name: 'Fall Town Hall' }
+    ]
+    mockResolve.mockReturnValue({ status: 'ambiguous', candidates })
+
+    const responses = await handleSummon(buildContext(), summonMessage, fakeLlm)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(responses[0].message).toBe(ambiguousMessage(candidates as any))
+    expect(responses[0].message).toContain('Spring Town Hall')
+    expect(responses[0].message).toContain('Fall Town Hall')
+    expect(mockBuildSummary).not.toHaveBeenCalled()
+  })
+
+  it('refuses and never reads content when the resolved event is on a private topic', async () => {
+    mockResolve.mockReturnValue({ status: 'resolved', event: { id: 'c1', name: 'Spring Town Hall' } })
+    mockResolvedConversation(true) // private topic, beyond the allPublicTopics grant
+
+    const responses = await handleSummon(buildContext(), summonMessage, fakeLlm)
+
+    expect(responses).toHaveLength(1)
+    expect(responses[0].responseKind).toBeUndefined()
+    expect(responses[0].message).toContain('can only recap public events')
+    expect(mockBuildSummary).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/agents/vibesAnalyst/verifyCuration.test.ts
+++ b/tests/unit/agents/vibesAnalyst/verifyCuration.test.ts
@@ -15,9 +15,14 @@ function metricsFixture(): ConversationMetrics {
       { label: '10-20', messageCount: 15 },
       { label: '20-30', messageCount: 30 }
     ],
+    spikes: [],
     participationHistory: [],
     baseline: null,
-    channelSplit: { public: 30, private: 20 }
+    channelSplit: { public: 30, private: 20 },
+    botInvocations: { botName: 'Berkie', count: 0 },
+    receptions: [],
+    resourceSummary: { total: 0, required: 0, referenced: 0, suggested: 0, withLinks: 0 },
+    eventPlatform: 'nextspace'
   }
 }
 

--- a/tests/unit/agents/vibesAnalyst/vibesAnalyst.agent.test.ts
+++ b/tests/unit/agents/vibesAnalyst/vibesAnalyst.agent.test.ts
@@ -14,12 +14,32 @@ const mockGetModelChat = jest.fn<(...args: any[]) => Promise<any>>()
 // agent runs it, off the stop path, before reading metrics.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockFetchAndStoreSnapshot = jest.fn<(...args: any[]) => Promise<void>>()
+// Spike annotation is exercised in spikeAnnotation tests; here we only check the
+// agent reads the allowed messages and feeds the annotated spikes to the curator.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockAnnotateSpikes = jest.fn<(...args: any[]) => Promise<any>>()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockLoadReadableMessages = jest.fn<(...args: any[]) => Promise<any>>()
+// Reception annotation is exercised in quoteReception tests; here we only check the
+// agent feeds the allowed messages and poster count in, and the receptions to the curator.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockAnnotateReceptions = jest.fn<(...args: any[]) => Promise<any>>()
 
 jest.unstable_mockModule('../src/agents/vibesAnalyst/curate.js', () => ({
   default: mockCurate
 }))
 jest.unstable_mockModule('../src/agents/vibesAnalyst/verifyCuration.js', () => ({
   default: mockVerify
+}))
+jest.unstable_mockModule('../src/agents/vibesAnalyst/spikeAnnotation.js', () => ({
+  default: mockAnnotateSpikes
+}))
+jest.unstable_mockModule('../src/agents/vibesAnalyst/quoteReception.js', () => ({
+  default: mockAnnotateReceptions
+}))
+jest.unstable_mockModule('../src/agents/vibesAnalyst/capabilities.js', () => ({
+  default: () => ({ read: [], write: [] }),
+  loadReadableMessages: mockLoadReadableMessages
 }))
 jest.unstable_mockModule('../src/agents/helpers/getModelChat.js', () => ({
   getModelChat: mockGetModelChat,
@@ -65,7 +85,8 @@ describe('vibesAnalyst agent', () => {
     }
 
     const sampleMetrics = {
-      participation: { posterCount: 5, frequentPosterCount: 1, frequentPosterMessageShare: 0.4, messageCount: 20 }
+      participation: { posterCount: 5, frequentPosterCount: 1, frequentPosterMessageShare: 0.4, messageCount: 20 },
+      spikes: []
     }
     const verifiedCard = { header: 'Recap', standouts: [{ text: 'Half spoke up' }], durationMinutes: 60 }
 
@@ -82,6 +103,22 @@ describe('vibesAnalyst agent', () => {
       } as any)
     }
 
+    /* A conversation whose topic did not populate (e.g. it was deleted between
+       dispatch and this job running). The read-site re-check must fail closed and
+       treat the unknown privacy as private. */
+    function mockStoppedConversationWithMissingTopic() {
+      jest.spyOn(Conversation, 'findById').mockReturnValue({
+        populate: jest.fn<() => Promise<unknown>>().mockResolvedValue({
+          _id: 'c1',
+          name: 'The Future of Work',
+          startTime: new Date('2026-06-10T10:00:00.000Z'),
+          endTime: new Date('2026-06-10T11:00:00.000Z'),
+          topic: undefined
+        })
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+    }
+
     beforeEach(() => {
       jest.restoreAllMocks()
       mockCurate.mockReset()
@@ -90,6 +127,13 @@ describe('vibesAnalyst agent', () => {
       mockGetModelChat.mockResolvedValue({ fakeLlm: true })
       mockFetchAndStoreSnapshot.mockReset()
       mockFetchAndStoreSnapshot.mockResolvedValue(undefined)
+      mockLoadReadableMessages.mockReset()
+      mockLoadReadableMessages.mockResolvedValue([])
+      mockAnnotateSpikes.mockReset()
+      // By default, pass the spikes straight through so the wiring is transparent.
+      mockAnnotateSpikes.mockImplementation((_messages, _start, spikes) => Promise.resolve(spikes))
+      mockAnnotateReceptions.mockReset()
+      mockAnnotateReceptions.mockResolvedValue([])
     })
 
     it('returns empty for non-conversationStopped events', async () => {
@@ -138,6 +182,76 @@ describe('vibesAnalyst agent', () => {
       expect(response.channels).toEqual([adminChannel])
     })
 
+    it('annotates spikes from the allowed messages before curating, when the event had spikes', async () => {
+      mockStoppedConversation(false)
+      const rawSpike = { label: '20-30', startMinute: 20, endMinute: 30, messageCount: 8, baselineAverage: 1, ratio: 8 }
+      const spikeMetrics = { participation: { posterCount: 5 }, spikes: [rawSpike] }
+      jest
+        .spyOn(conversationAnalyticsService, 'computeConversationMetrics')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockResolvedValue(spikeMetrics as any)
+
+      const readableMessages = [{ body: 'remote work is banned now?', createdAt: new Date('2026-06-10T10:21:00.000Z') }]
+      mockLoadReadableMessages.mockResolvedValue(readableMessages)
+      const annotatedSpikes = [
+        { ...rawSpike, annotation: { topic: 'remote work policy', quote: 'remote work is banned now?' } }
+      ]
+      mockAnnotateSpikes.mockResolvedValue(annotatedSpikes)
+      mockCurate.mockResolvedValue({ header: 'Draft', standouts: [], durationMinutes: 60 })
+      mockVerify.mockResolvedValue(verifiedCard)
+
+      await vibesAnalyst.onConversationEvent.call(buildContext(), {
+        type: 'conversationStopped',
+        conversationId: 'c1',
+        topicId: 't1'
+      })
+
+      // Reads only the allowed messages for this conversation, then hands them and the
+      // raw spikes to the annotator with the event start.
+      expect(mockLoadReadableMessages).toHaveBeenCalledWith('c1')
+      expect(mockAnnotateSpikes).toHaveBeenCalledWith(readableMessages, expect.any(Date), [rawSpike], { fakeLlm: true })
+      // The curator sees the annotated spikes, not the bare ones.
+      expect(mockCurate).toHaveBeenCalledWith(expect.objectContaining({ spikes: annotatedSpikes }), expect.anything(), {
+        fakeLlm: true
+      })
+    })
+
+    it('annotates receptions from the allowed messages before curating', async () => {
+      mockStoppedConversation(false)
+      const receptionMetrics = { participation: { posterCount: 12 }, spikes: [] }
+      jest
+        .spyOn(conversationAnalyticsService, 'computeConversationMetrics')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockResolvedValue(receptionMetrics as any)
+
+      const readableMessages = [
+        {
+          body: 'we should ban gas stoves entirely',
+          channels: ['transcript'],
+          createdAt: new Date('2026-06-10T10:05:00.000Z')
+        }
+      ]
+      mockLoadReadableMessages.mockResolvedValue(readableMessages)
+      const receptions = [
+        { sparkQuote: 'ban gas stoves', reactionVolume: 7, reactionQuote: 'no way', sentiment: 'pushback' }
+      ]
+      mockAnnotateReceptions.mockResolvedValue(receptions)
+      mockCurate.mockResolvedValue({ header: 'Draft', standouts: [], durationMinutes: 60 })
+      mockVerify.mockResolvedValue(verifiedCard)
+
+      await vibesAnalyst.onConversationEvent.call(buildContext(), {
+        type: 'conversationStopped',
+        conversationId: 'c1',
+        topicId: 't1'
+      })
+
+      // Reads the allowed messages once and hands them, with the poster count, to the annotator.
+      expect(mockLoadReadableMessages).toHaveBeenCalledWith('c1')
+      expect(mockAnnotateReceptions).toHaveBeenCalledWith(readableMessages, 12, { fakeLlm: true })
+      // The curator sees the receptions the annotator produced.
+      expect(mockCurate).toHaveBeenCalledWith(expect.objectContaining({ receptions }), expect.anything(), { fakeLlm: true })
+    })
+
     it('throws AccessDeniedError and reads no metrics when the event is on a private topic', async () => {
       mockStoppedConversation(true)
       const computeSpy = jest.spyOn(conversationAnalyticsService, 'computeConversationMetrics')
@@ -151,6 +265,21 @@ describe('vibesAnalyst agent', () => {
       ).rejects.toThrow(AccessDeniedError)
       expect(computeSpy).not.toHaveBeenCalled()
       // Access is checked before any work, so no snapshot fetch on a private event.
+      expect(mockFetchAndStoreSnapshot).not.toHaveBeenCalled()
+    })
+
+    it('throws AccessDeniedError and reads no metrics when the topic did not populate', async () => {
+      mockStoppedConversationWithMissingTopic()
+      const computeSpy = jest.spyOn(conversationAnalyticsService, 'computeConversationMetrics')
+
+      await expect(
+        vibesAnalyst.onConversationEvent.call(buildContext(), {
+          type: 'conversationStopped',
+          conversationId: 'c1',
+          topicId: 't1'
+        })
+      ).rejects.toThrow(AccessDeniedError)
+      expect(computeSpy).not.toHaveBeenCalled()
       expect(mockFetchAndStoreSnapshot).not.toHaveBeenCalled()
     })
   })

--- a/tests/unit/agents/vibesAnalyst/vibesAnalyst.respond.test.ts
+++ b/tests/unit/agents/vibesAnalyst/vibesAnalyst.respond.test.ts
@@ -1,0 +1,102 @@
+import { jest } from '@jest/globals'
+
+/* Covers the summon entry points on the agent itself: evaluate's mention handling and
+   respond's gate. The intent check and the summon handler are mocked so the gate is
+   deterministic (the real handler is exercised in summon.test.ts, the real intent check
+   in intentChecks tests). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCheckBotIntent = jest.fn<(...args: any[]) => Promise<boolean>>()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockMatchBotMention = jest.fn<(...args: any[]) => boolean>()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockNormalizeBotMention = jest.fn<(...args: any[]) => string>()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockHandleSummon = jest.fn<(...args: any[]) => Promise<any>>()
+
+jest.unstable_mockModule('../src/agents/helpers/intentChecks.js', () => ({
+  checkBotIntent: mockCheckBotIntent,
+  matchBotMention: mockMatchBotMention,
+  normalizeBotMention: mockNormalizeBotMention
+}))
+jest.unstable_mockModule('../src/agents/vibesAnalyst/summon.js', () => ({
+  default: mockHandleSummon
+}))
+
+const { default: vibesAnalyst } = await import('../../../../src/agents/vibesAnalyst/index.js')
+const { AgentMessageActions } = await import('../../../../src/types/index.types.js')
+
+describe('vibesAnalyst evaluate', () => {
+  const context = { agentConfig: { botName: 'Vibes' } }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('normalizes the mention and contributes when the message names the bot', async () => {
+    mockMatchBotMention.mockReturnValue(true)
+    mockNormalizeBotMention.mockReturnValue('@Vibes recap the town hall')
+
+    const result = await vibesAnalyst.evaluate.call(context, { body: '@vibez recap the town hall', _id: 'm1' })
+
+    expect(result.action).toBe(AgentMessageActions.CONTRIBUTE)
+    expect(result.userContributionVisible).toBe(true)
+    expect(result.userMessage.body).toBe('@Vibes recap the town hall')
+  })
+
+  it('contributes the message untouched when it does not name the bot, leaving the decision to respond', async () => {
+    mockMatchBotMention.mockReturnValue(false)
+    const message = { body: 'just chatting', _id: 'm2' }
+
+    const result = await vibesAnalyst.evaluate.call(context, message)
+
+    expect(result.action).toBe(AgentMessageActions.CONTRIBUTE)
+    expect(result.userMessage).toBe(message)
+    expect(mockNormalizeBotMention).not.toHaveBeenCalled()
+  })
+})
+
+describe('vibesAnalyst respond', () => {
+  const fakeLlm = { fakeLlm: true }
+
+  function buildContext() {
+    return {
+      agentConfig: { botName: 'Vibes' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getLLM: jest.fn<() => Promise<any>>().mockResolvedValue(fakeLlm),
+      conversation: { channels: [{ name: 'vibesAnalyst' }] }
+    }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('stays silent when the message is not addressed to it', async () => {
+    mockCheckBotIntent.mockResolvedValue(false)
+
+    const responses = await vibesAnalyst.respond.call(buildContext(), undefined, { body: 'hello', _id: 'm1' })
+
+    expect(responses).toEqual([])
+    expect(mockHandleSummon).not.toHaveBeenCalled()
+  })
+
+  it('hands off to the summon handler when addressed', async () => {
+    mockCheckBotIntent.mockResolvedValue(true)
+    const summonResult = [{ visible: true, message: 'card' }]
+    mockHandleSummon.mockResolvedValue(summonResult)
+    const context = buildContext()
+    const message = { body: '@Vibes recap town hall', _id: 'm1' }
+
+    const responses = await vibesAnalyst.respond.call(context, undefined, message)
+
+    expect(responses).toBe(summonResult)
+    expect(mockHandleSummon).toHaveBeenCalledWith(context, message, fakeLlm)
+  })
+
+  it('returns empty without checking intent when there is no user message', async () => {
+    const responses = await vibesAnalyst.respond.call(buildContext(), undefined, null)
+
+    expect(responses).toEqual([])
+    expect(mockCheckBotIntent).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/services/conversationAnalytics.service.test.ts
+++ b/tests/unit/services/conversationAnalytics.service.test.ts
@@ -1,7 +1,14 @@
 import mongoose from 'mongoose'
 import setupIntTest from '../../utils/setupIntTest.js'
 import { Conversation, Message, ConversationAnalytics, Channel } from '../../../src/models/index.js'
-import conversationAnalyticsService from '../../../src/services/conversationAnalytics.service.js'
+import conversationAnalyticsService, {
+  attributeSpikeSources,
+  computeResourceSummary,
+  deriveEventPlatform,
+  spikeSourceForChannels
+} from '../../../src/services/conversationAnalytics.service.js'
+import { ChatSpike } from '../../../src/types/index.types.js'
+import config from '../../../src/config/config.js'
 
 setupIntTest()
 
@@ -92,6 +99,29 @@ async function seedMessageAt(
   await Message.collection.updateOne({ _id: message._id }, { $set: { createdAt } })
 }
 
+/* Seeds one participant message on the given channels at a set minute past the event
+   start, so a spike can be built from a specific channel like a private 1:1. */
+async function seedMessageOnChannelAt(
+  conversationId: mongoose.Types.ObjectId,
+  start: Date,
+  minutesFromStart: number,
+  channels: string[]
+) {
+  const [message] = await Message.create([
+    {
+      body: 'm',
+      conversation: conversationId,
+      owner: ownerId,
+      pseudonymId: ownerId,
+      pseudonym: 'ana',
+      fromAgent: false,
+      channels
+    }
+  ])
+  const createdAt = new Date(start.getTime() + minutesFromStart * 60 * 1000)
+  await Message.collection.updateOne({ _id: message._id }, { $set: { createdAt } })
+}
+
 describe('computeConversationMetrics', () => {
   it('computes participation from Mongo and derives attention ratios from the snapshot', async () => {
     const conversation = await makeConversation()
@@ -109,8 +139,9 @@ describe('computeConversationMetrics', () => {
 
     const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
 
-    expect(metrics.participation).toMatchObject({ posterCount: 2, frequentPosterCount: 1, messageCount: 3 })
-    expect(metrics.participation.frequentPosterMessageShare).toBeCloseTo(2 / 3, 5)
+    // Two posters is below the handful threshold, so no frequent posters and a null share.
+    expect(metrics.participation).toMatchObject({ posterCount: 2, frequentPosterCount: 0, messageCount: 3 })
+    expect(metrics.participation.frequentPosterMessageShare).toBeNull()
     expect(metrics.audienceEngagement).toEqual({
       participantCount: 40,
       lurkerCount: 38,
@@ -133,8 +164,8 @@ describe('computeConversationMetrics', () => {
 
     const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
 
-    expect(metrics.participation).toMatchObject({ posterCount: 2, frequentPosterCount: 1, messageCount: 3 })
-    expect(metrics.participation.frequentPosterMessageShare).toBeCloseTo(2 / 3, 5)
+    expect(metrics.participation).toMatchObject({ posterCount: 2, frequentPosterCount: 0, messageCount: 3 })
+    expect(metrics.participation.frequentPosterMessageShare).toBeNull()
     expect(metrics.audienceEngagement).toBeNull()
     expect(metrics.trackedSessionSources).toEqual([])
     expect(metrics.trackedSessionStatus).toBe('notTracked')
@@ -239,8 +270,37 @@ describe('computeConversationMetrics pseudonym rotation', () => {
 
     expect(metrics.participation.posterCount).toBe(1)
     expect(metrics.participation.messageCount).toBe(2)
-    expect(metrics.participation.frequentPosterCount).toBe(1)
-    expect(metrics.participation.frequentPosterMessageShare).toBe(1)
+    expect(metrics.participation.frequentPosterCount).toBe(0)
+    expect(metrics.participation.frequentPosterMessageShare).toBeNull()
+  })
+
+  it('counts an owner-less guest with one pseudonym id but differing display names as one poster', async () => {
+    const conversation = await makeConversation()
+    const guestPseudonymId = new mongoose.Types.ObjectId()
+    /* Two messages from one guest (no owner). The display pseudonym differs between them
+       but the pseudonym id is the same, so the stable id, not the string, proves they are
+       one person. */
+    await Message.create([
+      {
+        body: 'first',
+        conversation: conversation._id,
+        pseudonymId: guestPseudonymId,
+        pseudonym: 'guest-a',
+        fromAgent: false
+      },
+      {
+        body: 'second',
+        conversation: conversation._id,
+        pseudonymId: guestPseudonymId,
+        pseudonym: 'guest-b',
+        fromAgent: false
+      }
+    ])
+
+    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+
+    expect(metrics.participation.posterCount).toBe(1)
+    expect(metrics.participation.messageCount).toBe(2)
   })
 })
 
@@ -255,6 +315,63 @@ describe('computeConversationMetrics frequent posters', () => {
     expect(metrics.participation.frequentPosterCount).toBe(2) // ceil(0.1 * 12)
     expect(metrics.participation.messageCount).toBe(20)
     expect(metrics.participation.frequentPosterMessageShare).toBeCloseTo(0.5, 5) // 10 of 20
+  })
+
+  it('reports a null share and no frequent posters below a handful of posters', async () => {
+    const conversation = await makeConversation()
+    // Only one poster, well below the handful threshold, so a dominance share is meaningless.
+    await Message.create([
+      {
+        body: 'solo',
+        conversation: conversation._id,
+        owner: ownerFor('solo'),
+        pseudonymId: ownerId,
+        pseudonym: 'solo',
+        fromAgent: false
+      }
+    ])
+
+    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+
+    expect(metrics.participation.posterCount).toBe(1)
+    expect(metrics.participation.frequentPosterCount).toBe(0)
+    expect(metrics.participation.frequentPosterMessageShare).toBeNull()
+  })
+
+  it('includes every poster tied at the cutoff message count, not just the top slice', async () => {
+    const conversation = await makeConversation()
+    // Six posters: three tie at five messages each, three send one each (18 total). The
+    // top 10% of 6 is ceil(0.6) = 1, but two more posters tie that busiest at five, so a
+    // tie-aware cut includes all three heavy posters rather than picking one arbitrarily.
+    const heavy = ['h1', 'h2', 'h3']
+    const light = ['l1', 'l2', 'l3']
+    await Message.create([
+      ...heavy.flatMap((pseudonym) =>
+        Array.from({ length: 5 }, () => ({
+          body: 'm',
+          conversation: conversation._id,
+          owner: ownerFor(pseudonym),
+          pseudonymId: ownerId,
+          pseudonym,
+          fromAgent: false
+        }))
+      ),
+      ...light.map((pseudonym) => ({
+        body: 'm',
+        conversation: conversation._id,
+        owner: ownerFor(pseudonym),
+        pseudonymId: ownerId,
+        pseudonym,
+        fromAgent: false
+      }))
+    ])
+
+    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+
+    expect(metrics.participation.posterCount).toBe(6)
+    expect(metrics.participation.frequentPosterCount).toBe(3) // all three tied at five, not ceil(0.6)=1
+    expect(metrics.participation.messageCount).toBe(18)
+    expect(metrics.participation.frequentPosterMessageShare).toBeCloseTo(15 / 18, 5)
   })
 })
 
@@ -323,14 +440,34 @@ describe('computeConversationMetrics activity buckets', () => {
     const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
 
     expect(metrics.activitySeries.map((bucket) => bucket.label)).toEqual([
-      '0-10',
-      '10-20',
-      '20-30',
-      '30-40',
-      '40-50',
-      '50-58'
+      '0-9',
+      '10-19',
+      '20-29',
+      '30-39',
+      '40-49',
+      '50-57'
     ])
     expect(metrics.activitySeries.map((bucket) => bucket.messageCount)).toEqual([1, 2, 1, 0, 0, 0])
+  })
+
+  it('labels adjacent windows so they never share a boundary number', async () => {
+    const start = new Date('2026-06-10T10:00:00.000Z')
+    const end = new Date(start.getTime() + 58 * 60 * 1000)
+    const conversation = await makeConversationWithWindow(start, end)
+
+    await seedMessageAt(conversation._id, start, 5)
+    await seedMessageAt(conversation._id, start, 25)
+
+    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+    const labels = metrics.activitySeries.map((bucket) => bucket.label)
+
+    // Pull the trailing number of one label and the leading number of the next; an
+    // inclusive-range scheme means they must differ, so minute N belongs to one window.
+    for (let index = 0; index < labels.length - 1; index += 1) {
+      const endOfThis = Number(labels[index].split('-').at(-1))
+      const startOfNext = Number(labels[index + 1].split('-')[0])
+      expect(endOfThis).not.toBe(startOfNext)
+    }
   })
 
   it('excludes messages sent before the event start or after the event end', async () => {
@@ -350,6 +487,19 @@ describe('computeConversationMetrics activity buckets', () => {
     expect(metrics.activitySeries.map((bucket) => bucket.messageCount)).toEqual([1, 0, 1, 0, 0, 0])
   })
 
+  it('collapses a zero-length window to a single-number label', async () => {
+    const start = new Date('2026-06-10T10:00:00.000Z')
+    // Start and end at the same minute, so the whole event is one zero-length window.
+    const conversation = await makeConversationWithWindow(start, start)
+
+    await seedMessageAt(conversation._id, start, 0)
+    await seedMessageAt(conversation._id, start, 0)
+
+    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+
+    expect(metrics.activitySeries).toEqual([{ label: '0', messageCount: 2 }])
+  })
+
   it('returns an empty activity series when the event has no messages', async () => {
     const start = new Date('2026-06-10T10:00:00.000Z')
     const end = new Date(start.getTime() + 30 * 60 * 1000)
@@ -358,6 +508,304 @@ describe('computeConversationMetrics activity buckets', () => {
     const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
 
     expect(metrics.activitySeries).toEqual([])
+  })
+})
+
+describe('computeConversationMetrics spikes', () => {
+  it('flags the busy window as a spike carrying its minute range', async () => {
+    const start = new Date('2026-06-10T10:00:00.000Z')
+    const end = new Date(start.getTime() + 58 * 60 * 1000)
+    const conversation = await makeConversationWithWindow(start, end)
+
+    // One message early, then a burst of six in the 20-30 window.
+    await seedMessageAt(conversation._id, start, 5)
+    for (const minute of [21, 22, 23, 24, 25, 26]) {
+      await seedMessageAt(conversation._id, start, minute)
+    }
+
+    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+
+    expect(metrics.spikes).toHaveLength(1)
+    expect(metrics.spikes[0]).toMatchObject({ startMinute: 20, endMinute: 30, messageCount: 6 })
+  })
+
+  it('reports no spikes for an evenly spread event', async () => {
+    const start = new Date('2026-06-10T10:00:00.000Z')
+    const end = new Date(start.getTime() + 58 * 60 * 1000)
+    const conversation = await makeConversationWithWindow(start, end)
+
+    for (const minute of [5, 15, 25, 35, 45]) {
+      await seedMessageAt(conversation._id, start, minute)
+    }
+
+    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+
+    expect(metrics.spikes).toEqual([])
+  })
+
+  it('marks a spike driven by private one-to-one messages as a private-source spike', async () => {
+    const start = new Date('2026-06-10T10:00:00.000Z')
+    const end = new Date(start.getTime() + 58 * 60 * 1000)
+    const conversation = await makeConversationWithWindow(start, end)
+    const directChannel = await Channel.create({
+      name: `dm-${new mongoose.Types.ObjectId().toString()}`,
+      direct: true,
+      participants: [new mongoose.Types.ObjectId(), new mongoose.Types.ObjectId()]
+    })
+
+    // One early public message, then a burst of six private messages to the bot.
+    await seedMessageAt(conversation._id, start, 5)
+    for (const minute of [21, 22, 23, 24, 25, 26]) {
+      await seedMessageOnChannelAt(conversation._id, start, minute, [directChannel.name])
+    }
+
+    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+
+    expect(metrics.spikes).toHaveLength(1)
+    expect(metrics.spikes[0].source).toBe('private')
+  })
+})
+
+/* A bare ChatSpike for the attribution unit tests: only the window and a placeholder
+   source matter, since attributeSpikeSources overwrites source from the messages. */
+function spikeWindow(startMinute: number, endMinute: number): ChatSpike {
+  return {
+    label: `${startMinute}-${endMinute}`,
+    startMinute,
+    endMinute,
+    messageCount: 6,
+    baselineAverage: 1,
+    ratio: 6,
+    source: 'chat'
+  }
+}
+
+describe('spikeSourceForChannels', () => {
+  const directNames = new Set(['dm-1'])
+
+  it('reads a public chat message as a chat source', () => {
+    expect(spikeSourceForChannels(['chat'], directNames)).toBe('chat')
+  })
+
+  it('reads a moderator backchannel message as a moderator source', () => {
+    expect(spikeSourceForChannels(['moderator'], directNames)).toBe('moderator')
+  })
+
+  it('reads a direct-channel message as a private source', () => {
+    expect(spikeSourceForChannels(['dm-1'], directNames)).toBe('private')
+  })
+
+  it('treats a message with no channel as public chat', () => {
+    expect(spikeSourceForChannels(undefined, directNames)).toBe('chat')
+  })
+})
+
+describe('attributeSpikeSources', () => {
+  const start = new Date('2026-06-10T10:00:00.000Z')
+  const at = (minutes: number) => new Date(start.getTime() + minutes * 60 * 1000)
+  const directNames = new Set(['dm-1'])
+
+  it('marks a spike private only when its window holds no readable messages', () => {
+    const messages = [
+      { createdAt: at(21), channels: ['dm-1'] },
+      { createdAt: at(22), channels: ['dm-1'] },
+      { createdAt: at(5), channels: ['chat'] } // outside the window, ignored
+    ]
+
+    const [attributed] = attributeSpikeSources([spikeWindow(20, 30)], messages, start, directNames)
+
+    expect(attributed.source).toBe('private')
+  })
+
+  it('attributes a mixed window to the dominant readable channel', () => {
+    const messages = [
+      { createdAt: at(21), channels: ['moderator'] },
+      { createdAt: at(22), channels: ['moderator'] },
+      { createdAt: at(23), channels: ['chat'] }
+    ]
+
+    const [attributed] = attributeSpikeSources([spikeWindow(20, 30)], messages, start, directNames)
+
+    expect(attributed.source).toBe('moderator')
+  })
+
+  it('prefers a readable channel over private when both are in the window', () => {
+    const messages = [
+      { createdAt: at(21), channels: ['dm-1'] },
+      { createdAt: at(22), channels: ['dm-1'] },
+      { createdAt: at(23), channels: ['chat'] }
+    ]
+
+    const [attributed] = attributeSpikeSources([spikeWindow(20, 30)], messages, start, directNames)
+
+    expect(attributed.source).toBe('chat')
+  })
+})
+
+describe('computeResourceSummary', () => {
+  it('counts visible readings by category and how many carry a link', () => {
+    const conversation = {
+      resources: [
+        { category: 'required', participantVisible: true, url: 'https://a' },
+        { category: 'required', participantVisible: true },
+        { category: 'referenced', participantVisible: true, url: 'https://b' },
+        { category: 'suggested', participantVisible: true }
+      ]
+    }
+
+    expect(computeResourceSummary(conversation)).toEqual({
+      total: 4,
+      required: 2,
+      referenced: 1,
+      suggested: 1,
+      withLinks: 2
+    })
+  })
+
+  it('excludes resources that participants could not see', () => {
+    const conversation = {
+      resources: [
+        { category: 'required', participantVisible: true, url: 'https://a' },
+        { category: 'referenced', participantVisible: false, url: 'https://b' }
+      ]
+    }
+
+    expect(computeResourceSummary(conversation)).toEqual({
+      total: 1,
+      required: 1,
+      referenced: 0,
+      suggested: 0,
+      withLinks: 1
+    })
+  })
+
+  it('returns zeros when the event has no resources', () => {
+    expect(computeResourceSummary({})).toEqual({ total: 0, required: 0, referenced: 0, suggested: 0, withLinks: 0 })
+  })
+})
+
+describe('deriveEventPlatform', () => {
+  it('reports both when the event ran on Nextspace and Zoom', () => {
+    expect(deriveEventPlatform({ platforms: ['nextspace', 'zoom'] })).toBe('both')
+  })
+
+  it('reports zoom for a Zoom-only event', () => {
+    expect(deriveEventPlatform({ platforms: ['zoom'] })).toBe('zoom')
+  })
+
+  it('reports nextspace for a Nextspace-only event', () => {
+    expect(deriveEventPlatform({ platforms: ['nextspace'] })).toBe('nextspace')
+  })
+
+  it('defaults to nextspace when no platform is recorded', () => {
+    expect(deriveEventPlatform({})).toBe('nextspace')
+  })
+})
+
+describe('computeConversationMetrics resources and platform', () => {
+  it('includes the visible resource summary and the event platform in the metrics', async () => {
+    const conversation = await Conversation.create({
+      name: 'Readings event',
+      slug: `readings-${new mongoose.Types.ObjectId().toString()}`,
+      owner: ownerId,
+      topic: new mongoose.Types.ObjectId(),
+      transcript: { status: 'stopped' },
+      platforms: ['nextspace', 'zoom'],
+      resources: [
+        { source: 'speaker', category: 'required', title: 'Required one', url: 'https://a', participantVisible: true },
+        { source: 'ai', category: 'suggested', title: 'Suggested one', participantVisible: true },
+        { source: 'speaker', category: 'referenced', title: 'Hidden ref', url: 'https://b', participantVisible: false }
+      ]
+    })
+
+    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+
+    // The hidden referenced resource drops out, so only the two visible ones count.
+    expect(metrics.resourceSummary).toEqual({ total: 2, required: 1, referenced: 0, suggested: 1, withLinks: 1 })
+    expect(metrics.eventPlatform).toBe('both')
+  })
+})
+
+/* Seeds one chat message with the given body. Defaults to a participant message in
+   the chat channel, where bot invocations happen. */
+async function seedChatMessage(
+  conversationId: mongoose.Types.ObjectId,
+  body: string,
+  options: { fromAgent?: boolean; channels?: string[]; visible?: boolean } = {}
+) {
+  const { fromAgent = false, channels = ['chat'], visible = true } = options
+  await Message.create([
+    {
+      body,
+      conversation: conversationId,
+      owner: ownerId,
+      pseudonymId: ownerId,
+      pseudonym: 'ana',
+      fromAgent,
+      channels,
+      visible
+    }
+  ])
+}
+
+describe('computeConversationMetrics bot invocations', () => {
+  it('counts participant chat messages that address the configured bot name', async () => {
+    const conversation = await Conversation.create({
+      name: 'Bot invocations event',
+      slug: `bot-${new mongoose.Types.ObjectId().toString()}`,
+      owner: ownerId,
+      topic: new mongoose.Types.ObjectId(),
+      properties: { botName: 'Athena' },
+      transcript: { status: 'stopped' }
+    })
+
+    await seedChatMessage(conversation._id, 'hey @Athena what did I miss?')
+    await seedChatMessage(conversation._id, 'athena, can you summarize?')
+    await seedChatMessage(conversation._id, 'athna are you there') // misspelling, fuzzy match
+    await seedChatMessage(conversation._id, 'this talk is great') // no mention
+    await seedChatMessage(conversation._id, 'good one Athena', { fromAgent: true }) // bot's own message
+    await seedChatMessage(conversation._id, 'ask Athena later', { channels: ['transcript'] }) // not chat
+
+    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+
+    expect(metrics.botInvocations).toEqual({ botName: 'Athena', count: 3 })
+  })
+
+  it('does not count a hidden chat message naming the bot, but counts a visible one', async () => {
+    const conversation = await Conversation.create({
+      name: 'Hidden invocation event',
+      slug: `bot-${new mongoose.Types.ObjectId().toString()}`,
+      owner: ownerId,
+      topic: new mongoose.Types.ObjectId(),
+      properties: { botName: 'Athena' },
+      transcript: { status: 'stopped' }
+    })
+
+    await seedChatMessage(conversation._id, 'hey Athena are you there', { visible: true })
+    await seedChatMessage(conversation._id, 'Athena can you help', { visible: false }) // hidden, excluded
+
+    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+
+    // Only the visible mention counts; the hidden one is dropped like every other human count.
+    expect(metrics.botInvocations).toEqual({ botName: 'Athena', count: 1 })
+  })
+
+  it('falls back to the default bot name when the event configured none', async () => {
+    const conversation = await Conversation.create({
+      name: 'Default bot event',
+      slug: `bot-${new mongoose.Types.ObjectId().toString()}`,
+      owner: ownerId,
+      topic: new mongoose.Types.ObjectId(),
+      transcript: { status: 'stopped' }
+    })
+
+    await seedChatMessage(conversation._id, `${config.conversationBotName} what is the agenda?`)
+    await seedChatMessage(conversation._id, 'no mention here')
+
+    const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
+
+    expect(metrics.botInvocations.botName).toBe(config.conversationBotName)
+    expect(metrics.botInvocations.count).toBe(1)
   })
 })
 
@@ -508,8 +956,9 @@ describe('computeConversationMetrics transcript exclusion', () => {
 
     const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
 
-    expect(metrics.participation).toMatchObject({ posterCount: 1, frequentPosterCount: 1, messageCount: 3 })
-    expect(metrics.participation.frequentPosterMessageShare).toBe(1)
+    // One poster is below the frequent-poster floor, so no dominance share is reported.
+    expect(metrics.participation).toMatchObject({ posterCount: 1, frequentPosterCount: 0, messageCount: 3 })
+    expect(metrics.participation.frequentPosterMessageShare).toBeNull()
     expect(metrics.channelSplit).toEqual({ public: 3, private: 0 })
     expect(metrics.activitySeries.reduce((sum, bucket) => sum + bucket.messageCount, 0)).toBe(3)
   })
@@ -552,8 +1001,8 @@ describe('computeConversationMetrics hidden message exclusion', () => {
     const metrics = await conversationAnalyticsService.computeConversationMetrics(conversation)
 
     // Only 'mara' and her three visible messages count; 'ghost' and the hidden message drop out.
-    expect(metrics.participation).toMatchObject({ posterCount: 1, frequentPosterCount: 1, messageCount: 3 })
-    expect(metrics.participation.frequentPosterMessageShare).toBe(1)
+    expect(metrics.participation).toMatchObject({ posterCount: 1, frequentPosterCount: 0, messageCount: 3 })
+    expect(metrics.participation.frequentPosterMessageShare).toBeNull()
     expect(metrics.channelSplit).toEqual({ public: 3, private: 0 })
     expect(metrics.activitySeries.reduce((sum, bucket) => sum + bucket.messageCount, 0)).toBe(3)
   })
@@ -579,8 +1028,8 @@ describe('computeConversationMetrics history and baseline', () => {
     const metrics = await conversationAnalyticsService.computeConversationMetrics(current)
 
     expect(metrics.participationHistory).toEqual([
-      { label: 'E1', posterCount: 5, lurkerCount: 15 },
-      { label: 'E2', posterCount: 6, lurkerCount: null },
+      { label: 'Topic series event (Jun 1)', posterCount: 5, lurkerCount: 15 },
+      { label: 'Topic series event (Jun 8)', posterCount: 6, lurkerCount: null },
       { label: 'Today', posterCount: 2, lurkerCount: 8 }
     ])
     expect(metrics.baseline).toEqual({
@@ -616,8 +1065,8 @@ describe('computeConversationMetrics history and baseline', () => {
     const metrics = await conversationAnalyticsService.computeConversationMetrics(current)
 
     expect(metrics.participationHistory).toEqual([
-      { label: 'E1', posterCount: 5, lurkerCount: 15 },
-      { label: 'E2', posterCount: 5, lurkerCount: null },
+      { label: 'Topic series event (Jun 1)', posterCount: 5, lurkerCount: 15 },
+      { label: 'Topic series event (Jun 8)', posterCount: 5, lurkerCount: null },
       { label: 'Today', posterCount: 2, lurkerCount: 8 }
     ])
     expect(metrics.baseline).toEqual({
@@ -652,9 +1101,9 @@ describe('computeConversationMetrics history and baseline', () => {
 
     const metrics = await conversationAnalyticsService.computeConversationMetrics(current)
 
-    // Only the one normal past event appears as E1; the experimental event is absent.
+    // Only the one normal past event appears, labeled by name and date; the experimental event is absent.
     expect(metrics.participationHistory).toEqual([
-      { label: 'E1', posterCount: 5, lurkerCount: 15 },
+      { label: 'Topic series event (Jun 1)', posterCount: 5, lurkerCount: 15 },
       { label: 'Today', posterCount: 2, lurkerCount: 8 }
     ])
     expect(metrics.baseline).toEqual({

--- a/tests/unit/services/conversationAnalytics.spikes.test.ts
+++ b/tests/unit/services/conversationAnalytics.spikes.test.ts
@@ -1,0 +1,81 @@
+import { computeSpikes, TimedActivityBucket } from '../../../src/services/conversationAnalytics.service.js'
+
+/* Builds one 10-minute bucket starting at the given minute offset. The width is
+   fixed because the spike rule only cares about counts, not window length. */
+function bucket(startMinute: number, messageCount: number): TimedActivityBucket {
+  return { startMinute, endMinute: startMinute + 10, messageCount }
+}
+
+/* Six evenly spaced buckets across an hour, one per ten minutes, from a list of
+   counts. Mirrors the shape computeConversationMetrics feeds in. */
+function sixBuckets(counts: number[]): TimedActivityBucket[] {
+  return counts.map((count, index) => bucket(index * 10, count))
+}
+
+describe('computeSpikes', () => {
+  it('flags a bucket that clears both the relative multiple and the floor', () => {
+    const spikes = computeSpikes(sixBuckets([2, 2, 18, 2, 2, 2]), 10)
+
+    expect(spikes).toHaveLength(1)
+    expect(spikes[0]).toMatchObject({ label: '20-29', startMinute: 20, endMinute: 30, messageCount: 18 })
+    expect(spikes[0].ratio).toBeCloseTo(9)
+  })
+
+  it('does not flag a flat distribution', () => {
+    expect(computeSpikes(sixBuckets([5, 5, 5, 5, 5, 5]), 10)).toEqual([])
+  })
+
+  it('still detects a spike in a small event, where a few messages is a real burst', () => {
+    const spikes = computeSpikes(sixBuckets([0, 1, 0, 4, 1, 0]), 4)
+
+    expect(spikes).toHaveLength(1)
+    expect(spikes[0]).toMatchObject({ startMinute: 30, messageCount: 4 })
+  })
+
+  it('ignores a bump below the absolute floor', () => {
+    expect(computeSpikes(sixBuckets([0, 1, 0, 2, 0, 0]), 4)).toEqual([])
+  })
+
+  it('returns no spikes when there are fewer than three buckets', () => {
+    expect(computeSpikes([bucket(0, 5), bucket(10, 40)], 10)).toEqual([])
+  })
+
+  it('reports a null ratio when the rest of the event was silent', () => {
+    const spikes = computeSpikes(sixBuckets([0, 0, 9, 0, 0, 0]), 5)
+
+    expect(spikes).toHaveLength(1)
+    expect(spikes[0].baselineAverage).toBe(0)
+    expect(spikes[0].ratio).toBeNull()
+  })
+
+  it('selects only the single busiest window when the baseline is zero', () => {
+    // [3,0,0]: all the messages land in one window and the rest are empty, so the
+    // baseline is zero everywhere. The multiple test is meaningless against a zero
+    // baseline, so only the single busiest window that clears the floor comes back.
+    const spikes = computeSpikes([bucket(0, 3), bucket(10, 0), bucket(20, 0)], 5)
+
+    expect(spikes).toHaveLength(1)
+    expect(spikes[0]).toMatchObject({ startMinute: 0, messageCount: 3 })
+  })
+
+  it('reports no spike on a zero baseline when the busiest window is below the floor', () => {
+    // The whole event is a single two-message window. Raw selection still must clear
+    // the floor, so a two-message blip is not a spike even with a silent rest.
+    const spikes = computeSpikes([bucket(0, 2), bucket(10, 0), bucket(20, 0)], 5)
+
+    expect(spikes).toEqual([])
+  })
+
+  it('detects multiple spikes in chronological order', () => {
+    const spikes = computeSpikes(sixBuckets([10, 1, 1, 1, 1, 12]), 10)
+
+    expect(spikes.map((s) => s.startMinute)).toEqual([0, 50])
+  })
+
+  it('scales the floor with participant count, so the same burst spikes a small event but not a large one', () => {
+    const counts = [1, 1, 1, 1, 1, 9]
+
+    expect(computeSpikes(sixBuckets(counts), 4)).toHaveLength(1)
+    expect(computeSpikes(sixBuckets(counts), 100)).toEqual([])
+  })
+})


### PR DESCRIPTION
## What is in this PR?

The Vibes Analyst card got a few upgrades: chat spikes now come with a verbatim quote and show which channel drove the burst, speaker lines that drew measurable chat response are noted with sentiment, and several lurker and participation metric calculations are corrected. Users can also @-mention the bot in its Slack channel to recap any past public event on demand; when the name doesn't match, the bot lists recent public events and waits for a pick. This PR also fixes a bug where updating `slackBotUserId` on an existing VA conversation never reached the live Slack adapter, so changing the bot's identity no longer requires recreating the conversation.

## Changes in the codebase

- The auto-generated summary now includes the busiest chat windows, each with a verbatim quote and which channel (public chat or moderator backchannel) drove the burst
- Speaker lines that generated measurable chat response are identified and rated by sentiment (agreement, pushback, or mixed)
- Lurker count, audience engagement rate, reading counts, event platform, and bot invocations are now tracked correctly
- @-mentioning the bot in its configured Slack channel with an event name (or "the latest") gets a recap on demand; when the name doesn't match, it lists recent public events to choose from
- Updating Slack properties on an existing VA conversation now syncs to the live Slack adapter without recreating it
- Added `METRICS.md` (plain-language reference for every metric on the card) and `SETUP.md` (step-by-step bot provisioning and deployment update flow)

## Documentation and automated testing

Did you:
- [x] document any breaking changes in your commit messages? (none)
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [x] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [x] update team documentation of any new or changed environment variables? (none added)

## Testing this PR

**Prerequisites:** Running llm_engine dev server, a Nextspace topic with at least one past public event, and a Slack workspace with a configured bot. See `src/agents/vibesAnalyst/SETUP.md` for Slack app provisioning (you need a bot token, signing secret, app key, and bot user ID). Create a private Slack channel for the bot to post to.

- [ ] Add the VA conversation: `POST <API host>/v1/conversations` with your admin bearer token, type `vibesAnalyst`, topic id, and `properties` containing `slackBotUserId`, `slackBotToken`, `slackSigningSecret`, `slackAppKey`, and `slackChannel: "<your channel name>"`
- [ ] Run a Nextspace event to completion with at least two participants chatting, then check your Slack channel for the auto-generated card
- [ ] Confirm the card includes spike annotations (a verbatim quote from the busiest chat window) if there were any spikes during the event
- [ ] Summon by name: `@<bot name> recap <event title>` in your channel; the bot should post the card for that event
- [ ] Summon latest: `@<bot name> tell me about the last event`; it should resolve to the most recent public event and post its card
- [ ] Summon a non-match: `@<bot name> recap past 2 events`; it should reply with a list of recent public events and ask you to pick one
- [ ] Test properties update: `PUT <API host>/v1/conversations` with `{ "id": "<VA conversation id>", "properties": { "slackBotUserId": "<updated value>" } }`, then summon the bot again to confirm it still responds

## Additional information

If the server logs an `E11000 duplicate key error ... index: conversationId_1` during the VA recap, your dev DB has a stale unique index from an earlier schema version. Drop it with `db.conversationanalytics.dropIndex('conversationId_1')` and restart — Mongoose recreates it correctly. Production is unaffected since the collection is new there.