### PR TITLE
private checkin fixes and performance improvements

### DIFF
--- a/src/agents/eventAssistant/checkinHandler.ts
+++ b/src/agents/eventAssistant/checkinHandler.ts
@@ -312,11 +312,14 @@ export async function buildCheckinResponses(conversationHistory: ConversationHis
   const now = conversationHistory.end ? conversationHistory.end.getTime() : Date.now()
   const minInterval = (this.agentConfig?.minInterval ?? 10) * 60 * 1000
 
+  // Use startTime as baseline for first checkin — resets on conversation restart, which is intentional.
+  const conversationStart = new Date(this.conversation.startTime).getTime()
   const anyEligible = directChannels.some((channel) => {
     const lastAgentMsg = conversationHistory.messages
       .filter((m) => m.channels?.includes(channel.name) && m.fromAgent && m.visible)
       .at(-1)
-    return !lastAgentMsg || now - new Date(lastAgentMsg.createdAt!).getTime() >= minInterval
+    const baseline = lastAgentMsg ? new Date(lastAgentMsg.createdAt!).getTime() : conversationStart
+    return now - baseline >= minInterval
   })
 
   if (!anyEligible) {

--- a/src/agents/eventAssistant/checkinHandler.ts
+++ b/src/agents/eventAssistant/checkinHandler.ts
@@ -307,6 +307,23 @@ export async function buildCheckinResponses(conversationHistory: ConversationHis
 
   if (directChannels.length === 0) return []
 
+  // Rate-limit pre-check: if every participant has been messaged recently, there is nothing
+  // to do and we should skip shared evaluations (which include an LLM call for transcript density).
+  const now = conversationHistory.end ? conversationHistory.end.getTime() : Date.now()
+  const minInterval = (this.agentConfig?.minInterval ?? 10) * 60 * 1000
+
+  const anyEligible = directChannels.some((channel) => {
+    const lastAgentMsg = conversationHistory.messages
+      .filter((m) => m.channels?.includes(channel.name) && m.fromAgent && m.visible)
+      .at(-1)
+    return !lastAgentMsg || now - new Date(lastAgentMsg.createdAt!).getTime() >= minInterval
+  })
+
+  if (!anyEligible) {
+    logger.debug('CheckinHandler: all participants rate-limited — skipping shared evaluations')
+    return []
+  }
+
   const sharedChatHistory = getConversationHistory(conversationHistory.messages, {
     count: 100,
     channels: ['chat'],

--- a/src/agents/helpers/interventionHandler.ts
+++ b/src/agents/helpers/interventionHandler.ts
@@ -292,11 +292,13 @@ export async function detectPrivateInterventionOpportunity(
   extraTemplateVars?: Record<string, string>
 ): Promise<InterventionAnalysis | null> {
   const now = sharedChatHistory.end ? sharedChatHistory.end.getTime() : Date.now()
-  const minInterval = (this.agentConfig?.minInterval || 2) * 60 * 1000
+  const minInterval = (this.agentConfig?.minInterval ?? 2) * 60 * 1000
 
   const lastIntervention = getRecentAgentInterventions(participantDmHistory).at(-1)
-  if (lastIntervention && now - lastIntervention.timestamp.getTime() < minInterval) {
-    const secondsAgo = Math.round((now - lastIntervention.timestamp.getTime()) / 1000)
+  // Use startTime as baseline for first intervention — resets on conversation restart, which is intentional.
+  const baseline = lastIntervention ? lastIntervention.timestamp.getTime() : new Date(this.conversation.startTime).getTime()
+  if (now - baseline < minInterval) {
+    const secondsAgo = Math.round((now - baseline) / 1000)
     logger.debug(
       `${this.agentType} ${this._id}: rate limited for participant — last intervention ${secondsAgo}s ago (min ${
         minInterval / 1000

--- a/tests/agents/eventAssistant/checkin.agent.test.ts
+++ b/tests/agents/eventAssistant/checkin.agent.test.ts
@@ -204,7 +204,6 @@ describe('checkin handler tests', () => {
         await prepareMessagesForAgent([msg1, reply1, msg2, reply2, msg3, reply3], ag.conversation, ag)
         const responses = await runCheckin(ag)
 
-        console.log('Self-minimization pattern responses:', JSON.stringify(responses, null, 2))
         const checkin = findCheckinForUser(responses, user1._id)
         expect(checkin).toBeDefined()
         expect(checkin.message.type).toBe('checkin')
@@ -263,7 +262,6 @@ describe('checkin handler tests', () => {
         await prepareMessagesForAgent([msg1, reply1, msg2, reply2, msg3, reply3], ag.conversation, ag)
         const responses = await runCheckin(ag)
 
-        console.log('Isolation-checking pattern responses:', JSON.stringify(responses, null, 2))
         const checkin = findCheckinForUser(responses, user1._id)
         expect(checkin).toBeDefined()
         expect(checkin.message.type).toBe('checkin')
@@ -322,7 +320,6 @@ describe('checkin handler tests', () => {
         await prepareMessagesForAgent([msg1, reply1, msg2, reply2, msg3, reply3], ag.conversation, ag)
         const responses = await runCheckin(ag)
 
-        console.log('Pull-back after friction responses:', JSON.stringify(responses, null, 2))
         const checkin = findCheckinForUser(responses, user1._id)
         expect(checkin).toBeDefined()
         expect(checkin.message.type).toBe('checkin')
@@ -363,7 +360,6 @@ describe('checkin handler tests', () => {
         await prepareMessagesForAgent([msg1, msg2, msg3], ag.conversation, ag)
         const responses = await runCheckin(ag)
 
-        console.log('NOT_ALONE responses:', JSON.stringify(responses, null, 2))
         expect(responses.length).toBeGreaterThan(0)
 
         responses.forEach((r) => {
@@ -409,7 +405,6 @@ describe('checkin handler tests', () => {
         await prepareMessagesForAgent([msg1, msg2, msg3], ag.conversation, ag)
         const responses = await runCheckin(ag)
 
-        console.log('INTEREST_BRIDGE responses:', JSON.stringify(responses, null, 2))
         expect(responses.length).toBeGreaterThan(0)
         responses.forEach((r) => {
           expect(r.message.type).toBe('checkin')
@@ -433,8 +428,6 @@ describe('checkin handler tests', () => {
         // transcript, which is only ~75s long and loaded at the very start of the conversation.
         await prepareMessagesForAgent([], ag.conversation, ag)
         const responses = await runCheckin(ag, getTime(2 * 60))
-
-        console.log('TRANSCRIPT_HOOK responses:', JSON.stringify(responses, null, 2))
 
         if (responses.length > 0) {
           const checkin = findCheckinForUser(responses, user1._id)
@@ -473,6 +466,45 @@ describe('checkin handler tests', () => {
   })
 
   describe('rate limiting', () => {
+    it('does not send a checkin when conversation started less than minInterval ago and no prior DMs', async () => {
+      const { agent: ag } = await createCheckinConversation([user1])
+      ag.agentConfig = { ...ag.agentConfig, minInterval: 10 }
+      // Override startTime to 2 min ago — well within the 10-min minInterval
+      ag.conversation.startTime = new Date(Date.now() - 2 * 60 * 1000)
+
+      const getLLMSpy = jest.spyOn(ag, 'getLLM')
+
+      await prepareMessagesForAgent([], ag.conversation, ag)
+      await runCheckin(ag, new Date())
+
+      // Rate-limit early return must have fired — LLM should never be called
+      expect(getLLMSpy).not.toHaveBeenCalled()
+    })
+
+    it(
+      'is eligible for first checkin after minInterval has passed since conversation start with no prior DMs',
+      async () => {
+        const { agent: ag } = await createCheckinConversation([user1])
+        ag.agentConfig = { ...ag.agentConfig, minInterval: 10 }
+        await loadPartTimeWorkTranscript(ag.conversation, true)
+
+        const getLLMSpy = jest.spyOn(ag, 'getLLM')
+
+        // 3 participant messages to make SOCIAL_REASSURANCE eligible
+        const msg1 = await createDirectMessage('This is really interesting', user1, ag.conversation, getTime(2 * 60))
+        const msg2 = await createDirectMessage('I had no idea about that', user1, ag.conversation, getTime(4 * 60))
+        const msg3 = await createDirectMessage('Makes me think about my own work', user1, ag.conversation, getTime(6 * 60))
+
+        await prepareMessagesForAgent([msg1, msg2, msg3], ag.conversation, ag)
+        // endTime is 12 min after startTime — past the 10-min minInterval, no prior agent messages
+        await runCheckin(ag, getTime(12 * 60))
+
+        // If rate-limited, buildCheckinResponses returns before any LLM call
+        expect(getLLMSpy).toHaveBeenCalled()
+      },
+      testTimeout
+    )
+
     it(
       'does not send a checkin when one was already sent recently',
       async () => {
@@ -531,12 +563,14 @@ describe('checkin handler tests', () => {
           getTime(320)
         )
 
+        const getLLMSpy = jest.spyOn(ag, 'getLLM')
+
         await prepareMessagesForAgent([msg1, reply1, msg2, reply2, msg3, reply3, recentCheckin], ag.conversation, ag)
         // endTime is 80s after the pre-seeded checkin — well within the 10-min minInterval
-        const responses = await runCheckin(ag, getTime(400))
+        await runCheckin(ag, getTime(400))
 
-        const checkin = findCheckinForUser(responses, user1._id)
-        expect(checkin).toBeUndefined()
+        // Rate-limit early return must have fired — LLM should never be called
+        expect(getLLMSpy).not.toHaveBeenCalled()
       },
       testTimeout
     )


### PR DESCRIPTION


## What is in this PR?

<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->

- performance improvement: eliminate private checkin transcript density LLM calls if all users would be rate limited
- fix: use conversation startTime as rate-limit baseline for first private checkin to prevent checkins from being sent in the first interval (default first 10 minutes)


## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- see above

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Create an EA conversation in NS using a transcript with a lot of academic/dense concepts
- [ ] Ensure jargon clarification preference is set to false to prevent those messages from coming as DMs
- [ ] Sit for about 10 minutes with transcript running but no DMs
- [ ] Verify 'transcript density' checkin shows up in DMs after about 10 mins


## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
