### PR TITLE
feat: remove submit to moderator qs in favor of /escalate and remove mod qs from conv history

### DIFF
--- a/src/agents/eventAssistant/eventAssistant.ts
+++ b/src/agents/eventAssistant/eventAssistant.ts
@@ -5,12 +5,7 @@ import renderAgentTemplate from '../helpers/renderAgentTemplate.js'
 
 import Message from '../../models/message.model.js'
 import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
-import {
-  eventAssistantLLMTemplates,
-  eventAssistantLlmTemplateVars,
-  answerQuestion,
-  QuestionClassification
-} from './eventQuestionHandler.js'
+import { eventAssistantLLMTemplates, eventAssistantLlmTemplateVars, answerQuestion } from './eventQuestionHandler.js'
 import { buildSystemPromptWithPersonality } from '../helpers/agentPersonality.js'
 import { getChatPromptResponse } from '../helpers/llmChain.js'
 
@@ -90,62 +85,35 @@ ${capabilityDescription}`
   } Your pseudonym keeps you anonymous, and nothing you share is ever used to train AI models. No need to respond, just know I'm here.`
 }
 
-const MODERATOR_MESSAGE_TYPES = new Set(['moderator_offered', 'moderator_submitted', 'moderator_declined'])
-
-// Filter out moderator interaction messages before passing history to the LLM.
-// Seeing these in history causes the model to spontaneously replicate the offer.
-// Also drops the user's confirmed yes/no reply (sandwiched between moderator_offered
-// and moderator_submitted/declined) since without the offer it becomes a non-sequitur.
+// Filter /mod and /escalate command messages and moderator_submitted replies from LLM history so
+// they don't appear as unanswered questions, causing the LLM to re-answer them on the next turn.
 function filterModeratorHistory(conversationHistory) {
   return {
     ...conversationHistory,
-    messages: conversationHistory.messages?.filter((msg, i, msgs) => {
-      if (msg.bodyType === 'json' && MODERATOR_MESSAGE_TYPES.has((msg.body as Record<string, unknown>)?.type as string)) {
-        return false
-      }
-      const prev = msgs[i - 1]
-      const next = msgs[i + 1]
-      if (
-        prev?.bodyType === 'json' &&
-        (prev.body as Record<string, unknown>)?.type === 'moderator_offered' &&
-        next?.bodyType === 'json' &&
-        ((next.body as Record<string, unknown>)?.type === 'moderator_submitted' ||
-          (next.body as Record<string, unknown>)?.type === 'moderator_declined')
-      ) {
-        return false
+    messages: conversationHistory.messages?.filter((msg) => {
+      if (msg.bodyType === 'json') {
+        const body = msg.body as Record<string, unknown>
+        const command = body?.command
+        if (command === 'mod' || command === 'escalate') return false
+        if (body?.type === 'moderator_submitted') return false
       }
       return true
     })
   }
 }
 
-const submitToModeratorQuestion = 'Would you like to submit this question anonymously to the moderator for Q&A?'
 const submitToModeratorReply = 'Your message has been submitted to the moderator.'
-const declineModeratorReply = "OK, I won't submit it. Feel free to ask me anything else!"
 const submitToModeratorCommand = '/mod'
 const mindMapCommand = '/mindmap'
 
+const escalateCommand = '/escalate '
+
 const supportedCommands: SlashCommand[] = [
   { command: 'mod', prefix: submitToModeratorCommand, addToChannels: ['participant'] },
+  { command: 'escalate', prefix: escalateCommand },
   { command: 'visual', prefix: '/visual ' },
   { command: 'mindmap', prefix: mindMapCommand }
 ]
-
-function isAffirmative(text) {
-  const normalized = text.trim().toLowerCase()
-  const affirmativePatterns =
-    /^(yes|yeah|yep|yup|sure|okay|ok|absolutely|definitely|certainly|affirmative|correct|right|indeed|of course|you bet|sounds good)/
-
-  return affirmativePatterns.test(normalized)
-}
-
-function isNegative(text) {
-  const normalized = text.trim().toLowerCase()
-  const negativePatterns =
-    /^(no|nah|nope|naw|not really|don't|dont|never mind|nevermind|no thanks|no thank you|negative|not now|maybe later|i'm good|im good)/
-
-  return negativePatterns.test(normalized)
-}
 
 function submitToModeratorResponse(userMessage, message) {
   return [
@@ -160,82 +128,6 @@ function submitToModeratorResponse(userMessage, message) {
     }
   ]
 }
-
-function declineModeratorResponse(userMessage, message) {
-  return [
-    {
-      visible: true,
-      message: { type: 'moderator_declined', text: declineModeratorReply, message: message._id.toString() },
-      messageType: 'json',
-      channels: this.conversation.channels.filter(
-        (channel) => userMessage.channels.includes(channel.name) && channel.direct === true
-      ),
-      parent: userMessage.parentMessage
-    }
-  ]
-}
-
-async function handleModeratorReply(conversationHistory, userMessage) {
-  const lastMessage = conversationHistory.messages[conversationHistory.messages.length - 1]
-  if (
-    conversationHistory.messages.length > 1 &&
-    lastMessage.bodyType === 'json' &&
-    (lastMessage.body as Record<string, unknown>).text === submitToModeratorQuestion
-  ) {
-    const originalMessageId = (lastMessage.body as Record<string, unknown>).message
-    const message = await Message.findById(originalMessageId)
-    const responseText = extractMessageText(userMessage)
-
-    if (isAffirmative(responseText)) {
-      if (!message) {
-        logger.error(`Could not find original message with ID ${originalMessageId} to submit to moderator`)
-        return []
-      }
-      message.channels = message.channels ?? []
-      message.channels.push('participant')
-      await message.save()
-      return submitToModeratorResponse.call(this, userMessage, message)
-    }
-
-    if (isNegative(responseText)) {
-      if (!message) {
-        logger.error(`Could not find original message with ID ${originalMessageId} to send acknowledgement of decline`)
-        return []
-      }
-      return declineModeratorResponse.call(this, userMessage, message)
-    }
-    // Neither affirmative nor negative — fall through to process as a new question
-  }
-  return null
-}
-
-function offerModeratorSubmission(userMessage, agentResponses, conversation) {
-  const { classification } = agentResponses[0]
-  if (
-    classification === QuestionClassification.UNANSWERABLE ||
-    classification === QuestionClassification.ON_TOPIC_ASK_SPEAKER
-  ) {
-    agentResponses.push({
-      visible: true,
-      message: {
-        type: 'moderator_offered',
-        text: submitToModeratorQuestion,
-        message: userMessage._id.toString()
-      },
-      messageType: 'json',
-      channels: conversation.channels.filter((channel) => userMessage.channels.includes(channel.name)),
-      replyFormat: {
-        type: 'singleChoice',
-        options: [
-          { value: 'no', label: 'No' },
-          { value: 'yes', label: 'Yes' }
-        ]
-      },
-      parent: userMessage.parentMessage
-    })
-  }
-}
-
 
 type TraceResponse = {
   message?: unknown
@@ -315,7 +207,7 @@ export default verify({
     // Parse slash commands using shared parser
     const activeCommands = this.agentConfig?.moderatorSupport
       ? supportedCommands
-      : supportedCommands.filter((c) => c.command !== 'mod')
+      : supportedCommands.filter((c) => c.command !== 'mod' && c.command !== 'escalate')
     let modifiedMessage = parseSlashCommands(userMessage, activeCommands)
 
     if (modifiedMessage?.channels?.includes('chat')) {
@@ -358,13 +250,24 @@ export default verify({
       return await answerQuestion.call(this, userMessage, filterModeratorHistory(conversationHistory))
     }
 
-    if (this.agentConfig?.moderatorSupport) {
-      const moderatorReply = await handleModeratorReply.call(this, conversationHistory, userMessage)
-      if (moderatorReply !== null) return moderatorReply
-
-      if (userMessage.channels?.includes('participant')) {
-        return submitToModeratorResponse.call(this, userMessage, userMessage)
+    if (this.agentConfig?.moderatorSupport && hasCommand(userMessage, 'escalate')) {
+      const questionId = userMessage.body?.text
+      const originalMessage = await Message.findById(questionId)
+      if (originalMessage) {
+        originalMessage.channels = originalMessage.channels ?? []
+        if (!originalMessage.channels.includes('participant')) {
+          originalMessage.channels.push('participant')
+          await originalMessage.save()
+        }
+      } else {
+        logger.error(`escalate: could not find original message ${questionId}`)
+        return []
       }
+      return submitToModeratorResponse.call(this, userMessage, { _id: questionId })
+    }
+
+    if (this.agentConfig?.moderatorSupport && userMessage.channels?.includes('participant')) {
+      return submitToModeratorResponse.call(this, userMessage, userMessage)
     }
 
     // Check for visual command (set in evaluate)
@@ -374,15 +277,10 @@ export default verify({
     const modifiedMessage = { ...userMessage }
     modifiedMessage.body = extractMessageText(userMessage)
 
-    const agentResponses = await answerQuestion.call(this, modifiedMessage, filterModeratorHistory(conversationHistory), {
-      forceVisual
+    return answerQuestion.call(this, modifiedMessage, filterModeratorHistory(conversationHistory), {
+      forceVisual,
+      moderatorSupport: !!this.agentConfig?.moderatorSupport
     })
-
-    if (this.agentConfig?.moderatorSupport) {
-      offerModeratorSubmission(userMessage, agentResponses, this.conversation)
-    }
-
-    return agentResponses
   },
   async start() {
     return true

--- a/src/agents/eventAssistant/eventQuestionHandler.ts
+++ b/src/agents/eventAssistant/eventQuestionHandler.ts
@@ -612,11 +612,17 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
     }
   }
 
+  const moderatorSuggested =
+    options?.moderatorSupport &&
+    (classification === QuestionClassification.ON_TOPIC_ASK_SPEAKER ||
+      classification === QuestionClassification.UNANSWERABLE)
+
   const agentResponse = {
     visible: true,
     message: {
       text: responseMessage,
-      type: classification.toLowerCase()
+      type: classification.toLowerCase(),
+      ...(moderatorSuggested ? { moderatorSuggested: true, message: userMessage._id?.toString() } : {})
     },
     messageType: 'json',
     channels: responseChannels,

--- a/tests/agents/eventAssistant/eventAssistantModSupport.agent.test.ts
+++ b/tests/agents/eventAssistant/eventAssistantModSupport.agent.test.ts
@@ -19,11 +19,6 @@ jest.setTimeout(180000)
 
 const testConfig = setupAgentTest('eventAssistant')
 
-const submitToModeratorQuestion = {
-  text: 'Would you like to submit this question anonymously to the moderator for Q&A?',
-  type: 'moderator_offered'
-}
-
 const testTimeout = 120000
 
 describe('eventAssistant moderator support tests', () => {
@@ -74,9 +69,9 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
     return createDirectMessage(body, user1, conversation)
   }
 
-  describe('moderator offer on on_topic_ask_speaker questions', () => {
+  describe('moderator suggested flag', () => {
     it(
-      'offers to submit to moderator for a speaker-directed question',
+      'suggests submitting to moderator for ask speaker classification',
       async () => {
         const questionMsg = await createQuestion(
           'What does Jessica think is the biggest misconception businesses have about part-time employees?'
@@ -89,251 +84,45 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
           savedQuestion.toObject()
         )
 
+        expect(responses.length).toBeGreaterThan(0)
+        expect(responses[0].classification).toBeDefined()
         const offer = responses.find((r) => r.message?.type === 'moderator_offered')
+        expect(offer).toBeUndefined()
+        // moderatorSuggested flag set on message body when classification warrants it
         if (responses[0].classification === QuestionClassification.ON_TOPIC_ASK_SPEAKER) {
-          expect(offer).toBeDefined()
-          expect(offer!.message).toMatchObject({
-            ...submitToModeratorQuestion,
-            message: savedQuestion._id.toString()
-          })
-          expect(offer!.replyFormat).toMatchObject({
-            type: 'singleChoice',
-            options: [
-              { value: 'no', label: 'No' },
-              { value: 'yes', label: 'Yes' }
-            ]
-          })
-          expect(offer!.visible).toBe(true)
+          expect(responses[0].message.moderatorSuggested).toBe(true)
+          expect(responses[0].message.message).toBe(savedQuestion._id.toString())
         }
       },
       testTimeout
     )
-  })
 
-  describe('submit to moderator functionality', () => {
     it(
-      'should submit to moderator when user responds with yes',
+      'does not set moderatorSuggested when moderatorSupport is disabled',
       async () => {
-        const questionMsg = await createQuestion('What is the meaning of life?')
-        const savedQuestion = await Message.create(questionMsg)
-
-        const affirmativeMsg = await createQuestion('yes')
-        const conversationHistory = {
-          messages: [
-            savedQuestion,
-            { body: "I don't have enough information.", bodyType: 'text', fromAgent: true },
-            { body: { ...submitToModeratorQuestion, message: savedQuestion._id }, bodyType: 'json', fromAgent: true }
-          ]
-        }
-
-        const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, conversationHistory, affirmativeMsg)
-
-        await validateResponse(responses)
-        expect(responses).toHaveLength(1)
-        expect(responses[0].message).toMatchObject({
-          text: 'Your message has been submitted to the moderator.',
-          type: 'moderator_submitted',
-          message: savedQuestion._id.toString()
+        const agentWithoutModSupport = new Agent({
+          agentType: 'eventAssistant',
+          conversation,
+          llmPlatform: agent.llmPlatform,
+          llmModel: agent.llmModel,
+          agentConfig: { moderatorSupport: undefined }
         })
-        expect(responses[0].parent).toBeUndefined()
+        await agentWithoutModSupport.save()
+        agentWithoutModSupport.conversation = conversation
 
-        const updatedMessage = await Message.findById(savedQuestion._id)
-        expect(updatedMessage!.channels).toContain('participant')
-      },
-      testTimeout
-    )
-
-    it(
-      'should decline submission when user responds with no',
-      async () => {
-        const questionMsg = await createQuestion('What is the meaning of life?')
+        const questionMsg = await createQuestion(
+          'What does Jessica think is the biggest misconception businesses have about part-time employees?'
+        )
         const savedQuestion = await Message.create(questionMsg)
-
-        const negativeMsg = await createQuestion('no')
-        const conversationHistory = {
-          messages: [
-            savedQuestion,
-            { body: "I don't have enough information.", bodyType: 'text', fromAgent: true },
-            { body: { ...submitToModeratorQuestion, message: savedQuestion._id }, bodyType: 'json', fromAgent: true }
-          ]
-        }
-
-        const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, conversationHistory, negativeMsg)
-
-        await validateResponse(responses)
-        expect(responses).toHaveLength(1)
-        expect(responses[0].message).toMatchObject({
-          type: 'moderator_declined',
-          text: "OK, I won't submit it. Feel free to ask me anything else!",
-          message: savedQuestion._id.toString()
-        })
-        expect(responses[0].parent).toBeUndefined()
-
-        const updatedMessage = await Message.findById(savedQuestion._id)
-        expect(updatedMessage!.channels).not.toContain('participant')
-      },
-      testTimeout
-    )
-
-    it(
-      'should submit to moderator for various affirmative responses',
-      async () => {
-        const affirmativeVariants = ['yes', 'yeah', 'yep', 'yup', 'sure', 'okay', 'ok', 'absolutely', 'definitely']
-
-        for (const variant of affirmativeVariants) {
-          const questionMsg = await createQuestion('What is the meaning of life?')
-          const savedQuestion = await Message.create(questionMsg)
-          const affirmativeMsg = await createQuestion(variant)
-          const conversationHistory = {
-            messages: [
-              savedQuestion,
-              { body: "I don't have enough information.", bodyType: 'text', fromAgent: true },
-              { body: { ...submitToModeratorQuestion, message: savedQuestion._id }, bodyType: 'json', fromAgent: true }
-            ]
-          }
-
-          const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, conversationHistory, affirmativeMsg)
-          await validateResponse(responses)
-          expect(responses).toHaveLength(1)
-          expect(responses[0].message).toMatchObject({
-            text: 'Your message has been submitted to the moderator.',
-            type: 'moderator_submitted',
-            message: savedQuestion._id.toString()
-          })
-        }
-      },
-      testTimeout
-    )
-
-    it(
-      'should decline submission for various negative responses',
-      async () => {
-        const negativeVariants = ['no', 'nope', 'nah', 'no thanks', "don't", 'never mind']
-
-        for (const variant of negativeVariants) {
-          const questionMsg = await createQuestion('What is the meaning of life?')
-          const savedQuestion = await Message.create(questionMsg)
-          const negativeMsg = await createQuestion(variant)
-          const conversationHistory = {
-            messages: [
-              savedQuestion,
-              { body: "I don't have enough information.", bodyType: 'text', fromAgent: true },
-              { body: { ...submitToModeratorQuestion, message: savedQuestion._id }, bodyType: 'json', fromAgent: true }
-            ]
-          }
-
-          const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, conversationHistory, negativeMsg)
-          await validateResponse(responses)
-          expect(responses).toHaveLength(1)
-          expect(responses[0].message).toMatchObject({
-            type: 'moderator_declined',
-            text: "OK, I won't submit it. Feel free to ask me anything else!",
-            message: savedQuestion._id.toString()
-          })
-        }
-      },
-      testTimeout
-    )
-
-    it(
-      'falls through to answer question when user ignores submit prompt',
-      async () => {
-        const questionMsg = await createQuestion('What is the meaning of life?')
-        const savedQuestion = await Message.create(questionMsg)
-
-        const newQuestion = await createQuestion("What was the speaker's main point?")
-        const savedNewQuestion = await Message.create(newQuestion)
-        const conversationHistory = {
-          messages: [
-            savedQuestion,
-            { body: "I don't have enough information.", bodyType: 'text', fromAgent: true },
-            {
-              body: {
-                message: savedQuestion._id.toString(),
-                text: submitToModeratorQuestion.text,
-                type: 'moderator_offered'
-              },
-              bodyType: 'json',
-              fromAgent: true
-            }
-          ]
-        }
 
         const responses = await defaultAgentTypes.eventAssistant.respond.call(
-          agent,
-          conversationHistory,
-          savedNewQuestion.toObject()
+          agentWithoutModSupport,
+          { messages: [] },
+          savedQuestion.toObject()
         )
 
-        // Should have answered the new question, not returned empty
         expect(responses.length).toBeGreaterThan(0)
-        expect(responses[0].message?.type).not.toBe('moderator_declined')
-        expect(responses[0].message?.type).not.toBe('moderator_submitted')
-
-        const updatedMessage = await Message.findById(savedQuestion._id)
-        expect(updatedMessage!.channels).not.toContain('participant')
-      },
-      testTimeout
-    )
-
-    it(
-      'should propagate parent thread when submitting to moderator',
-      async () => {
-        const parentMessageId = new mongoose.Types.ObjectId()
-        const questionMsg = await createQuestion('What is the meaning of life?')
-        questionMsg.parentMessage = parentMessageId
-        const savedQuestion = await Message.create(questionMsg)
-
-        const affirmativeMsg = await createQuestion('yes')
-        affirmativeMsg.parentMessage = parentMessageId
-        const conversationHistory = {
-          messages: [
-            savedQuestion,
-            { body: "I don't have enough information.", bodyType: 'text', fromAgent: true },
-            { body: { ...submitToModeratorQuestion, message: savedQuestion._id }, bodyType: 'json', fromAgent: true }
-          ]
-        }
-
-        const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, conversationHistory, affirmativeMsg)
-
-        expect(responses).toHaveLength(1)
-        expect(responses[0].message).toMatchObject({
-          text: 'Your message has been submitted to the moderator.',
-          type: 'moderator_submitted',
-          message: savedQuestion._id.toString()
-        })
-        expect(responses[0].parent).toBe(parentMessageId)
-      },
-      testTimeout
-    )
-
-    it(
-      'should propagate parent thread when declining moderator submission',
-      async () => {
-        const parentMessageId = new mongoose.Types.ObjectId()
-        const questionMsg = await createQuestion('What is the meaning of life?')
-        questionMsg.parentMessage = parentMessageId
-        const savedQuestion = await Message.create(questionMsg)
-
-        const negativeMsg = await createQuestion('no')
-        negativeMsg.parentMessage = parentMessageId
-        const conversationHistory = {
-          messages: [
-            savedQuestion,
-            { body: "I don't have enough information.", bodyType: 'text', fromAgent: true },
-            { body: { ...submitToModeratorQuestion, message: savedQuestion._id }, bodyType: 'json', fromAgent: true }
-          ]
-        }
-
-        const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, conversationHistory, negativeMsg)
-
-        expect(responses).toHaveLength(1)
-        expect(responses[0].message).toMatchObject({
-          type: 'moderator_declined',
-          text: "OK, I won't submit it. Feel free to ask me anything else!",
-          message: savedQuestion._id.toString()
-        })
-        expect(responses[0].parent).toBe(parentMessageId)
+        expect(responses[0].message.moderatorSuggested).toBeUndefined()
       },
       testTimeout
     )
@@ -341,88 +130,39 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
 
   describe('moderator history filtering', () => {
     it(
-      'LLM does not spontaneously offer moderator submission when prior moderator_offered messages are in history',
+      '/mod command messages and moderator_submitted replies are filtered from LLM history so they do not appear as unanswered questions',
       async () => {
-        const priorQuestion = await createQuestion('What percentage of U.S. workers are part-time?')
-        const savedPriorQuestion = await Message.create(priorQuestion)
+        const modQuestion = await createQuestion('/mod What is the return on investment for part-time staffing?')
+        modQuestion.bodyType = 'json'
+        modQuestion.body = { command: 'mod', text: 'What is the return on investment for part-time staffing?' }
+        const savedModQuestion = await Message.create(modQuestion)
 
-        const newQuestion = await createQuestion("What was Jessica's main argument?")
-        const savedNewQuestion = await Message.create(newQuestion)
+        const followUp = await createQuestion("What was Jessica's main argument?")
+        const savedFollowUp = await Message.create(followUp)
+
+        const moderatorSubmittedReply = {
+          body: {
+            type: 'moderator_submitted',
+            text: 'Your message has been submitted to the moderator.',
+            message: savedModQuestion._id.toString()
+          },
+          bodyType: 'json',
+          fromAgent: true
+        }
 
         const conversationHistory = {
-          messages: [
-            savedPriorQuestion,
-            {
-              body: 'According to the transcript, approximately 20% of workers are part-time.',
-              bodyType: 'text',
-              fromAgent: true
-            },
-            {
-              body: { ...submitToModeratorQuestion, message: savedPriorQuestion._id.toString() },
-              bodyType: 'json',
-              fromAgent: true
-            }
-          ]
+          messages: [savedModQuestion, moderatorSubmittedReply]
         }
 
         const responses = await defaultAgentTypes.eventAssistant.respond.call(
           agent,
           conversationHistory,
-          savedNewQuestion.toObject()
+          savedFollowUp.toObject()
         )
 
+        // Should answer only the follow-up — not attempt to also answer the /mod question
         expect(responses.length).toBeGreaterThan(0)
         const answerText = responses[0].message?.text ?? responses[0].message
-        expect(answerText).not.toMatch(/submit.*moderator|moderator.*Q&A|anonymously/i)
-      },
-      testTimeout
-    )
-
-    it(
-      'LLM answers normally when history contains a full moderator offer/accept exchange',
-      async () => {
-        const priorQuestion = await createQuestion('What percentage of U.S. workers are part-time?')
-        const savedPriorQuestion = await Message.create(priorQuestion)
-
-        const newQuestion = await createQuestion("What was Jessica's main argument?")
-        const savedNewQuestion = await Message.create(newQuestion)
-
-        const conversationHistory = {
-          messages: [
-            savedPriorQuestion,
-            {
-              body: 'According to the transcript, approximately 20% of workers are part-time.',
-              bodyType: 'text',
-              fromAgent: true
-            },
-            {
-              body: { ...submitToModeratorQuestion, message: savedPriorQuestion._id.toString() },
-              bodyType: 'json',
-              fromAgent: true
-            },
-            { body: 'yes', bodyType: 'text', fromAgent: false },
-            {
-              body: {
-                type: 'moderator_submitted',
-                text: 'Your message has been submitted to the moderator.',
-                message: savedPriorQuestion._id.toString()
-              },
-              bodyType: 'json',
-              fromAgent: true
-            }
-          ]
-        }
-
-        const responses = await defaultAgentTypes.eventAssistant.respond.call(
-          agent,
-          conversationHistory,
-          savedNewQuestion.toObject()
-        )
-
-        expect(responses.length).toBeGreaterThan(0)
-        const answerText = responses[0].message?.text ?? responses[0].message
-        expect(answerText).not.toMatch(/submit.*moderator|moderator.*Q&A|anonymously/i)
-        // Should be a substantive answer, not empty or an error
         expect(typeof answerText).toBe('string')
         expect((answerText as string).length).toBeGreaterThan(10)
       },
@@ -463,6 +203,128 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
           message: participantMsg._id.toString()
         })
         expect(responses[0].parent).toBeUndefined()
+      },
+      testTimeout
+    )
+  })
+
+  describe('/escalate command', () => {
+    it(
+      'should handle /escalate command in evaluate',
+      async () => {
+        const originalQuestion = await createQuestion('What is the meaning of life?')
+        const savedQuestion = await Message.create(originalQuestion)
+
+        const escalateMsg = await createQuestion(`/escalate ${savedQuestion._id}`)
+
+        const evaluation = await defaultAgentTypes.eventAssistant.evaluate.call(agent, escalateMsg)
+
+        expect(evaluation.userMessage.body).toEqual({ command: 'escalate', text: savedQuestion._id.toString() })
+        expect(evaluation.userMessage.bodyType).toBe('json')
+        expect(evaluation.action).toBe(AgentMessageActions.CONTRIBUTE)
+      },
+      testTimeout
+    )
+
+    it(
+      'should add participant channel to original message and return moderator submission response',
+      async () => {
+        const originalQuestion = await createQuestion('What is the meaning of life?')
+        const savedQuestion = await Message.create(originalQuestion)
+
+        const escalateMsg = await createQuestion(`/escalate ${savedQuestion._id}`)
+        const savedEscalate = await Message.create(escalateMsg)
+        const parsedEscalate = {
+          ...savedEscalate.toObject(),
+          body: { command: 'escalate', text: savedQuestion._id.toString() },
+          bodyType: 'json'
+        }
+
+        const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, { messages: [] }, parsedEscalate)
+
+        await validateResponse(responses)
+        expect(responses).toHaveLength(1)
+        expect(responses[0].message).toMatchObject({
+          type: 'moderator_submitted',
+          text: 'Your message has been submitted to the moderator.',
+          message: savedQuestion._id.toString()
+        })
+
+        const updatedQuestion = await Message.findById(savedQuestion._id)
+        expect(updatedQuestion!.channels).toContain('participant')
+      },
+      testTimeout
+    )
+
+    it(
+      'should return empty response when original message cannot be found',
+      async () => {
+        const nonExistentId = new mongoose.Types.ObjectId()
+        const escalateMsg = await createQuestion(`/escalate ${nonExistentId}`)
+        const savedEscalate = await Message.create(escalateMsg)
+        const parsedEscalate = {
+          ...savedEscalate.toObject(),
+          body: { command: 'escalate', text: nonExistentId.toString() },
+          bodyType: 'json'
+        }
+
+        const responses = await defaultAgentTypes.eventAssistant.respond.call(agent, { messages: [] }, parsedEscalate)
+
+        expect(responses).toHaveLength(0)
+      },
+      testTimeout
+    )
+
+    it(
+      'does not add participant channel twice if already escalated',
+      async () => {
+        const originalQuestion = await createQuestion('What is the meaning of life?')
+        const savedQuestion = await Message.create(originalQuestion)
+        savedQuestion.channels = [...(savedQuestion.channels ?? []), 'participant']
+        await savedQuestion.save()
+
+        const escalateMsg = await createQuestion(`/escalate ${savedQuestion._id}`)
+        const savedEscalate = await Message.create(escalateMsg)
+        const parsedEscalate = {
+          ...savedEscalate.toObject(),
+          body: { command: 'escalate', text: savedQuestion._id.toString() },
+          bodyType: 'json'
+        }
+
+        await defaultAgentTypes.eventAssistant.respond.call(agent, { messages: [] }, parsedEscalate)
+
+        const updatedQuestion = await Message.findById(savedQuestion._id)
+        const participantCount = (updatedQuestion!.channels ?? []).filter((c) => c === 'participant').length
+        expect(participantCount).toBe(1)
+      },
+      testTimeout
+    )
+
+    it(
+      'does not route /escalate command when moderatorSupport is disabled',
+      async () => {
+        const agentWithoutModSupport = new Agent({
+          agentType: 'eventAssistant',
+          conversation,
+          llmPlatform: agent.llmPlatform,
+          llmModel: agent.llmModel,
+          agentConfig: { moderatorSupport: undefined }
+        })
+        await agentWithoutModSupport.save()
+        agentWithoutModSupport.conversation = conversation
+
+        const originalQuestion = await createQuestion('What is the meaning of life?')
+        const savedQuestion = await Message.create(originalQuestion)
+
+        const escalateMsg = await createQuestion(`/escalate ${savedQuestion._id}`)
+        const evaluation = await defaultAgentTypes.eventAssistant.evaluate.call(agentWithoutModSupport, escalateMsg)
+
+        // /escalate is not in the active commands when moderatorSupport is disabled,
+        // so the message body should be unparsed plain text
+        expect(evaluation.userMessage.bodyType).not.toBe('json')
+
+        const updatedQuestion = await Message.findById(savedQuestion._id)
+        expect(updatedQuestion!.channels).not.toContain('participant')
       },
       testTimeout
     )
@@ -511,7 +373,6 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
           participantMsg
         )
 
-        // No moderator_submitted response — falls through to normal answer
         const submitted = responses.find((r) => r.message?.type === 'moderator_submitted')
         expect(submitted).toBeUndefined()
       },
@@ -543,9 +404,9 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
   })
 
   describe('parseOutput', () => {
-    it('transforms moderator JSON messages into plain text', async () => {
+    it('transforms moderator_submitted JSON message into plain text', async () => {
       const agentMsg = new Message({
-        body: submitToModeratorQuestion,
+        body: { type: 'moderator_submitted', text: 'Your message has been submitted to the moderator.' },
         bodyType: 'json',
         conversation: conversation._id,
         pseudonym: agent.pseudonyms[0].pseudonym,
@@ -555,7 +416,7 @@ Since then, Jessica has led the company to a 7-figure annual business – all in
       const translatedMsg = await defaultAgentTypes.eventAssistant.parseOutput(agentMsg)
       expect(translatedMsg).toMatchObject({
         ...agentMsg.toObject(),
-        body: submitToModeratorQuestion.text,
+        body: 'Your message has been submitted to the moderator.',
         bodyType: 'text'
       })
     })


### PR DESCRIPTION
## What is in this PR?

<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->

This PR prevents the LLM from trying to answer /mod questions or talk about moderator submission and adds support to simplify the 'suggest submitting to moderator' flow.

Addresses/supports issues: 
https://github.com/berkmancenter/llm_engine/issues/167
https://github.com/berkmancenter/nextspace/issues/133
https://github.com/berkmancenter/llm_engine/issues/175

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- Remove the 'would you like to submit to moderator?' yes/no question response from eventAssistant
- Add a `moderatorSuggested` prop to EA response body with ref to original question ID when the LLM determines that the question is a good candidate for moderator submission (same classification logic as before). This prop can be used by clients to visually suggest mod submission in any way they see fit, rather than baking in a cumbersome question and answer process
- Support a new '/escalate [message id]' command that can be sent from FE when a user chooses to escalate their question to the moderator
- Remove all /mod, /escalate, and 'your message has been submitted to the moderator' messages from conversation history so the LLM does not attempt to offer to submit to moderator or claim it has done so or answer questions meant to go directly to the moderator with /mod. Basically, the LLM has no knowledge of the moderator submission flow.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x] Test in conjunction with NextSpace FE PR TODO
- [x] Create an EA convo for NextSpace and Zoom
- [x] Send a /mod question from NS and verify that no response message is displayed, but a 'Submitted' pill shows up for verification and question is visible on moderator page
- [x] In NS, ask a question that the LLM is likely to flag for possible moderator submission, something like 'What does the speaker think of XYZ'?
- [x] Verify the 'Moderator' button appears below the message
- [x] Click the moderator button
- [x] Verify it turns green and says submitted and that the question shows up on the moderator page
- [x] Ask another question likely to flag for possible moderator submission, but do NOT press the button
- [x] Reload the page and ensure submitted pills still show up and the one message still has the 'Moderator' button
- [x] Click the moderator button and verify submitted
- [x] In Zoom, send a /mod command. Ensure you receive the 'Your message has been submitted to the moderator' message. Verify message shows up on mod page (NOTE: PM has approved the removal of the 'Would you like to submit?' question in Zoom with no alternative)



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
