### PR TITLE
feat: handle participant_events.leave to clean up zoom adapter DM config on departure

### DIFF
--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -154,6 +154,10 @@ export default {
   async participantJoined(participant) {
     // no-op for now. Agents do not DM participants until they receive a DM
   },
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async participantLeft(participant) {
+    // no-op
+  },
   async getChannels(message) {
     const isDM = message.channel_type === 'im'
     if (isDM && !this.conversation.enableDMs.includes('agents')) {

--- a/src/adapters/zoom.ts
+++ b/src/adapters/zoom.ts
@@ -55,7 +55,7 @@ async function deployMeetingBot() {
     },
     {
       type: 'webhook',
-      events: ['participant_events.join', 'participant_events.update'],
+      events: ['participant_events.join', 'participant_events.update', 'participant_events.leave'],
       url: `${config.recall.endpointBaseUrl}/v1/webhooks/recall/join/?conversationId=${this.conversation._id}`
     }
   ]
@@ -441,6 +441,17 @@ export default {
         defaultPreferences
       }
       return adapterUser
+    }
+  },
+  async participantLeft(participant) {
+    if (!this.conversation.populated('adapters')) {
+      await this.conversation.populate('adapters')
+    }
+    const bots = this.conversation.adapters.filter((adapter) => adapter.type === 'zoom' && adapter.config?.botName)
+    const botNames = bots.map((bot) => bot.config?.botName)
+    botNames.push(defaultBotName)
+    if (!botNames.includes(participant.name)) {
+      return { username: participant.name }
     }
   },
   async participantUpdated(participant) {

--- a/src/handlers/recall.ts
+++ b/src/handlers/recall.ts
@@ -115,6 +115,7 @@ const supportedEvents = [
   'transcript.data',
   'participant_events.chat_message',
   'participant_events.join',
+  'participant_events.leave',
   'participant_events.update',
   'bot.call_ended',
   'bot.in_call_recording',
@@ -158,6 +159,8 @@ const handleEvent = async (req, _res) => {
     await webhookService.receiveMessage(zoomAdapter, req.body)
   } else if (event === 'participant_events.join') {
     await webhookService.participantJoined(zoomAdapter, req.body.data.data.participant)
+  } else if (event === 'participant_events.leave') {
+    await webhookService.participantLeft(zoomAdapter, req.body.data.data.participant)
   } else if (event === 'participant_events.update') {
     await webhookService.participantUpdated(zoomAdapter, req.body.data.data.participant)
   }

--- a/src/models/adapter.model.ts
+++ b/src/models/adapter.model.ts
@@ -11,6 +11,7 @@ export interface AdapterMethods {
   sendMessage(message: IMessage)
   validateBeforeUpdate()
   participantJoined(participant: Record<string, unknown>)
+  participantLeft(participant: Record<string, unknown>)
   participantUpdated(participant: Record<string, unknown>)
 }
 
@@ -121,6 +122,9 @@ function getChannelConfigByName(channelName) {
       return dmChannel
     }
   }
+  logger.debug(
+    `No channel config found for channel ${channelName} on adapter ${this._id}. Participant may have left. Message will not be sent.`
+  )
 }
 
 async function populateConversation() {
@@ -235,6 +239,15 @@ adapterSchema.method('participantJoined', async function (participant) {
     return
   }
   return await adapterTypes[this.type].participantJoined.call(this, participant)
+})
+
+adapterSchema.method('participantLeft', async function (participant) {
+  if (!this.active) {
+    logger.warn(`Inactive adapter: ${this._id} received message`)
+    return
+  }
+  await populateConversation.call(this)
+  return await adapterTypes[this.type].participantLeft.call(this, participant)
 })
 
 adapterSchema.method('participantUpdated', async function (participant) {

--- a/src/services/webhook.service.ts
+++ b/src/services/webhook.service.ts
@@ -133,6 +133,41 @@ const participantJoined = async (adapter, participant) => {
   }
 }
 
+const participantLeft = async (adapter, participant) => {
+  const adapterUser = await adapter.participantLeft(participant)
+  if (!adapterUser) return
+
+  const user = await User.findOne({ username: adapterUser.username })
+  if (!user) {
+    logger.warn(`participantLeft: no user found for username "${adapterUser.username}"`)
+    return
+  }
+
+  // Clean up adapter dmChannels config for this user — mirrors what getOrCreateUser does on join
+  const directChannelPrefix = `direct-${user._id}-`
+  let configChanged = false
+  const updatedDmChannels = adapter.dmChannels.map((dmChannelConfig) => {
+    const updatedConfig = { ...(dmChannelConfig.config || {}) }
+    let channelConfigChanged = false
+    for (const key of Object.keys(updatedConfig)) {
+      if (key.startsWith(directChannelPrefix) || key === adapterUser.username) {
+        delete updatedConfig[key]
+        channelConfigChanged = true
+      }
+    }
+    if (channelConfigChanged) {
+      configChanged = true
+      return { ...dmChannelConfig, config: updatedConfig }
+    }
+    return dmChannelConfig
+  })
+  if (configChanged) {
+    // eslint-disable-next-line no-param-reassign
+    adapter.dmChannels = updatedDmChannels
+    await adapter.save()
+  }
+}
+
 const participantUpdated = async (adapter, participant) => {
   const adapterUser: AdapterUser = await adapter.participantUpdated(participant)
   if (adapterUser) {
@@ -140,5 +175,5 @@ const participantUpdated = async (adapter, participant) => {
   }
 }
 
-const webhookService = { receiveMessage, participantJoined, participantUpdated }
+const webhookService = { receiveMessage, participantJoined, participantLeft, participantUpdated }
 export default webhookService

--- a/tests/adapters/zoom.adapter.test.ts
+++ b/tests/adapters/zoom.adapter.test.ts
@@ -2212,7 +2212,7 @@ describe('zoom adapter tests', () => {
               },
               {
                 type: 'webhook',
-                events: ['participant_events.join', 'participant_events.update'],
+                events: ['participant_events.join', 'participant_events.update', 'participant_events.leave'],
                 url: `${config.recall.endpointBaseUrl}/v1/webhooks/recall/join/?conversationId=${conversation._id}`
               }
             ],
@@ -2290,7 +2290,7 @@ describe('zoom adapter tests', () => {
               },
               {
                 type: 'webhook',
-                events: ['participant_events.join', 'participant_events.update'],
+                events: ['participant_events.join', 'participant_events.update', 'participant_events.leave'],
                 url: `${config.recall.endpointBaseUrl}/v1/webhooks/recall/join/?conversationId=${conversation._id}`
               }
             ],
@@ -3030,6 +3030,51 @@ describe('zoom adapter tests', () => {
         platform: 'zoom'
       }
       const adapterUser = await adapter.participantJoined(customBotParticipant)
+      expect(adapterUser).toBeUndefined()
+    })
+  })
+  describe('participantLeft', () => {
+    it('returns username when a real participant leaves', async () => {
+      await createConversation('Meeting with Leaving Participant')
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      const participant = { id: 200, name: 'Leaving User', is_host: false, platform: 'zoom' }
+
+      const adapterUser = await adapter.participantLeft(participant)
+      expect(adapterUser).toEqual({ username: 'Leaving User' })
+    })
+
+    it('returns undefined when the default bot leaves', async () => {
+      await createConversation('Meeting where Bot Leaves')
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      const botParticipant = { id: 600, name: 'LLM Engine', is_host: false, platform: 'zoom' }
+
+      const adapterUser = await adapter.participantLeft(botParticipant)
+      expect(adapterUser).toBeUndefined()
+    })
+
+    it('returns undefined when a configured bot name leaves', async () => {
+      await createConversation('Meeting with Custom Bot Leave')
+      conversation.enableDMs = ['agents']
+
+      const adapter2 = await Adapter.create({
+        type: 'zoom',
+        conversation,
+        config: {
+          botId: 'custom-bot-id-789',
+          meetingUrl: 'http://zoom.meeting.com',
+          botName: 'Custom Meeting Assistant'
+        },
+        active: true
+      })
+      conversation.adapters.push(adapter2)
+      await conversation.save()
+
+      const customBotParticipant = { id: 700, name: 'Custom Meeting Assistant', is_host: false, platform: 'zoom' }
+      const adapterUser = await adapter.participantLeft(customBotParticipant)
       expect(adapterUser).toBeUndefined()
     })
   })

