### PR TITLE
Return fields in conversation service update

### DIFF
--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -24,7 +24,7 @@ import resourceService from '../resource.service.js'
 export { updateTranscriptStatus }
 
 const returnFields =
-  'name slug locked owner createdAt active conversationType platforms scheduledTime scheduledEndTime description moderators presenters transcript properties features'
+  'name slug locked owner createdAt active conversationType platforms scheduledTime scheduledEndTime startTime endTime description moderators presenters transcript properties features'
 export const maxScheduledInterval = 10 * 60 * 1000 // 10 minutes in milliseconds
 export const { autoStartLeadTimeMs } = config.conversation
 export const { autoStopDelayMs } = config.conversation


### PR DESCRIPTION
## What is in this PR?
This pull request makes a minor update to the `returnFields` constant in the `conversation.service` module. The change adds `startTime` and `endTime` to the list of fields returned for conversations.
<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->

## Changes in the codebase
See above.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [ ] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [ ] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR
N/A