### PR TITLE
feat: remove public intervention rate limiting, delegate chattiness control to LLM

### DIFF
--- a/src/agents/engagement/engagementAgent.ts
+++ b/src/agents/engagement/engagementAgent.ts
@@ -184,7 +184,7 @@ export default verify({
   priority: 85,
   maxTokens: 3000,
   defaultTriggers: {
-    periodic: { timerPeriod: 60, conversationHistorySettings: { channels: ['transcript'] } }
+    periodic: { timerPeriod: 120, conversationHistorySettings: { channels: ['transcript'] } }
   },
   agentConfig: {
     personality: 'sarcastic-expert'

--- a/src/agents/engagement/engagementAgent.ts
+++ b/src/agents/engagement/engagementAgent.ts
@@ -187,7 +187,6 @@ export default verify({
     periodic: { timerPeriod: 60, conversationHistorySettings: { channels: ['transcript'] } }
   },
   agentConfig: {
-    minInterval: 5, // 5 min between interventions
     personality: 'sarcastic-expert'
   },
   llmTemplateVars: interventionLlmTemplateVars,

--- a/src/agents/engagement/engagementAgent.ts
+++ b/src/agents/engagement/engagementAgent.ts
@@ -166,6 +166,7 @@ export async function executePollReveal(
         {
           ...interventionAnalysis,
           visible: true,
+          proactive: true,
           message: result,
           messageType: 'json',
           channels: chatChannels
@@ -250,6 +251,7 @@ export default verify({
         {
           ...interventionAnalysis,
           visible: true,
+          proactive: true,
           message: interventionAnalysis.sharedChatMessage,
           channels: this.conversation.channels.filter((c: IChannel) => c.name === 'chat')
         }

--- a/src/agents/eventMediator/eventMediator.ts
+++ b/src/agents/eventMediator/eventMediator.ts
@@ -141,9 +141,9 @@ export default verify({
     'Makes strategic interventions in shared chat based on configurable intervention categories: collective consciousness, engagement, and facilitation',
   priority: 85,
   maxTokens: 3000,
-  // uses 67 seconds for now to prevent overlap with Engagement Agent (timer set to 60 seconds) - can be adjusted as needed
+  // uses 127 seconds for now to prevent overlap with Engagement Agent (timer set to 120 seconds) - can be adjusted as needed
   defaultTriggers: {
-    periodic: { timerPeriod: 67, conversationHistorySettings: { channels: ['transcript'] } }
+    periodic: { timerPeriod: 127, conversationHistorySettings: { channels: ['transcript'] } }
   },
   agentConfig: {
     personality: 'sarcastic-expert' // Use sarcastic-expert personality (set to null for no personality)

--- a/src/agents/eventMediator/eventMediator.ts
+++ b/src/agents/eventMediator/eventMediator.ts
@@ -213,6 +213,7 @@ export default verify({
       responses.push({
         ...interventionAnalysis,
         visible: true,
+        proactive: true,
         message: interventionAnalysis.sharedChatMessage,
         channels: this.conversation.channels.filter((c: IChannel) => c.name === 'chat')
       } as AgentResponse<string | Record<string, unknown>>)

--- a/src/agents/eventMediator/eventMediator.ts
+++ b/src/agents/eventMediator/eventMediator.ts
@@ -146,7 +146,6 @@ export default verify({
     periodic: { timerPeriod: 67, conversationHistorySettings: { channels: ['transcript'] } }
   },
   agentConfig: {
-    minInterval: 2, // 2 min between interventions
     personality: 'sarcastic-expert' // Use sarcastic-expert personality (set to null for no personality)
   },
   llmTemplateVars: interventionLlmTemplateVars,

--- a/src/agents/helpers/interventionHandler.ts
+++ b/src/agents/helpers/interventionHandler.ts
@@ -6,7 +6,6 @@ import { getChatPromptResponse } from './llmChain.js'
 
 import config from '../../config/config.js'
 import logger from '../../config/logger.js'
-import Message from '../../models/message.model.js'
 import { InterventionAnalysis, InterventionType } from './interventionTypes.js'
 import { buildSystemPromptWithPersonality, getInterventionExamples } from './agentPersonality.js'
 import validateProfessionalism from './professionalismValidator.js'
@@ -223,9 +222,12 @@ async function runInterventionAnalysis(
   return result
 }
 
+const PUBLIC_INTERVENTION_RULES = `
+When weighing recent agent activity in Shared Chat History, distinguish between agents answering direct participant questions and agents making facilitative contributions — only the latter should count against intervening now.`
+
 /**
  * Detects whether to post a public intervention to the shared chat channel.
- * Rate limiting and the DB race guard are both scoped to the shared chat.
+ * The LLM decides on every invocation whether intervention is appropriate — no rate limiting.
  * Used by eventMediator and engagementAgent.
  */
 export async function detectPublicInterventionOpportunity(
@@ -235,39 +237,14 @@ export async function detectPublicInterventionOpportunity(
   privateConversationHistory?: ConversationHistory | null,
   userTemplate?: string
 ): Promise<InterventionAnalysis | null> {
-  const now = sharedChatHistory.end ? sharedChatHistory.end.getTime() : Date.now()
-  const minInterval = (this.agentConfig?.minInterval || 2) * 60 * 1000
-
-  const lastIntervention = getRecentAgentInterventions(sharedChatHistory).at(-1)
-  if (lastIntervention && now - lastIntervention.timestamp.getTime() < minInterval) {
-    const secondsAgo = Math.round((now - lastIntervention.timestamp.getTime()) / 1000)
-    logger.debug(`${this.agentType} ${this._id}: rate limited — last intervention ${secondsAgo}s ago (min ${minInterval / 1000}s)`)
-    return null
-  }
-
-  const result = await runInterventionAnalysis.call(
+  return runInterventionAnalysis.call(
     this,
     sharedChatHistory,
-    baseSystemPrompt,
+    baseSystemPrompt + PUBLIC_INTERVENTION_RULES,
     schema,
     privateConversationHistory ?? null,
     userTemplate
   )
-  if (!result) return null
-
-  const freshRecentIntervention = await Message.findOne({
-    conversation: this.conversation._id,
-    fromAgent: true,
-    visible: true,
-    channels: 'chat',
-    createdAt: { $gte: new Date(now - minInterval) }
-  })
-  if (freshRecentIntervention) {
-    logger.info(`Agent ${this.name} dropping intervention: another agent posted during LLM call`)
-    return null
-  }
-
-  return result
 }
 
 /**

--- a/src/agents/helpers/interventionHandler.ts
+++ b/src/agents/helpers/interventionHandler.ts
@@ -6,6 +6,7 @@ import { getChatPromptResponse } from './llmChain.js'
 
 import config from '../../config/config.js'
 import logger from '../../config/logger.js'
+import Message from '../../models/message.model.js'
 import { InterventionAnalysis, InterventionType } from './interventionTypes.js'
 import { buildSystemPromptWithPersonality, getInterventionExamples } from './agentPersonality.js'
 import validateProfessionalism from './professionalismValidator.js'
@@ -225,10 +226,28 @@ async function runInterventionAnalysis(
 const PUBLIC_INTERVENTION_RULES = `
 When weighing recent agent activity in Shared Chat History, distinguish between agents answering direct participant questions and agents making facilitative contributions — only the latter should count against intervening now.`
 
+const RACE_GUARD_WINDOW_MS = 60 * 1000
+
+/**
+ * Returns true if a proactive agent intervention was posted to chat within the race guard window.
+ * Exported for testing.
+ */
+export async function proactiveRaceGuard(conversationId, now = Date.now()): Promise<boolean> {
+  const fresh = await Message.findOne({
+    conversation: conversationId,
+    'source.proactive': true,
+    visible: true,
+    channels: 'chat',
+    createdAt: { $gte: new Date(now - RACE_GUARD_WINDOW_MS) }
+  })
+  return !!fresh
+}
+
 /**
  * Detects whether to post a public intervention to the shared chat channel.
  * The LLM decides on every invocation whether intervention is appropriate — no rate limiting.
- * Used by eventMediator and engagementAgent.
+ * A post-LLM DB race guard prevents two proactive agents from double-posting when both
+ * evaluate concurrently. Only proactive messages are considered (not Q&A agents).
  */
 export async function detectPublicInterventionOpportunity(
   sharedChatHistory: ConversationHistory,
@@ -237,7 +256,9 @@ export async function detectPublicInterventionOpportunity(
   privateConversationHistory?: ConversationHistory | null,
   userTemplate?: string
 ): Promise<InterventionAnalysis | null> {
-  return runInterventionAnalysis.call(
+  const now = sharedChatHistory.end ? sharedChatHistory.end.getTime() : Date.now()
+
+  const result = await runInterventionAnalysis.call(
     this,
     sharedChatHistory,
     baseSystemPrompt + PUBLIC_INTERVENTION_RULES,
@@ -245,6 +266,14 @@ export async function detectPublicInterventionOpportunity(
     privateConversationHistory ?? null,
     userTemplate
   )
+  if (!result) return null
+
+  if (await proactiveRaceGuard(this.conversation._id, now)) {
+    logger.info(`Agent ${this.name} dropping intervention: another proactive agent posted during LLM call`)
+    return null
+  }
+
+  return result
 }
 
 /**
@@ -268,7 +297,11 @@ export async function detectPrivateInterventionOpportunity(
   const lastIntervention = getRecentAgentInterventions(participantDmHistory).at(-1)
   if (lastIntervention && now - lastIntervention.timestamp.getTime() < minInterval) {
     const secondsAgo = Math.round((now - lastIntervention.timestamp.getTime()) / 1000)
-    logger.debug(`${this.agentType} ${this._id}: rate limited for participant — last intervention ${secondsAgo}s ago (min ${minInterval / 1000}s)`)
+    logger.debug(
+      `${this.agentType} ${this._id}: rate limited for participant — last intervention ${secondsAgo}s ago (min ${
+        minInterval / 1000
+      }s)`
+    )
     return null
   }
 

--- a/src/conversations/eventAssistant.ts
+++ b/src/conversations/eventAssistant.ts
@@ -93,23 +93,10 @@ const eventAssistant: ConversationType = {
       default: true,
       category: 'group-chat',
       userControlled: false,
-      properties: [
-        {
-          name: 'minContributionInterval',
-          label: 'Minimum Minutes Between Contributions',
-          required: false,
-          type: 'number',
-          default: 10
-        }
-      ],
       agents: [
         {
           name: 'eventMediator',
-          properties: [
-            { $ref: 'llmModel.llmModel' },
-            { $ref: 'llmModel.llmPlatform' },
-            { $ref: 'collectiveVoice.minContributionInterval', as: 'agentConfig.minInterval' }
-          ]
+          properties: [{ $ref: 'llmModel.llmModel' }, { $ref: 'llmModel.llmPlatform' }]
         }
       ]
     },
@@ -121,23 +108,10 @@ const eventAssistant: ConversationType = {
       default: true,
       category: 'group-chat',
       userControlled: false,
-      properties: [
-        {
-          name: 'minContributionInterval',
-          label: 'Minimum Minutes Between Contributions',
-          required: false,
-          type: 'number',
-          default: 10
-        }
-      ],
       agents: [
         {
           name: 'engagementAgent',
-          properties: [
-            { $ref: 'llmModel.llmModel' },
-            { $ref: 'llmModel.llmPlatform' },
-            { $ref: 'catalyst.minContributionInterval', as: 'agentConfig.minInterval' }
-          ]
+          properties: [{ $ref: 'llmModel.llmModel' }, { $ref: 'llmModel.llmPlatform' }]
         }
       ]
     },

--- a/src/services/message.service.ts
+++ b/src/services/message.service.ts
@@ -420,7 +420,8 @@ export const agentResponseToMessageData = (response, agent) => ({
   /* Pass the neutral render instruction through so the Slack adapter can
      render it into blocks at send time. */
   ...(response.responseKind !== undefined && { responseKind: response.responseKind }),
-  ...(response.renderData !== undefined && { renderData: response.renderData })
+  ...(response.renderData !== undefined && { renderData: response.renderData }),
+  source: { type: 'agent', ...(response.proactive === true && { proactive: true }) }
 })
 
 const messageService = {

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -463,6 +463,7 @@ export interface AgentResponse<T> {
      into blocks at send time. Other adapters ignore these and send `message`. */
   responseKind?: string
   renderData?: unknown
+  proactive?: boolean
 }
 
 /* The raw counts an analytics source fetcher returns for one event, before we

--- a/tests/agents/engagement/engagement.agent.test.ts
+++ b/tests/agents/engagement/engagement.agent.test.ts
@@ -74,7 +74,6 @@ describe(`engagement agent tests`, () => {
     it('has correct default configuration', () => {
       expect(agent.name).toBe('Engagement Agent')
       expect(agent.description).toContain('energy and participation')
-      expect(agent.agentConfig.minInterval).toBe(5) // 5 min
       expect(agent.agentConfig.personality).toBe('sarcastic-expert')
     })
 
@@ -340,37 +339,70 @@ describe(`engagement agent tests`, () => {
 
   describe('NONE intervention scenarios', () => {
     it(
-      'SHOULD NOT intervene when rate limited (recent intervention)',
+      'SHOULD NOT intervene when agent recently posted and active discussion is flowing',
       async () => {
-        // Create agent message at 01:00 (60 seconds), then check at 03:00 (180 seconds)
-        // That's 2 minutes apart, which is less than minInterval of 5 minutes
-        const agentMsg = await createMessage(
-          'What are your thoughts on this approach?',
-          agent,
+        // Agent posted a provocation, and it sparked a genuine back-and-forth — stay quiet
+        const recentAgentMsg = await createMessage(
+          'Bold claim just went unchallenged — what would need to be true for this whole approach to be wrong?',
+          user1,
           conversation,
           ['chat'],
-          getMessageTime(60)
+          getMessageTime(120)
         )
-        agentMsg.fromAgent = true
+        recentAgentMsg.fromAgent = true
+        recentAgentMsg.pseudonym = agent.name
+
         const messages = [
-          agentMsg,
-          await createMessage('Interesting question', user1, conversation, ['chat'], getMessageTime(120)),
-          await createMessage('I have some thoughts', user2, conversation, ['chat'], getMessageTime(140))
+          recentAgentMsg,
+          await createMessage(
+            'Honestly the whole assumption that people want more hours is wrong — most people I know would take fewer hours for the same pay immediately',
+            user1,
+            conversation,
+            ['chat'],
+            getMessageTime(130)
+          ),
+          await createMessage(
+            'Exactly — the 40 hour week was never about productivity, it was about factory scheduling. We just inherited it',
+            user2,
+            conversation,
+            ['chat'],
+            getMessageTime(145)
+          ),
+          await createMessage(
+            'But then how do you handle roles that need coverage? Not everything can be async',
+            user3,
+            conversation,
+            ['chat'],
+            getMessageTime(158)
+          ),
+          await createMessage(
+            'That is the real question — the model works for knowledge workers but falls apart for shift-based roles',
+            user1,
+            conversation,
+            ['chat'],
+            getMessageTime(170)
+          )
         ]
         await prepareMessagesForAgent(messages, conversation, agent)
 
-        // Try to get response at 03:00, which is 2 minutes after agent's last post (minInterval is 5 min)
-        // Rate limiting now uses conversationHistory.end as "now", so this simulates the correct time
+        // Active discussion is flowing — agent should recognise its provocation landed
         const conversationHistory = getConversationHistory(conversation.messages, {
           count: 100,
           channels: ['transcript'],
-          endTime: new Date(startTime.getTime() + 180 * 1000) // 03:00
+          endTime: new Date(startTime.getTime() + 180 * 1000)
         })
 
         const responses = await defaultAgentTypes.engagementAgent.respond.call(agent, conversationHistory)
 
-        // Should be rate limited - no intervention (only 2 min since last post, need 5 min)
-        expect(responses).toHaveLength(0)
+        if (responses.length > 0) {
+          const { interventionType } = responses[0]
+          console.warn(
+            `[self-limiting] Agent intervened into active discussion: ${interventionType}: ${responses[0].message}`
+          )
+        } else {
+          console.log('[self-limiting] Agent correctly stayed quiet while discussion flowed')
+        }
+        expect(Array.isArray(responses)).toBe(true)
       },
       testTimeout
     )

--- a/tests/agents/engagement/engagement.agent.test.ts
+++ b/tests/agents/engagement/engagement.agent.test.ts
@@ -77,9 +77,9 @@ describe(`engagement agent tests`, () => {
       expect(agent.agentConfig.personality).toBe('sarcastic-expert')
     })
 
-    it('uses periodic trigger on transcript with 60 second interval', () => {
+    it('uses periodic trigger on transcript with 120 second interval', () => {
       expect(agent.triggers.periodic).toBeDefined()
-      expect(agent.triggers.periodic.timerPeriod).toBe(60)
+      expect(agent.triggers.periodic.timerPeriod).toBe(120)
       expect(agent.triggers.periodic.conversationHistorySettings.channels).toContain('transcript')
     })
   })

--- a/tests/agents/eventMediator/eventMediator.agent.test.ts
+++ b/tests/agents/eventMediator/eventMediator.agent.test.ts
@@ -78,9 +78,9 @@ describe(`event mediator agent tests`, () => {
       expect(agent.agentConfig.personality).toBe('sarcastic-expert')
     })
 
-    it('uses periodic trigger on transcript with 67 second interval', () => {
+    it('uses periodic trigger on transcript with 127 second interval', () => {
       expect(agent.triggers.periodic).toBeDefined()
-      expect(agent.triggers.periodic.timerPeriod).toBe(67)
+      expect(agent.triggers.periodic.timerPeriod).toBe(127)
       expect(agent.triggers.periodic.conversationHistorySettings.channels).toContain('transcript')
     })
   })

--- a/tests/agents/eventMediator/eventMediator.agent.test.ts
+++ b/tests/agents/eventMediator/eventMediator.agent.test.ts
@@ -13,7 +13,6 @@ import {
 
 import getConversationHistory from '../../../src/agents/helpers/getConversationHistory.js'
 import { InterventionType } from '../../../src/agents/helpers/interventionTypes.js'
-import Agent from '../../../src/models/user.model/agent.model/index.js'
 import websocketGateway from '../../../src/websockets/websocketGateway.js'
 import schedule from '../../../src/jobs/schedule.js'
 
@@ -69,17 +68,6 @@ describe(`event mediator agent tests`, () => {
     agent = conversation.agents.find((a) => a.name === 'Event Mediator')
     expect(agent).toBeDefined()
 
-    // Add Engagement Agent to the conversation for cross-agent rate limiting tests
-    const engagementAgent = new Agent({
-      agentType: 'engagementAgent',
-      conversation,
-      llmPlatform: testConfig.llmPlatform,
-      llmModel: testConfig.llmModel
-    })
-    await engagementAgent.save()
-    conversation.agents.push(engagementAgent)
-    await conversation.save()
-
     await loadPartTimeWorkTranscript(conversation, true)
   })
 
@@ -87,7 +75,6 @@ describe(`event mediator agent tests`, () => {
     it('has correct default configuration', () => {
       expect(agent.name).toBe('Event Mediator')
       expect(agent.description).toContain('strategic interventions')
-      expect(agent.agentConfig.minInterval).toBe(2) // 2 min
       expect(agent.agentConfig.personality).toBe('sarcastic-expert')
     })
 
@@ -160,203 +147,137 @@ describe(`event mediator agent tests`, () => {
       testTimeout
     )
 
-    describe('rate limiting', () => {
+    describe('self-limiting based on recent agent activity', () => {
       it(
-        'respects rate limiting between interventions',
+        'SHOULD NOT intervene when it recently posted a facilitation message',
         async () => {
-          // Create first pattern
-          const messages1 = [
-            await createDirectMessage('Question about part-time benefits', user1, conversation, getMessageTime(200)),
-            await createDirectMessage('Also curious about part-time benefits', user2, conversation, getMessageTime(210))
-          ]
-          await prepareMessagesForAgent(messages1, conversation, agent)
-
-          const conversationHistory1 = getConversationHistory(conversation.messages, {
-            count: 100,
-            channels: ['transcript'],
-            endTime: new Date(startTime.getTime() + 300 * 1000)
-          })
-
-          const responses1 = await defaultAgentTypes.eventMediator.respond.call(agent, conversationHistory1)
-
-          // If it intervened, create another similar pattern immediately
-          if (responses1.length > 0) {
-            // Add the first agent response to the conversation history
-            const firstResponse = responses1[0]
-            const agentMessage = await createMessage(
-              firstResponse.message,
-              user1, // Using user1 as placeholder since agent messages need a user
-              conversation,
-              ['chat'],
-              getMessageTime(300) // Time when the agent responded
-            )
-            agentMessage.fromAgent = true
-            agentMessage.pseudonym = 'Event Mediator'
-            agentMessage.visible = true
-            await prepareMessagesForAgent([agentMessage], conversation, agent)
-
-            const messages2 = [
-              await createDirectMessage('What about remote work options?', user1, conversation, getMessageTime(301)),
-              await createDirectMessage('Yes, curious about remote work too', user2, conversation, getMessageTime(302))
-            ]
-            await prepareMessagesForAgent(messages2, conversation, agent)
-
-            // Try to respond again immediately (within 1 min)
-            const conversationHistory2 = getConversationHistory(conversation.messages, {
-              count: 100,
-              channels: ['transcript'],
-              endTime: new Date(startTime.getTime() + 335 * 1000) // 35 seconds later
-            })
-
-            const responses2 = await defaultAgentTypes.eventMediator.respond.call(agent, conversationHistory2)
-
-            // Should be rate limited
-            expect(responses2).toEqual([])
-          }
-        },
-        testTimeout
-      )
-
-      it(
-        'respects rate limiting across different agents (Engagement Agent blocks Mediator)',
-        async () => {
-          // Get the Engagement Agent from the conversation
-          const engagementAgent = conversation.agents.find((a) => a.name === 'Engagement Agent')
-          expect(engagementAgent).toBeDefined()
-
-          // Engagement Agent posts an intervention
-          const engagementMessage = await createMessage(
-            'This is an intervention from the engagement agent',
+          // Mediator posted a substantive facilitation message just 30 seconds ago
+          const recentMediatorMsg = await createMessage(
+            'Interesting tension in the room right now — some of you are energised by this framework, others feel something important is being flattened.',
             user1,
             conversation,
             ['chat'],
-            getMessageTime(100)
+            getMessageTime(120)
           )
-          engagementMessage.fromAgent = true
-          engagementMessage.pseudonym = 'Engagement Agent'
-          engagementMessage.visible = true
+          recentMediatorMsg.fromAgent = true
+          recentMediatorMsg.pseudonym = agent.name
+          recentMediatorMsg.pseudonym = agent.name
+          recentMediatorMsg.visible = true
 
-          await prepareMessagesForAgent([engagementMessage], conversation, agent)
+          const messages = [
+            recentMediatorMsg,
+            await createMessage('That is a good point', user1, conversation, ['chat'], getMessageTime(130)),
+            await createMessage('Agreed', user2, conversation, ['chat'], getMessageTime(140))
+          ]
+          await prepareMessagesForAgent(messages, conversation, agent)
 
-          // Try to have Mediator respond 30 seconds later (within the 2 min minInterval)
           const conversationHistory = getConversationHistory(conversation.messages, {
             count: 100,
             channels: ['transcript'],
-            endTime: getMessageTime(130) // 30 seconds after Engagement Agent's post
+            endTime: new Date(startTime.getTime() + 150 * 1000)
           })
 
           const responses = await defaultAgentTypes.eventMediator.respond.call(agent, conversationHistory)
 
-          // Should be rate limited because Engagement Agent posted recently
-          expect(responses).toEqual([])
-        },
-        testTimeout
-      )
-
-      it(
-        'respects rate limiting across different agents (Mediator blocks Engagement Agent)',
-        async () => {
-          // Get the Engagement Agent from the conversation
-          const engagementAgent = conversation.agents.find((a) => a.name === 'Engagement Agent')
-          expect(engagementAgent).toBeDefined()
-
-          // Mediator posts an intervention
-          const mediatorMessage = await createMessage(
-            'This is an intervention from the mediator',
-            user1,
-            conversation,
-            ['chat'],
-            getMessageTime(100)
-          )
-          mediatorMessage.fromAgent = true
-          mediatorMessage.pseudonym = 'Event Mediator'
-          mediatorMessage.visible = true
-
-          await prepareMessagesForAgent([mediatorMessage], conversation, engagementAgent)
-
-          // Try to have Engagement Agent respond 30 seconds later (within the 2 min minInterval)
-          const conversationHistory = getConversationHistory(conversation.messages, {
-            count: 100,
-            channels: ['transcript'],
-            endTime: getMessageTime(130) // 30 seconds after Mediator's post
-          })
-
-          const responses = await defaultAgentTypes.engagementAgent.respond.call(engagementAgent, conversationHistory)
-
-          // Should be rate limited because Mediator posted recently
-          expect(responses).toEqual([])
-        },
-        testTimeout
-      )
-
-      it(
-        'allows intervention after enough time has passed since other agent intervened',
-        async () => {
-          // Get the Engagement Agent from the conversation
-          const engagementAgent = conversation.agents.find((a) => a.name === 'Engagement Agent')
-          expect(engagementAgent).toBeDefined()
-
-          // Mediator posts an intervention
-          const mediatorMessage = await createMessage(
-            'This is an intervention from the mediator',
-            user1,
-            conversation,
-            ['chat'],
-            getMessageTime(100)
-          )
-          mediatorMessage.fromAgent = true
-          mediatorMessage.pseudonym = 'Event Mediator'
-          mediatorMessage.visible = true
-
-          await prepareMessagesForAgent([mediatorMessage], conversation, engagementAgent)
-
-          // Try to have Engagement Agent respond 5 minutes later (beyond the 2 min minInterval)
-          const conversationHistory = getConversationHistory(conversation.messages, {
-            count: 100,
-            channels: ['transcript'],
-            endTime: getMessageTime(360) // 260 seconds = 4 min 20 sec after Mediator's post
-          })
-
-          const responses = await defaultAgentTypes.engagementAgent.respond.call(engagementAgent, conversationHistory)
-
-          // Should NOT be rate limited because enough time has passed
+          if (responses.length > 0) {
+            const { interventionType } = responses[0]
+            console.warn(`[self-limiting] Agent intervened 30s after own post: ${interventionType}: ${responses[0].message}`)
+          } else {
+            console.log('[self-limiting] Agent correctly held back after recent post')
+          }
           expect(Array.isArray(responses)).toBe(true)
         },
         testTimeout
       )
 
       it(
-        'ignores non-visible agent messages for rate limiting',
+        'SHOULD NOT intervene when another facilitation agent recently posted',
         async () => {
-          // Get the Engagement Agent from the conversation
-          const engagementAgent = conversation.agents.find((a) => a.name === 'Engagement Agent')
-          expect(engagementAgent).toBeDefined()
-
-          // Create an agent intervention that is not visible
-          const hiddenAgentMessage = await createMessage(
-            'Hidden intervention',
+          // Engagement Agent posted a provocation 30 seconds ago — mediator should hold back
+          const recentEngagementMsg = await createMessage(
+            "We've been in agreement for a while now. What's the strongest case against what we're converging on?",
             user1,
             conversation,
             ['chat'],
-            getMessageTime(100)
+            getMessageTime(120)
           )
-          hiddenAgentMessage.fromAgent = true
-          hiddenAgentMessage.pseudonym = 'Event Mediator'
-          hiddenAgentMessage.visible = false // Not visible
+          recentEngagementMsg.fromAgent = true
+          recentEngagementMsg.pseudonym = 'Engagement Agent'
+          recentEngagementMsg.visible = true
 
-          await prepareMessagesForAgent([hiddenAgentMessage], conversation, engagementAgent)
+          const messages = [
+            recentEngagementMsg,
+            await createMessage('Hmm good question', user1, conversation, ['chat'], getMessageTime(130)),
+            await createMessage('Let me think', user2, conversation, ['chat'], getMessageTime(140))
+          ]
+          await prepareMessagesForAgent(messages, conversation, agent)
 
-          // Try to have Engagement Agent respond shortly after (within what would be minInterval)
           const conversationHistory = getConversationHistory(conversation.messages, {
             count: 100,
             channels: ['transcript'],
-            endTime: getMessageTime(130)
+            endTime: new Date(startTime.getTime() + 150 * 1000)
           })
 
-          const responses = await defaultAgentTypes.engagementAgent.respond.call(engagementAgent, conversationHistory)
+          const responses = await defaultAgentTypes.eventMediator.respond.call(agent, conversationHistory)
 
-          // Should NOT be rate limited because the agent message was not visible
+          if (responses.length > 0) {
+            const { interventionType } = responses[0]
+            console.warn(
+              `[cross-agent limiting] Agent intervened 30s after other facilitation agent: ${interventionType}: ${responses[0].message}`
+            )
+          } else {
+            console.log('[cross-agent limiting] Agent correctly held back after recent facilitation post')
+          }
           expect(Array.isArray(responses)).toBe(true)
+        },
+        testTimeout
+      )
+
+      it(
+        'SHOULD intervene despite recent Q&A agent activity',
+        async () => {
+          // An event assistant answered a direct question recently — this should NOT block the mediator
+          const recentQAMsg = await createMessage(
+            'The conference is on June 15th at the downtown venue.',
+            user1,
+            conversation,
+            ['chat'],
+            getMessageTime(120)
+          )
+          recentQAMsg.fromAgent = true
+          recentQAMsg.pseudonym = 'Event Assistant'
+          recentQAMsg.visible = true
+
+          const messages = [
+            recentQAMsg,
+            // Strong convergence pattern to give the mediator a clear reason to intervene
+            await createDirectMessage(
+              'What about healthcare for part-time workers?',
+              user1,
+              conversation,
+              getMessageTime(130)
+            ),
+            await createDirectMessage('Healthcare benefits are my main question', user2, conversation, getMessageTime(140)),
+            await createDirectMessage('The benefits question is huge', user3, conversation, getMessageTime(150)),
+            await createMessage('Really useful so far', user1, conversation, ['chat'], getMessageTime(160))
+          ]
+          await prepareMessagesForAgent(messages, conversation, agent)
+
+          const conversationHistory = getConversationHistory(conversation.messages, {
+            count: 100,
+            channels: ['transcript'],
+            endTime: new Date(startTime.getTime() + 200 * 1000)
+          })
+
+          const responses = await defaultAgentTypes.eventMediator.respond.call(agent, conversationHistory)
+
+          // Q&A activity should not suppress the mediator when there is a clear pattern
+          if (responses.length > 0) {
+            console.log(`[Q&A not blocking] Detected ${responses[0].interventionType}:`, responses[0].message)
+          } else {
+            console.warn('[Q&A not blocking] Agent did not intervene despite strong convergence pattern')
+          }
+          expect(responses.length).toBeGreaterThan(0)
         },
         testTimeout
       )

--- a/tests/agents/helpers/interventionHandler.test.ts
+++ b/tests/agents/helpers/interventionHandler.test.ts
@@ -1,9 +1,15 @@
+import mongoose from 'mongoose'
 import {
   getInterventionAnalysisSchema,
   interventionLlmTemplateVars,
-  USER_TEMPLATE
+  USER_TEMPLATE,
+  proactiveRaceGuard
 } from '../../../src/agents/helpers/interventionHandler.js'
 import { InterventionType } from '../../../src/agents/helpers/interventionTypes.js'
+import Message from '../../../src/models/message.model.js'
+import setupIntTest from '../../utils/setupIntTest.js'
+
+setupIntTest()
 
 describe('interventionHandler', () => {
   describe('InterventionType enum', () => {
@@ -191,6 +197,59 @@ describe('interventionHandler', () => {
       expect(USER_TEMPLATE).toContain('{privateMessages}')
       expect(USER_TEMPLATE).toContain('{sharedChatHistory}')
       expect(USER_TEMPLATE).toContain('{agentRecentPosts}')
+    })
+  })
+
+  describe('proactiveRaceGuard', () => {
+    const conversationId = new mongoose.Types.ObjectId()
+    const userId = new mongoose.Types.ObjectId()
+    const pseudonymId = new mongoose.Types.ObjectId()
+
+    const makeMessage = (overrides = {}) =>
+      Message.create({
+        body: 'Test intervention',
+        bodyType: 'text',
+        conversation: conversationId,
+        owner: userId,
+        pseudonym: 'Test Agent',
+        pseudonymId,
+        fromAgent: true,
+        visible: true,
+        channels: ['chat'],
+        upVotes: [],
+        downVotes: [],
+        ...overrides
+      })
+
+    it('returns true when a proactive message exists within the window', async () => {
+      await makeMessage({ source: { type: 'agent', proactive: true }, createdAt: new Date() })
+      expect(await proactiveRaceGuard(conversationId)).toBe(true)
+    })
+
+    it('returns false when no proactive message exists', async () => {
+      expect(await proactiveRaceGuard(conversationId)).toBe(false)
+    })
+
+    it('returns false when proactive message is outside the window', async () => {
+      const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000)
+      await makeMessage({ source: { type: 'agent', proactive: true }, createdAt: twoMinutesAgo })
+      expect(await proactiveRaceGuard(conversationId)).toBe(false)
+    })
+
+    it('returns false for agent messages without source.proactive (e.g. Q&A agents)', async () => {
+      await makeMessage({ source: { type: 'agent' }, createdAt: new Date() })
+      expect(await proactiveRaceGuard(conversationId)).toBe(false)
+    })
+
+    it('returns false for proactive message on a different conversation', async () => {
+      const otherConversationId = new mongoose.Types.ObjectId()
+      await makeMessage({ source: { type: 'agent', proactive: true }, conversation: otherConversationId, createdAt: new Date() })
+      expect(await proactiveRaceGuard(conversationId)).toBe(false)
+    })
+
+    it('returns false for non-visible proactive messages', async () => {
+      await makeMessage({ source: { type: 'agent', proactive: true }, visible: false, createdAt: new Date() })
+      expect(await proactiveRaceGuard(conversationId)).toBe(false)
     })
   })
 })

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -782,15 +782,15 @@ describe('Conversation service methods', () => {
           ...baseParams,
           topicId: topicOne._id.toString(),
           properties: { zoomMeetingUrl: 'https://zoom.us/j/123456789' },
-          features: [{ name: 'collectiveVoice', config: { minContributionInterval: 10 } }]
+          features: [{ name: 'librarian', config: { recommendationsPerInterval: 4 } }]
         }
 
         const conversation = await conversationService.createConversationFromType(params, registeredUser)
 
         const agents = await Agent.find({ conversation: conversation._id })
-        const mediator = agents.find((a) => a.agentType === 'eventMediator')
-        expect(mediator).toBeDefined()
-        expect(mediator!.agentConfig?.minInterval).toBe(10)
+        const librarian = agents.find((a) => a.agentType === 'librarian')
+        expect(librarian).toBeDefined()
+        expect(librarian!.agentConfig?.recommendationsPerInterval).toBe(4)
       })
 
       test('should use feature sub-property default when not provided', async () => {
@@ -798,16 +798,16 @@ describe('Conversation service methods', () => {
           ...baseParams,
           topicId: topicOne._id.toString(),
           properties: { zoomMeetingUrl: 'https://zoom.us/j/123456789' },
-          features: [{ name: 'collectiveVoice' }]
-          // minContributionInterval not provided — feature default is 5
+          features: [{ name: 'librarian' }]
+          // recommendationsPerInterval not provided — feature default is 2
         }
 
         const conversation = await conversationService.createConversationFromType(params, registeredUser)
 
         const agents = await Agent.find({ conversation: conversation._id })
-        const mediator = agents.find((a) => a.agentType === 'eventMediator')
-        expect(mediator).toBeDefined()
-        expect(mediator!.agentConfig?.minInterval).toBe(10)
+        const librarian = agents.find((a) => a.agentType === 'librarian')
+        expect(librarian).toBeDefined()
+        expect(librarian!.agentConfig?.recommendationsPerInterval).toBe(2)
       })
 
       test('should use provided feature sub-property value', async () => {
@@ -815,15 +815,15 @@ describe('Conversation service methods', () => {
           ...baseParams,
           topicId: topicOne._id.toString(),
           properties: { zoomMeetingUrl: 'https://zoom.us/j/123456789' },
-          features: [{ name: 'catalyst', config: { minContributionInterval: 7 } }]
+          features: [{ name: 'librarian', config: { recommendationsPerInterval: 7 } }]
         }
 
         const conversation = await conversationService.createConversationFromType(params, registeredUser)
 
         const agents = await Agent.find({ conversation: conversation._id })
-        const engagement = agents.find((a) => a.agentType === 'engagementAgent')
-        expect(engagement).toBeDefined()
-        expect(engagement!.agentConfig?.minInterval).toBe(7)
+        const librarian = agents.find((a) => a.agentType === 'librarian')
+        expect(librarian).toBeDefined()
+        expect(librarian!.agentConfig?.recommendationsPerInterval).toBe(7)
       })
 
       test('should not set llmModel on agents when llmModel property is omitted', async () => {


### PR DESCRIPTION
## What is in this PR?

<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->

The engagement and eventMediator agents were rate limited by any agent that posts in the group chat. Since EA often decides to contribute by answering questions, any post from EA would reset the rate limit clock (default 10 mins). In some ways this seems desirable. If the chat is active enough, you'd have a natural cap on agent participation. But 10 mins for every single message may be too limiting. 3 or 4 active users can cause no proactive interventions (including polling) to occur at all (as seen in a recent event).

This PR removes the rate limiting entirely and trusts agent discretion as to whether intervention is appropriate given other periodic agent interventions, user contributions to group chat, and transcript content. We also increase the periodic run interval from one minute to two, just in case it decides intervention is always warranted (and to limit LLM cycles)

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- feat: remove public intervention rate limiting, delegate chattiness control to LLM
- feat: change proactive chat agents default periodic interval from one minute to two minutes
- feat: add post-LLM race guard using message source to prevent concurrent proactive agent collisions
this uses the Message `source` property to indicate if a message is from a proactive agent - prevents problem where both agents decide to intervene at the same time (thus neither can see the other one's pending contribution)

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [ ] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x] Create an EA conversation with collectiveVoice and catalyst features
- [x] Play an event and watch logs for intervention analysis. You should not see interventions more frequently than 2 minutes, but you may see one every 2 minutes depending on talk content.
- [x] Ask Berkie some questions in the group chat and ensure that does not cause proactive agents to skip a cycle (again, requires reading reasoning in the log messages to determine for sure why it decides to intervene or not)
- [x] Create another EA conversation with one or both features disabled and ensure only one (or none) enabled (no logs from the agents, etc)



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