--- a/tests/handlers/recall.handler.test.ts
+++ b/tests/handlers/recall.handler.test.ts
@@ -55,6 +55,7 @@ const testAdapterTypes = {
 describe('POST /v1/webhooks/recall', () => {
   let receiveMessageSpy
   let updateTranscriptStatusSpy
+  let participantLeftSpy
   let zoomAdapter
   let realtimeSecret
   let svixSecret
@@ -81,6 +82,7 @@ describe('POST /v1/webhooks/recall', () => {
     await conversation.save()
     receiveMessageSpy = jest.spyOn(webhookService, 'receiveMessage').mockResolvedValue()
     updateTranscriptStatusSpy = jest.spyOn(conversationService, 'updateTranscriptStatus').mockResolvedValue()
+    participantLeftSpy = jest.spyOn(webhookService, 'participantLeft').mockResolvedValue()
     mockZoomGetUniqueKeys.mockReturnValue(['type', 'config.meetingUrl'])
   })
   afterAll(() => {
@@ -590,6 +592,27 @@ describe('POST /v1/webhooks/recall', () => {
       await request(app).post(`/v1/webhooks/recall`).set(headers).send(statusChangeEvent).expect(httpStatus.OK)
 
       expect(updateTranscriptStatusSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('participant_events.leave event', () => {
+    test('should call participantLeft with the adapter and participant from the payload', async () => {
+      const participant = { id: 123, name: 'Leaving User', is_host: false }
+      const participantLeftEvent = {
+        event: 'participant_events.leave',
+        data: {
+          bot: { id: botId },
+          data: { participant }
+        }
+      }
+      const headers = generateWebhookSignature(participantLeftEvent, config.recall.realtimeSecret)
+      await request(app)
+        .post(`/v1/webhooks/recall?conversationId=${conversation._id}`)
+        .set(headers)
+        .send(participantLeftEvent)
+        .expect(httpStatus.OK)
+
+      expect(participantLeftSpy).toHaveBeenCalledWith(expect.objectContaining({ _id: zoomAdapter._id }), participant)
     })
   })
 })

--- a/tests/models/adapter.model.test.ts
+++ b/tests/models/adapter.model.test.ts
@@ -15,6 +15,7 @@ const mockStart = jest.fn()
 const mockStop = jest.fn()
 const mockGetChannels = jest.fn()
 const mockparticipantJoined = jest.fn()
+const mockParticipantLeft = jest.fn()
 const mockGetUniqueKeys = jest.fn()
 
 const testAdapterTypes = {
@@ -25,6 +26,7 @@ const testAdapterTypes = {
     stop: mockStop,
     getChannels: mockGetChannels,
     participantJoined: mockparticipantJoined,
+    participantLeft: mockParticipantLeft,
     getUniqueKeys: mockGetUniqueKeys
   },
   zoom: {
@@ -34,6 +36,7 @@ const testAdapterTypes = {
     stop: mockStop,
     getChannels: mockGetChannels,
     participantJoined: mockparticipantJoined,
+    participantLeft: mockParticipantLeft,
     getUniqueKeys: mockGetUniqueKeys
   }
 }
@@ -260,5 +263,23 @@ describe('adapter tests', () => {
     const adapterUser = await adapter.participantJoined(participant)
     expect(mockparticipantJoined).toHaveBeenCalledWith(participant)
     expect(adapterUser).toBe(mockUser)
+  })
+
+  test('should not call participantLeft on adapter type if inactive', async () => {
+    const adapter = new Adapter({ type: 'slack', conversation })
+    await adapter.save()
+    const participant = { id: 'participant1', name: 'Participant 1' }
+    await adapter.participantLeft(participant)
+    expect(mockParticipantLeft).not.toHaveBeenCalled()
+  })
+
+  test('should call participantLeft on adapter type when active', async () => {
+    const adapter = new Adapter({ type: 'slack', conversation })
+    await adapter.save()
+    await adapter.start()
+    const participant = { id: 'participant1', name: 'Participant 1' }
+    mockParticipantLeft.mockResolvedValue({ username: 'Participant 1' })
+    await adapter.participantLeft(participant)
+    expect(mockParticipantLeft).toHaveBeenCalledWith(participant)
   })
 })

--- a/tests/services/webhook.service.test.ts
+++ b/tests/services/webhook.service.test.ts
@@ -39,6 +39,7 @@ const testAgentTypeSpecification = {
 const mockAdapterType = {
   receiveMessage: jest.fn(),
   participantJoined: jest.fn(),
+  participantLeft: jest.fn(),
   participantUpdated: jest.fn()
 }
 const testAdapterTypes = {
@@ -93,6 +94,7 @@ describe('adapter service tests', () => {
     // Add mock methods to the adapter instance
     adapter.receiveMessage = mockAdapterType.receiveMessage
     adapter.participantJoined = mockAdapterType.participantJoined
+    adapter.participantLeft = mockAdapterType.participantLeft
     adapter.participantUpdated = mockAdapterType.participantUpdated
 
     conversation.adapters.push(adapter)
@@ -1241,6 +1243,148 @@ describe('adapter service tests', () => {
       await conversation.populate('channels')
       const directChannel = conversation.channels.find((c) => c.name.includes('direct-'))
       expect(directChannel).toBeUndefined()
+    })
+  })
+
+  describe('participantLeft', () => {
+    it('does nothing when adapter type returns null (bot left)', async () => {
+      await createConversation('Meeting where Bot Left')
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      mockAdapterType.participantLeft.mockReturnValue(null)
+
+      await webhookService.participantLeft(adapter, { id: 999, name: 'LLM Engine', is_host: false })
+
+      expect(mockAdapterType.participantLeft).toHaveBeenCalled()
+      // No channels should exist
+      await conversation.populate('channels')
+      expect(conversation.channels.filter((c) => c.name?.startsWith('direct-'))).toHaveLength(0)
+    })
+
+    it('does nothing when user is not found in the database', async () => {
+      await createConversation('Meeting with Unknown Leaver')
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      mockAdapterType.participantLeft.mockReturnValue({ username: 'Ghost User' })
+
+      // Ghost User was never created in the DB
+      await webhookService.participantLeft(adapter, { id: 1, name: 'Ghost User', is_host: false })
+
+      expect(mockAdapterType.participantLeft).toHaveBeenCalled()
+      const ghostUser = await User.findOne({ username: 'Ghost User' })
+      expect(ghostUser).toBeNull()
+    })
+
+    it('cleans up adapter dmChannels config when participant leaves', async () => {
+      await createConversation('Meeting with Leaving Participant')
+      conversation.enableDMs = ['agents']
+
+      const agent = new Agent({ agentType: 'test', conversation })
+      await agent.save()
+      conversation.agents.push(agent)
+      await conversation.save()
+
+      const leavingUser = await User.create({
+        username: 'Leaving User',
+        pseudonyms: [{ token: 'leave-token', pseudonym: 'Leaving Pseudonym', active: true }]
+      })
+      const directChannelName = `direct-${leavingUser._id}-${agent._id}`
+
+      adapter.dmChannels = [{ direct: true, agent: agent._id, config: { [directChannelName]: { to: 200 } } }]
+      await adapter.save()
+
+      mockAdapterType.participantLeft.mockReturnValue({ username: 'Leaving User' })
+
+      await webhookService.participantLeft(adapter, { id: 200, name: 'Leaving User', is_host: false })
+
+      const updatedAdapter = await Adapter.findById(adapter._id)
+      const dmChannel = updatedAdapter!.dmChannels!.find((c) => c.direct)
+      expect(dmChannel!.config?.[directChannelName]).toBeUndefined()
+    })
+
+    it('removes username-keyed dmChannel config entry when participant leaves', async () => {
+      await createConversation('Meeting with Named Moderator Leaving')
+      conversation.enableDMs = ['agents']
+      await conversation.save()
+
+      await User.create({
+        username: 'Host User',
+        pseudonyms: [{ token: 'host-token', pseudonym: 'Host Pseudonym', active: true }]
+      })
+
+      adapter.dmChannels = [{ name: 'moderator', users: 'hosts', config: { 'Host User': { to: 700 } } }]
+      await adapter.save()
+
+      mockAdapterType.participantLeft.mockReturnValue({ username: 'Host User' })
+
+      await webhookService.participantLeft(adapter, { id: 700, name: 'Host User', is_host: true })
+
+      const updatedAdapter = await Adapter.findById(adapter._id)
+      const moderatorChannel = updatedAdapter!.dmChannels!.find((c) => c.name === 'moderator')
+      expect(moderatorChannel!.config?.['Host User']).toBeUndefined()
+    })
+
+    it('leaves unrelated channels and other users dmConfig intact', async () => {
+      await createConversation('Meeting with Multiple Participants Leaving')
+      conversation.enableDMs = ['agents']
+
+      const agent = new Agent({ agentType: 'test', conversation })
+      await agent.save()
+      conversation.agents.push(agent)
+      await conversation.save()
+
+      const leavingUser = await User.create({
+        username: 'Participant A',
+        pseudonyms: [{ token: 'token-a', pseudonym: 'Pseudonym A', active: true }]
+      })
+      const stayingUser = await User.create({
+        username: 'Participant B',
+        pseudonyms: [{ token: 'token-b', pseudonym: 'Pseudonym B', active: true }]
+      })
+
+      const leavingChannelName = `direct-${leavingUser._id}-${agent._id}`
+      const stayingChannelName = `direct-${stayingUser._id}-${agent._id}`
+      const groupChannel = await Channel.create({ name: 'participant' })
+      const leavingChannel = await Channel.create({
+        name: leavingChannelName,
+        direct: true,
+        participants: [leavingUser, agent]
+      })
+      const stayingChannel = await Channel.create({
+        name: stayingChannelName,
+        direct: true,
+        participants: [stayingUser, agent]
+      })
+      conversation.channels.push(groupChannel, leavingChannel, stayingChannel)
+      await conversation.save()
+
+      adapter.dmChannels = [
+        {
+          direct: true,
+          agent: agent._id,
+          config: {
+            [leavingChannelName]: { to: 100 },
+            [stayingChannelName]: { to: 200 }
+          }
+        }
+      ]
+      await adapter.save()
+
+      mockAdapterType.participantLeft.mockReturnValue({ username: 'Participant A' })
+      await webhookService.participantLeft(adapter, { id: 100, name: 'Participant A', is_host: false })
+
+      // All channel documents are preserved
+      expect(await Channel.findById(leavingChannel._id)).not.toBeNull()
+      expect(await Channel.findById(stayingChannel._id)).not.toBeNull()
+      expect(await Channel.findById(groupChannel._id)).not.toBeNull()
+
+      // Only the leaving user's dmConfig entry is removed
+      const updatedAdapter = await Adapter.findById(adapter._id)
+      const dmChannel = updatedAdapter!.dmChannels!.find((c) => c.direct)
+      expect(dmChannel!.config?.[leavingChannelName]).toBeUndefined()
+      expect(dmChannel!.config?.[stayingChannelName]).toEqual({ to: 200 })
     })
   })
 })


### PR DESCRIPTION
## What is in this PR?

<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->

removes departed participant's dmChannels config on leave; future messages dropped silently

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

Listen for recall `participant_events.leave` and remove user's entry in the Zoom adapter's dmChannelConfig to prevent future 400 errors attempting to send proactive checkin DMs to a user who is no longer there. Considered deleting the direct channel entirely, which would be more efficient to prevent the checkin LLM call in the first place, but we have post-event reporting and possibly other areas that assume that direct channels remain after an event is over. A user leaving early should not necessarily impact this. Could be worth implementing a leaveConversation endpoint that at least sets a property on the channel in the future if NS could detect when someone has 'left' the conversation by closing the browser tab.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x] You need at least two people, so grab me or someone else :)
- [x] Create a NS event for Zoom with an academic/dense transcript
- [x] Have both users join the Zoom. The user that is going to leave should not send a DM. 
- [x] Have a user leave 
- [x] Send a DM to Berkie in Zoom (this is only necessary bc of a bug that is fixed in another PR that requires some DM history to send any proactive messages)
- [x] Wait 10 minutes or so. You should get a checkin message. The log should not show any 400 errors for attempts to send a checkin to the user that left 


## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
