### PR TITLE
Add draft status for incomplete calendar-invite conversations

### DIFF
--- a/src/conversations/eventAssistant.ts
+++ b/src/conversations/eventAssistant.ts
@@ -23,7 +23,8 @@ const eventAssistant: ConversationType = {
       label: 'Zoom Meeting URL',
       description: 'The zoom meeting link for transcription purposes',
       required: true,
-      type: 'string'
+      type: 'string',
+      format: 'zoomUrl'
     },
     {
       name: 'botName',

--- a/src/conversations/propertyFormats.ts
+++ b/src/conversations/propertyFormats.ts
@@ -1,0 +1,35 @@
+import { PropertyFormat } from '../types/index.types.js'
+
+/*
+ * Named validators for a ConfigProperty's optional `format`. A format names a real check rather
+ * than a regex, so security-sensitive rules parse the value the way the runtime will instead of
+ * pattern-matching a raw string. Both the create path (resolver.validateProperties, which throws)
+ * and the draft check (isConversationDraft, which flags for review) run these, so each rule lives
+ * in one place and the two paths can never disagree.
+ */
+
+/**
+ * True when the URL points at a Zoom host: zoom.us or a vanity subdomain like harvard.zoom.us.
+ * Parses with the URL constructor so a spoof like https://zoom.us@evil.com resolves to its real
+ * host (evil.com) and fails. Anything that isn't a parseable URL is invalid.
+ */
+export function isZoomUrl(url: unknown): boolean {
+  if (typeof url !== 'string' || !url) return false
+  try {
+    const { hostname } = new URL(url)
+    return hostname === 'zoom.us' || hostname.endsWith('.zoom.us')
+  } catch {
+    return false
+  }
+}
+
+/* Record over PropertyFormat, so adding a format name to the union without a validator here is a
+   compile error rather than a silent pass. */
+const propertyFormatValidators: Record<PropertyFormat, (value: unknown) => boolean> = {
+  zoomUrl: isZoomUrl
+}
+
+/** Runs the validator for a property's declared format against a value. */
+export function isValidPropertyFormat(format: PropertyFormat, value: unknown): boolean {
+  return propertyFormatValidators[format](value)
+}

--- a/src/conversations/resolver.ts
+++ b/src/conversations/resolver.ts
@@ -2,6 +2,7 @@ import handlebars from 'handlebars'
 import httpStatus from 'http-status'
 import ApiError from '../utils/ApiError.js'
 import { AgentProperty, ConversationType, Feature, FeatureConfig } from '../types/index.types.js'
+import { isValidPropertyFormat } from './propertyFormats.js'
 
 interface ResolvedConversationConfig {
   agentTypes: Array<{ name: string; properties?: Record<string, unknown> }>
@@ -98,9 +99,17 @@ const resolvePropertyReferences = (obj, properties: Record<string, unknown>) => 
   return coerceValues(removeEmptyValues(parsed))
 }
 
-const validateProperties = (properties: Record<string, unknown>, propDefs: ConversationType['properties']): void => {
+/* allowDraft relaxes the two checks that draft status also tracks: a missing required
+   property and a malformed format value. The email webhook sets it so an incomplete
+   invite becomes a draft for review instead of a 400. Enum and object-shape checks stay
+   strict either way. The event form leaves it off, so form submissions stay strict. */
+const validateProperties = (
+  properties: Record<string, unknown>,
+  propDefs: ConversationType['properties'],
+  allowDraft = false
+): void => {
   for (const prop of propDefs) {
-    if (prop.required && !(prop.name in properties)) {
+    if (!allowDraft && prop.required && !(prop.name in properties)) {
       throw new ApiError(httpStatus.BAD_REQUEST, `Required property '${prop.name}' is missing`)
     }
 
@@ -143,6 +152,15 @@ const validateProperties = (properties: Record<string, unknown>, propDefs: Conve
           )
         }
       }
+    }
+
+    if (
+      !allowDraft &&
+      prop.format &&
+      prop.name in properties &&
+      !isValidPropertyFormat(prop.format, properties[prop.name])
+    ) {
+      throw new ApiError(httpStatus.BAD_REQUEST, `Property '${prop.name}' is not a valid ${prop.format}`)
     }
   }
 }
@@ -220,11 +238,12 @@ export default function resolveConversationType(
     properties?: Record<string, unknown>
     features?: Array<{ name: string; enabled?: boolean; config?: Record<string, unknown> }>
   },
-  conversationType: ConversationType
+  conversationType: ConversationType,
+  allowDraft = false
 ): ResolvedConversationConfig {
   const { platforms, properties = {}, features: requestedFeatures } = params
 
-  validateProperties(properties, conversationType.properties)
+  validateProperties(properties, conversationType.properties, allowDraft)
   const resolvedProperties = resolvePropertyDefaults(properties, conversationType.properties)
   const features = resolveFeatures(requestedFeatures, conversationType.features)
 

--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -827,6 +827,12 @@ components:
             $ref: '#/components/schemas/Experiment'
         active:
           type: boolean
+        draft:
+          type: boolean
+          readOnly: true
+          description: >
+            Server-computed. True until the conversation has a valid Zoom link, name,
+            topic, scheduledTime, and scheduledEndTime; cannot be set directly by clients.
         locked:
           type: boolean
         enableAgents:

--- a/src/models/conversation.model.ts
+++ b/src/models/conversation.model.ts
@@ -103,6 +103,12 @@ const conversationSchema = new mongoose.Schema<IConversation, ConversationModel>
       type: Boolean,
       default: false
     },
+    /* Fail-closed default: an unsaved or bypassed-service-layer conversation is treated as
+       Draft until conversation.service explicitly computes and sets the real value. */
+    draft: {
+      type: Boolean,
+      default: true
+    },
     owner: {
       type: mongoose.SchemaTypes.ObjectId,
       ref: 'BaseUser',

--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -18,13 +18,16 @@ import resolveConversationType from '../../conversations/resolver.js'
 import { supportedModels } from '../../agents/helpers/getEmbeddings.js'
 import transcript from '../../agents/helpers/transcript.js'
 import reportService from '../report.service.js'
-import { doStartConversation, doStopConversation, updateTranscriptStatus } from './lifecycle.js'
+import { doStartConversation, doStopConversation, updateTranscriptStatus, isConversationDraft } from './lifecycle.js'
 import resourceService from '../resource.service.js'
 
 export { updateTranscriptStatus }
 
 const returnFields =
-  'name slug locked owner createdAt active conversationType platforms scheduledTime scheduledEndTime startTime endTime description moderators presenters transcript properties features'
+  'name slug locked owner createdAt active draft conversationType platforms scheduledTime scheduledEndTime startTime endTime description moderators presenters transcript properties features'
+/* A Draft conversation can no longer be edited once its scheduled start time is imminent;
+   past this point the owner should create a new event rather than editing this one. */
+const draftEditLockoutMs = 6 * 60 * 1000 // 6 minutes
 export const maxScheduledInterval = 10 * 60 * 1000 // 10 minutes in milliseconds
 export const { autoStartLeadTimeMs } = config.conversation
 export const { autoStopDelayMs } = config.conversation
@@ -184,6 +187,7 @@ const createConversation = async (conversationBody, user) => {
     scheduledTime: conversationBody.scheduledTime,
     scheduledEndTime: conversationBody.scheduledEndTime
   })
+  conversation.draft = isConversationDraft(conversation)
   // need to save to get id
   await conversation.save()
 
@@ -218,8 +222,13 @@ const createConversation = async (conversationBody, user) => {
       await scheduleConversationAutoStop(conversation)
       await scheduleConversationEndingSoon(conversation)
     }
-  } else {
+  } else if (!conversation.draft) {
     await startConversation(conversation, user)
+  } else {
+    /* A Draft conversation created with no scheduledTime would otherwise hit the
+       immediate-start path above. Draft conversations can never start (see
+       doStartConversation), so creation must succeed without attempting it. */
+    logger.debug(`Conversation ${conversation._id} created as Draft; skipping automatic start`)
   }
   return conversation
 }
@@ -267,6 +276,21 @@ const updateConversation = async (conversationBody, user) => {
   if (conversationDoc.active) {
     throw new ApiError(httpStatus.BAD_REQUEST, 'Cannot update an active conversation')
   }
+  /* Once a Draft conversation's scheduled start time is within 6 minutes (including
+     after it has already passed), it stays locked from further edits: the owner
+     should create a new event rather than editing this one. Non-Draft conversations
+     aren't subject to this: they're already separately blocked from updates once
+     active by the guard above. */
+  if (
+    conversationDoc.draft &&
+    conversationDoc.scheduledTime &&
+    Date.now() >= conversationDoc.scheduledTime.getTime() - draftEditLockoutMs
+  ) {
+    throw new ApiError(
+      httpStatus.BAD_REQUEST,
+      'This draft event is too close to its scheduled start time to edit. Please create a new event instead.'
+    )
+  }
 
   const {
     resources: incomingResources,
@@ -278,6 +302,9 @@ const updateConversation = async (conversationBody, user) => {
     platforms: incomingPlatforms,
     topicId,
     type,
+    // draft is server-computed (see recompute below); never let the client set it directly.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    draft: _incomingDraft,
     ...restBody
   } = conversationBody
 
@@ -500,6 +527,8 @@ const updateConversation = async (conversationBody, user) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     conversationDoc!.resources = reconciled as any
   }
+
+  conversationDoc!.draft = isConversationDraft(conversationDoc!)
 
   await conversationDoc!.save()
 

--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -234,7 +234,10 @@ const createConversation = async (conversationBody, user) => {
  * @param {Object} user
  * @returns {Promise<Conversation>}
  */
-const createConversationFromType = async (params, user) => {
+/* allowDraft comes from trusted internal callers only. The email webhook passes it so an
+   incomplete invite resolves into a draft instead of a 400; the HTTP route omits it, so
+   form submissions stay strict. */
+const createConversationFromType = async (params, user, { allowDraft = false } = {}) => {
   const { type, platforms } = params
 
   const conversationType = getConversationType(type)
@@ -247,7 +250,7 @@ const createConversationFromType = async (params, user) => {
     throw new ApiError(httpStatus.NOT_FOUND, `Invalid platform(s): ${invalidPlatforms.join(', ')}`)
   }
 
-  const resolved = resolveConversationType(params, conversationType)
+  const resolved = resolveConversationType(params, conversationType, allowDraft)
   return createConversation({ ...params, conversationType: type, ...resolved }, user)
 }
 

--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -222,13 +222,8 @@ const createConversation = async (conversationBody, user) => {
       await scheduleConversationAutoStop(conversation)
       await scheduleConversationEndingSoon(conversation)
     }
-  } else if (!conversation.draft) {
-    await startConversation(conversation, user)
   } else {
-    /* A Draft conversation created with no scheduledTime would otherwise hit the
-       immediate-start path above. Draft conversations can never start (see
-       doStartConversation), so creation must succeed without attempting it. */
-    logger.debug(`Conversation ${conversation._id} created as Draft; skipping automatic start`)
+    await startConversation(conversation, user)
   }
   return conversation
 }

--- a/src/services/conversation.service/lifecycle.ts
+++ b/src/services/conversation.service/lifecycle.ts
@@ -55,8 +55,52 @@ async function scheduleTranscriptBatching(conversation) {
   await schedule.batchTranscript(`${transcriptBatchInterval} seconds`, { conversationId: conversation._id })
 }
 
+/**
+ * A conversation-like object with just the fields needed to determine draft status. Accepts
+ * either a Mongoose document or a plain object being assembled before the first save.
+ */
+export interface DraftStatusInput {
+  name?: string
+  topic?: unknown
+  scheduledTime?: Date | string | null
+  scheduledEndTime?: Date | string | null
+  properties?: { zoomMeetingUrl?: unknown } & Record<string, unknown>
+}
+
+/**
+ * Checks whether a URL string points at a Zoom domain: zoom.us itself, or a vanity
+ * subdomain like harvard.zoom.us. Anything that isn't a parseable URL is treated as invalid.
+ */
+function isZoomUrl(url: unknown): boolean {
+  if (typeof url !== 'string' || !url) return false
+  try {
+    const { hostname } = new URL(url)
+    return hostname === 'zoom.us' || hostname.endsWith('.zoom.us')
+  } catch {
+    return false
+  }
+}
+
+/**
+ * A conversation is Draft until every field required to run it as a scheduled event is
+ * present and valid: a Zoom meeting link, a name, a topic, a scheduled start time, and a
+ * scheduled end time. Once all five hold, the conversation is Scheduled (draft: false).
+ */
+export function isConversationDraft(conversation: DraftStatusInput): boolean {
+  const hasValidZoomUrl = isZoomUrl(conversation.properties?.zoomMeetingUrl)
+  const hasName = typeof conversation.name === 'string' && conversation.name.trim().length > 0
+  const hasTopic = !!conversation.topic
+  const hasScheduledTime = !!conversation.scheduledTime
+  const hasScheduledEndTime = !!conversation.scheduledEndTime
+
+  return !(hasValidZoomUrl && hasName && hasTopic && hasScheduledTime && hasScheduledEndTime)
+}
+
 export async function doStartConversation(conversation) {
   const doc = conversation
+  if (doc.draft) {
+    throw new ApiError(httpStatus.BAD_REQUEST, 'Cannot start a draft conversation until required fields are filled in.')
+  }
   logger.debug(`Start conversation: ${doc._id}`)
   doc.startTime = new Date()
   for (const agent of doc.agents) {

--- a/src/services/conversation.service/lifecycle.ts
+++ b/src/services/conversation.service/lifecycle.ts
@@ -13,6 +13,8 @@ import { Conversation, User } from '../../models/index.js'
 import { formatTranscript, formatMultiUserConversationHistory } from '../../agents/helpers/llmInputFormatters.js'
 import getConversationHistory from '../../agents/helpers/getConversationHistory.js'
 import Poll from '../../models/poll.model/poll.js'
+import { getConversationType } from '../../conversations/index.js'
+import { isValidPropertyFormat } from '../../conversations/propertyFormats.js'
 
 const transcriptBatchInterval = 30
 const SUMMARIZATION_PROMPT = `
@@ -62,32 +64,39 @@ async function scheduleTranscriptBatching(conversation) {
 export interface DraftStatusInput {
   name?: string
   topic?: unknown
+  conversationType?: string
   scheduledTime?: Date | string | null
   scheduledEndTime?: Date | string | null
-  properties?: { zoomMeetingUrl?: unknown } & Record<string, unknown>
+  properties?: Record<string, unknown>
 }
 
 /**
- * Checks whether a URL string points at a Zoom domain: zoom.us itself, or a vanity
- * subdomain like harvard.zoom.us. Anything that isn't a parseable URL is treated as invalid.
+ * Whether the conversation satisfies every property rule its type declares: each required
+ * property is present (a declared default counts, matching how resolveConversationType fills
+ * them), and each present property with a `format` passes it. Rules come from the type
+ * definition, so this stays correct as types change rather than naming any property here.
+ * The same format validators back resolver.validateProperties, so the two paths agree.
  */
-function isZoomUrl(url: unknown): boolean {
-  if (typeof url !== 'string' || !url) return false
-  try {
-    const { hostname } = new URL(url)
-    return hostname === 'zoom.us' || hostname.endsWith('.zoom.us')
-  } catch {
-    return false
-  }
+function satisfiesTypeProperties(conversation: DraftStatusInput): boolean {
+  const type = conversation.conversationType ? getConversationType(conversation.conversationType) : undefined
+  const propertyDefs = type?.properties ?? []
+  return propertyDefs.every((property) => {
+    const value = conversation.properties?.[property.name] ?? property.default
+    if (property.required && (value === undefined || value === null || value === '')) return false
+    if (property.format && value !== undefined && value !== null && !isValidPropertyFormat(property.format, value)) {
+      return false
+    }
+    return true
+  })
 }
 
 /**
- * A conversation is Draft until every field required to run it as a scheduled event is
- * present and valid. The Zoom link and scheduled end time are only required once a
- * scheduledTime has actually been requested, conversations with no scheduledTime are
- * instant-start (the existing nextspace "create and start now" flow, not a calendar-invite
- * event awaiting completion) and are never Draft as long as they have a name and a topic,
- * both of which the schema already requires.
+ * A conversation is Draft until everything needed to run it as a scheduled event is present
+ * and valid. Conversations with no scheduledTime are instant-start (the existing nextspace
+ * "create and start now" flow, not a calendar-invite event awaiting completion) and are never
+ * Draft as long as they have a name and a topic, both already schema-required. Scheduled
+ * conversations additionally need an end time and every property rule their type declares,
+ * including format rules such as the Zoom-host check.
  */
 export function isConversationDraft(conversation: DraftStatusInput): boolean {
   const hasName = typeof conversation.name === 'string' && conversation.name.trim().length > 0
@@ -97,10 +106,8 @@ export function isConversationDraft(conversation: DraftStatusInput): boolean {
     return !hasName || !hasTopic
   }
 
-  const hasValidZoomUrl = isZoomUrl(conversation.properties?.zoomMeetingUrl)
-  const hasScheduledEndTime = !!conversation.scheduledEndTime
-
-  return !(hasValidZoomUrl && hasName && hasTopic && hasScheduledEndTime)
+  if (!hasName || !hasTopic || !conversation.scheduledEndTime) return true
+  return !satisfiesTypeProperties(conversation)
 }
 
 export async function doStartConversation(conversation) {

--- a/src/services/conversation.service/lifecycle.ts
+++ b/src/services/conversation.service/lifecycle.ts
@@ -83,17 +83,24 @@ function isZoomUrl(url: unknown): boolean {
 
 /**
  * A conversation is Draft until every field required to run it as a scheduled event is
- * present and valid: a Zoom meeting link, a name, a topic, a scheduled start time, and a
- * scheduled end time. Once all five hold, the conversation is Scheduled (draft: false).
+ * present and valid. The Zoom link and scheduled end time are only required once a
+ * scheduledTime has actually been requested, conversations with no scheduledTime are
+ * instant-start (the existing nextspace "create and start now" flow, not a calendar-invite
+ * event awaiting completion) and are never Draft as long as they have a name and a topic,
+ * both of which the schema already requires.
  */
 export function isConversationDraft(conversation: DraftStatusInput): boolean {
-  const hasValidZoomUrl = isZoomUrl(conversation.properties?.zoomMeetingUrl)
   const hasName = typeof conversation.name === 'string' && conversation.name.trim().length > 0
   const hasTopic = !!conversation.topic
-  const hasScheduledTime = !!conversation.scheduledTime
+
+  if (!conversation.scheduledTime) {
+    return !hasName || !hasTopic
+  }
+
+  const hasValidZoomUrl = isZoomUrl(conversation.properties?.zoomMeetingUrl)
   const hasScheduledEndTime = !!conversation.scheduledEndTime
 
-  return !(hasValidZoomUrl && hasName && hasTopic && hasScheduledTime && hasScheduledEndTime)
+  return !(hasValidZoomUrl && hasName && hasTopic && hasScheduledEndTime)
 }
 
 export async function doStartConversation(conversation) {

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -193,6 +193,11 @@ export interface IExperiment {
   executedAt?: Date
 }
 
+/* Names a real validator (see conversations/propertyFormats.ts), not a regex, so security rules
+   like the Zoom-host check parse the value rather than pattern-match it. Extend the union and add
+   the matching validator together. */
+export type PropertyFormat = 'zoomUrl'
+
 export interface ConfigProperty {
   name: string
   as?: string // destination key (supports dot notation for nesting); defaults to name
@@ -205,6 +210,7 @@ export interface ConfigProperty {
   validationKeys?: string[]
   itemKey?: string
   schema?: Array<object>
+  format?: PropertyFormat // extra validation beyond `type`, run on create and for draft status
 }
 
 export interface PropertyRef {

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -349,6 +349,10 @@ export interface IConversation {
   properties?: Record<string, unknown>
   features?: Feature[]
   active?: boolean
+  /* Server-computed: true until all fields required to run this conversation as a scheduled
+     event are present and valid (see conversation.service/lifecycle.ts). Read-only from the
+     client's perspective: conversation.service recomputes it on every create/update. */
+  draft?: boolean
   locked?: boolean
   enableAgents?: boolean
   owner: IUser

--- a/tests/conversations/resolver.test.ts
+++ b/tests/conversations/resolver.test.ts
@@ -90,6 +90,56 @@ describe('resolveConversationType', () => {
         expect.objectContaining({ statusCode: httpStatus.BAD_REQUEST })
       )
     })
+
+    test('throws BAD_REQUEST when a value fails its declared format', () => {
+      const type: ConversationType = {
+        ...baseType,
+        properties: [{ name: 'meetingLink', required: false, type: 'string', format: 'zoomUrl' }]
+      }
+      expect(() => resolveConversationType({ properties: { meetingLink: 'https://evil.com/j/1' } }, type)).toThrow(
+        expect.objectContaining({ statusCode: httpStatus.BAD_REQUEST })
+      )
+    })
+
+    test('accepts a value that satisfies its declared format', () => {
+      const type: ConversationType = {
+        ...baseType,
+        properties: [{ name: 'meetingLink', required: false, type: 'string', format: 'zoomUrl' }]
+      }
+      expect(() => resolveConversationType({ properties: { meetingLink: 'https://zoom.us/j/1' } }, type)).not.toThrow()
+    })
+
+    test('does not throw for a missing required property when allowDraft is set', () => {
+      expect(() => resolveConversationType({ properties: {} }, baseType, true)).not.toThrow()
+    })
+
+    test('does not throw for an invalid format when allowDraft is set', () => {
+      const type: ConversationType = {
+        ...baseType,
+        properties: [{ name: 'meetingLink', required: false, type: 'string', format: 'zoomUrl' }]
+      }
+      expect(() =>
+        resolveConversationType({ properties: { meetingLink: 'https://evil.com/j/1' } }, type, true)
+      ).not.toThrow()
+    })
+
+    test('still throws for an invalid enum even when allowDraft is set', () => {
+      const type: ConversationType = {
+        ...baseType,
+        properties: [
+          {
+            name: 'model',
+            required: false,
+            type: 'enum',
+            options: [{ llmPlatform: 'openai', llmModel: 'gpt-4' }],
+            validationKeys: ['llmPlatform', 'llmModel']
+          }
+        ]
+      }
+      expect(() =>
+        resolveConversationType({ properties: { model: { llmPlatform: 'openai', llmModel: 'not-a-model' } } }, type, true)
+      ).toThrow(expect.objectContaining({ statusCode: httpStatus.BAD_REQUEST }))
+    })
   })
 
   describe('property defaults', () => {

--- a/tests/handlers/zoom.handler.test.ts
+++ b/tests/handlers/zoom.handler.test.ts
@@ -41,7 +41,6 @@ describe('POST /v1/webhooks/zoom', () => {
   let conversation
   let zoomSecretToken
   let zoomAdapter
-  let receiveMessageSpy
   let broadcastTranscriptStatusChangeSpy
   beforeAll(() => {
     setAdapterTypes(testAdapterTypes)
@@ -51,7 +50,7 @@ describe('POST /v1/webhooks/zoom', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
     await insertTopics([publicTopic])
-    conversation = new Conversation(conversationAgentsEnabled)
+    conversation = new Conversation({ ...conversationAgentsEnabled, draft: false })
     await conversation.save()
     zoomAdapter = await Adapter.create({
       type: 'zoom',
@@ -62,7 +61,7 @@ describe('POST /v1/webhooks/zoom', () => {
 
     conversation.adapters.push(zoomAdapter)
     await conversation.save()
-    receiveMessageSpy = jest.spyOn(webhookService, 'receiveMessage').mockResolvedValue()
+    jest.spyOn(webhookService, 'receiveMessage').mockResolvedValue()
     broadcastTranscriptStatusChangeSpy = jest.spyOn(websocketGateway, 'broadcastTranscriptStatusChange').mockResolvedValue()
     mockZoomGetUniqueKeys.mockReturnValue(['type', 'config.meetingUrl'])
   })
@@ -336,7 +335,7 @@ describe('POST /v1/webhooks/zoom', () => {
     beforeEach(async () => {
       // Create a second conversation with the same meeting ID
 
-      conversation2 = new Conversation({ ...conversationAgentsEnabled, _id: new mongoose.Types.ObjectId() })
+      conversation2 = new Conversation({ ...conversationAgentsEnabled, _id: new mongoose.Types.ObjectId(), draft: false })
       await conversation2.save()
 
       zoomAdapter2 = await Adapter.create({
@@ -389,7 +388,8 @@ describe('POST /v1/webhooks/zoom', () => {
       const conversation3 = new Conversation({
         ...conversationAgentsEnabled,
         _id: new mongoose.Types.ObjectId(),
-        active: true
+        active: true,
+        draft: false
       })
       await conversation3.save()
 

--- a/tests/integration/conversation.test.ts
+++ b/tests/integration/conversation.test.ts
@@ -245,7 +245,11 @@ describe('Conversation routes', () => {
     experimentalConversation.messages = [messageFour, invisibleMessage]
 
     await insertConversations([conversationOne, conversationTwo, conversationThree, experimentalConversation])
-    agentConversation = new Conversation(conversationAgentsEnabled)
+    /* draft: false because this fixture backs the manual /start and /stop endpoint tests,
+       which exercise start/stop mechanics rather than draft-status behavior; it has no
+       scheduledTime/zoomMeetingUrl, which would otherwise default it to Draft and block
+       it from starting. */
+    agentConversation = new Conversation({ ...conversationAgentsEnabled, draft: false })
     await agentConversation.save()
     cancelBatchTranscriptSpy = jest.spyOn(schedule, 'cancelBatchTranscript').mockResolvedValue()
     scheduleBatchTranscriptSpy = jest.spyOn(schedule, 'batchTranscript').mockResolvedValue()

--- a/tests/jobs/handlers/conversation.handlers.test.ts
+++ b/tests/jobs/handlers/conversation.handlers.test.ts
@@ -15,7 +15,10 @@ describe('conversation handler tests', () => {
     await insertUsers([userOne])
     await insertTopics([publicTopic])
 
-    conversation = new Conversation({ ...conversationOne, active: false })
+    /* draft: false because this describes start/stop mechanics, not draft-status behavior;
+       conversationOne itself has no scheduledTime/zoomMeetingUrl, which would otherwise
+       default it to Draft and block it from starting. */
+    conversation = new Conversation({ ...conversationOne, active: false, draft: false })
     await conversation.save()
   })
 
@@ -44,6 +47,18 @@ describe('conversation handler tests', () => {
     test('should not throw if conversation not found', async () => {
       const fakeId = '000000000000000000000000'
       await expect(JobHandlers.autoStartConversation({ attrs: { data: { conversationId: fakeId } } })).resolves.not.toThrow()
+    })
+
+    test('should not start a Draft conversation, and should not throw out of the job', async () => {
+      await Conversation.findByIdAndUpdate(conversation._id, { draft: true })
+
+      await expect(
+        JobHandlers.autoStartConversation({ attrs: { data: { conversationId: conversation._id } } })
+      ).resolves.not.toThrow()
+
+      const updated = await Conversation.findById(conversation._id)
+      expect(updated!.active).toBe(false)
+      expect(updated!.startTime).toBeUndefined()
     })
   })
 

--- a/tests/models/conversation.model.test.ts
+++ b/tests/models/conversation.model.test.ts
@@ -35,3 +35,15 @@ describe('conversation analyticsRefs', () => {
     expect(reloaded!.analyticsRefs).toBeUndefined()
   })
 })
+
+describe('conversation draft default', () => {
+  /* Fail-closed guarantee: a conversation saved without the service layer setting draft
+     must persist as draft, so a bypassed or partially-built record can never auto-start. */
+  it('defaults draft to true when none is provided', async () => {
+    const conversation = await Conversation.create(baseConversation())
+
+    const reloaded = await Conversation.findById(conversation._id)
+
+    expect(reloaded!.draft).toBe(true)
+  })
+})

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -914,7 +914,7 @@ describe('Conversation service methods', () => {
       expect(conversation.draft).toBe(true)
     })
 
-    test('does not auto-start a Draft conversation created with no scheduledTime, and does not throw', async () => {
+    test('is not Draft and starts immediately when created with no scheduledTime (instant-start)', async () => {
       const conversation = await conversationService.createConversation(
         {
           name: 'No Schedule Yet',
@@ -922,8 +922,8 @@ describe('Conversation service methods', () => {
         },
         registeredUser
       )
-      expect(conversation.draft).toBe(true)
-      expect(conversation.active).toBe(false)
+      expect(conversation.draft).toBe(false)
+      expect(conversation.active).toBe(true)
     })
   })
 

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -733,6 +733,36 @@ describe('Conversation service methods', () => {
       })
     })
 
+    describe('draft tolerance (allowDraft)', () => {
+      const incompleteParams = {
+        type: 'eventAssistant',
+        name: 'Incomplete Event',
+        platforms: ['zoom'],
+        scheduledTime: new Date(Date.now() + 3600000), // starts in 1 hour
+        scheduledEndTime: new Date(Date.now() + 7200000) // ends in 2 hours
+        // zoomMeetingUrl is required by the eventAssistant type but omitted here
+      }
+
+      test('throws when a required property is missing and allowDraft is not set', async () => {
+        const params = { ...incompleteParams, topicId: topicOne._id.toString() }
+
+        await expect(conversationService.createConversationFromType(params, registeredUser)).rejects.toMatchObject({
+          statusCode: httpStatus.BAD_REQUEST
+        })
+      })
+
+      test('saves a draft instead of throwing when a required property is missing and allowDraft is set', async () => {
+        const params = { ...incompleteParams, topicId: topicOne._id.toString() }
+
+        const conversation = await conversationService.createConversationFromType(params, registeredUser, {
+          allowDraft: true
+        })
+
+        expect(conversation.draft).toBe(true)
+        expect(conversation.active).toBe(false)
+      })
+    })
+
     describe('feature agent inclusion and property resolution', () => {
       const baseParams = {
         type: 'eventAssistant',
@@ -1248,7 +1278,7 @@ describe('Conversation service methods', () => {
       await conversation.save()
 
       await expect(conversationService.startConversation(conversation._id.toString(), registeredUser)).rejects.toMatchObject(
-        { statusCode: httpStatus.BAD_REQUEST }
+        { statusCode: httpStatus.BAD_REQUEST, message: expect.stringMatching(/Cannot start a draft conversation/) }
       )
 
       const reloaded = await Conversation.findById(conversation._id)
@@ -1795,7 +1825,10 @@ describe('Conversation service methods', () => {
 
         await expect(
           conversationService.updateConversation({ id: conversation._id.toString(), name: 'Too Late' }, registeredUser)
-        ).rejects.toMatchObject({ statusCode: httpStatus.BAD_REQUEST })
+        ).rejects.toMatchObject({
+          statusCode: httpStatus.BAD_REQUEST,
+          message: expect.stringMatching(/too close to its scheduled start time/)
+        })
       })
 
       test('editing a Draft conversation throws once its scheduledTime has already passed', async () => {
@@ -1803,7 +1836,10 @@ describe('Conversation service methods', () => {
 
         await expect(
           conversationService.updateConversation({ id: conversation._id.toString(), name: 'Too Late' }, registeredUser)
-        ).rejects.toMatchObject({ statusCode: httpStatus.BAD_REQUEST })
+        ).rejects.toMatchObject({
+          statusCode: httpStatus.BAD_REQUEST,
+          message: expect.stringMatching(/too close to its scheduled start time/)
+        })
       })
 
       test('the lockout does not apply to a non-Draft conversation close to its start time', async () => {

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -881,6 +881,52 @@ describe('Conversation service methods', () => {
     })
   })
 
+  describe('createConversation() draft status', () => {
+    beforeEach(async () => {
+      await insertUsers([registeredUser])
+      await insertTopics([topicOne])
+    })
+
+    test('is not Draft when all required fields are present and valid', async () => {
+      const conversation = await conversationService.createConversation(
+        {
+          name: 'Complete Event',
+          topicId: topicOne._id.toString(),
+          scheduledTime: new Date(Date.now() + 3600000),
+          scheduledEndTime: new Date(Date.now() + 7200000),
+          properties: { zoomMeetingUrl: 'https://zoom.us/j/123456789' }
+        },
+        registeredUser
+      )
+      expect(conversation.draft).toBe(false)
+    })
+
+    test('is Draft when a required field is missing', async () => {
+      const conversation = await conversationService.createConversation(
+        {
+          name: 'Incomplete Event',
+          topicId: topicOne._id.toString(),
+          scheduledTime: new Date(Date.now() + 3600000)
+          // scheduledEndTime and a valid zoomMeetingUrl are both missing
+        },
+        registeredUser
+      )
+      expect(conversation.draft).toBe(true)
+    })
+
+    test('does not auto-start a Draft conversation created with no scheduledTime, and does not throw', async () => {
+      const conversation = await conversationService.createConversation(
+        {
+          name: 'No Schedule Yet',
+          topicId: topicOne._id.toString()
+        },
+        registeredUser
+      )
+      expect(conversation.draft).toBe(true)
+      expect(conversation.active).toBe(false)
+    })
+  })
+
   describe('generateConversationReport()', () => {
     let periodicConversation
     let perMessageConversation
@@ -1180,6 +1226,51 @@ describe('Conversation service methods', () => {
       // pulls the snapshot from its own dispatched job, where it can retry patiently.
       expect(snapshotSpy).not.toHaveBeenCalled()
       expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('startConversation() draft gating', () => {
+    beforeEach(async () => {
+      await insertUsers([registeredUser])
+      await insertTopics([topicOne])
+    })
+
+    test('refuses to start a Draft conversation and leaves it inactive', async () => {
+      const conversation = new Conversation({
+        name: 'Draft Event',
+        owner: registeredUser._id,
+        topic: topicOne._id,
+        draft: true,
+        agents: [],
+        adapters: [],
+        messages: []
+      })
+      await conversation.save()
+
+      await expect(conversationService.startConversation(conversation._id.toString(), registeredUser)).rejects.toMatchObject(
+        { statusCode: httpStatus.BAD_REQUEST }
+      )
+
+      const reloaded = await Conversation.findById(conversation._id)
+      expect(reloaded!.active).toBe(false)
+    })
+
+    test('starts normally when the conversation is not Draft (regression)', async () => {
+      const conversation = new Conversation({
+        name: 'Ready Event',
+        owner: registeredUser._id,
+        topic: topicOne._id,
+        draft: false,
+        agents: [],
+        adapters: [],
+        messages: []
+      })
+      await conversation.save()
+
+      await conversationService.startConversation(conversation._id.toString(), registeredUser)
+
+      const reloaded = await Conversation.findById(conversation._id)
+      expect(reloaded!.active).toBe(true)
     })
   })
 
@@ -1662,6 +1753,72 @@ describe('Conversation service methods', () => {
       const [updated] = await Adapter.find({ conversation: conversation._id, type: 'slack' })
       expect(updated.config.botName).toBe('NewName')
       expect(updated.config.botUserId).toBe('U123')
+    })
+
+    describe('draft status and lockout', () => {
+      /* The beforeEach event has zoomMeetingUrl, name, topic, and scheduledTime set, but
+         never scheduledEndTime, so it starts out Draft. Its scheduledTime is set an hour
+         out, well outside the 6-minute lockout window. */
+      test('starts out Draft because scheduledEndTime was never set', () => {
+        expect(conversation.draft).toBe(true)
+      })
+
+      test('a client-supplied draft field in the update body is ignored; the server recomputes it', async () => {
+        const result = await conversationService.updateConversation(
+          { id: conversation._id.toString(), draft: false, name: 'Still Draft' },
+          registeredUser
+        )
+        // scheduledEndTime is still unset, so the conversation must remain Draft
+        // regardless of what the client sent.
+        expect(result!.draft).toBe(true)
+      })
+
+      test('filling in the last missing required field flips draft from true to false', async () => {
+        const result = await conversationService.updateConversation(
+          { id: conversation._id.toString(), scheduledEndTime: new Date(Date.now() + 7200000) },
+          registeredUser
+        )
+        expect(result!.draft).toBe(false)
+      })
+
+      test('editing a Draft conversation succeeds when its scheduledTime is more than 6 minutes away', async () => {
+        const result = await conversationService.updateConversation(
+          { id: conversation._id.toString(), name: 'Updated While Draft' },
+          registeredUser
+        )
+        expect(result!.name).toBe('Updated While Draft')
+      })
+
+      test('editing a Draft conversation throws once its scheduledTime is within 6 minutes', async () => {
+        // 5 minutes out: inside the 6-minute lockout window.
+        await Conversation.findByIdAndUpdate(conversation._id, { scheduledTime: new Date(Date.now() + 5 * 60 * 1000) })
+
+        await expect(
+          conversationService.updateConversation({ id: conversation._id.toString(), name: 'Too Late' }, registeredUser)
+        ).rejects.toMatchObject({ statusCode: httpStatus.BAD_REQUEST })
+      })
+
+      test('editing a Draft conversation throws once its scheduledTime has already passed', async () => {
+        await Conversation.findByIdAndUpdate(conversation._id, { scheduledTime: new Date(Date.now() - 60 * 1000) })
+
+        await expect(
+          conversationService.updateConversation({ id: conversation._id.toString(), name: 'Too Late' }, registeredUser)
+        ).rejects.toMatchObject({ statusCode: httpStatus.BAD_REQUEST })
+      })
+
+      test('the lockout does not apply to a non-Draft conversation close to its start time', async () => {
+        await Conversation.findByIdAndUpdate(conversation._id, {
+          draft: false,
+          scheduledEndTime: new Date(Date.now() + 7200000),
+          scheduledTime: new Date(Date.now() + 5 * 60 * 1000)
+        })
+
+        const result = await conversationService.updateConversation(
+          { id: conversation._id.toString(), name: 'Updated Close To Start' },
+          registeredUser
+        )
+        expect(result!.name).toBe('Updated Close To Start')
+      })
     })
   })
 

--- a/tests/services/conversation.service/lifecycle.test.ts
+++ b/tests/services/conversation.service/lifecycle.test.ts
@@ -1,0 +1,77 @@
+import { isConversationDraft } from '../../../src/services/conversation.service/lifecycle.js'
+
+/* A conversation with all five required-for-non-Draft fields present and valid. Individual
+   tests mutate a copy of this to knock out one field at a time. */
+function completeConversation() {
+  return {
+    name: 'Tech Conference Q&A',
+    topic: 'topic-id',
+    scheduledTime: new Date('2030-01-01T10:00:00Z'),
+    scheduledEndTime: new Date('2030-01-01T11:00:00Z'),
+    properties: { zoomMeetingUrl: 'https://zoom.us/j/123456789' }
+  }
+}
+
+describe('isConversationDraft', () => {
+  test('returns false when all required fields are present and valid', () => {
+    expect(isConversationDraft(completeConversation())).toBe(false)
+  })
+
+  test('returns false for a valid vanity Zoom subdomain', () => {
+    const conversation = completeConversation()
+    conversation.properties.zoomMeetingUrl = 'https://berkman.zoom.us/j/123456789'
+    expect(isConversationDraft(conversation)).toBe(false)
+  })
+
+  test('returns true when zoomMeetingUrl is missing', () => {
+    const conversation = completeConversation()
+    conversation.properties = {} as { zoomMeetingUrl: string }
+    expect(isConversationDraft(conversation)).toBe(true)
+  })
+
+  test('returns true when zoomMeetingUrl is not a Zoom domain', () => {
+    const conversation = completeConversation()
+    conversation.properties.zoomMeetingUrl = 'https://evil.com/j/123456789'
+    expect(isConversationDraft(conversation)).toBe(true)
+  })
+
+  test('returns true when zoomMeetingUrl is not a parseable URL', () => {
+    const conversation = completeConversation()
+    conversation.properties.zoomMeetingUrl = 'not-a-url'
+    expect(isConversationDraft(conversation)).toBe(true)
+  })
+
+  test('returns true when name is missing', () => {
+    const conversation = completeConversation()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(conversation as any).name = undefined
+    expect(isConversationDraft(conversation)).toBe(true)
+  })
+
+  test('returns true when name is an empty string', () => {
+    const conversation = completeConversation()
+    conversation.name = ''
+    expect(isConversationDraft(conversation)).toBe(true)
+  })
+
+  test('returns true when scheduledTime is missing', () => {
+    const conversation = completeConversation()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(conversation as any).scheduledTime = undefined
+    expect(isConversationDraft(conversation)).toBe(true)
+  })
+
+  test('returns true when scheduledEndTime is missing', () => {
+    const conversation = completeConversation()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(conversation as any).scheduledEndTime = undefined
+    expect(isConversationDraft(conversation)).toBe(true)
+  })
+
+  test('returns true when topic is missing', () => {
+    const conversation = completeConversation()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(conversation as any).topic = undefined
+    expect(isConversationDraft(conversation)).toBe(true)
+  })
+})

--- a/tests/services/conversation.service/lifecycle.test.ts
+++ b/tests/services/conversation.service/lifecycle.test.ts
@@ -1,11 +1,21 @@
 import { isConversationDraft } from '../../../src/services/conversation.service/lifecycle.js'
+import { setConversationTypes, resetConversationTypes } from '../../../src/conversations/index.js'
+import { ConfigProperty, ConversationType } from '../../../src/types/index.types.js'
 
-/* A conversation with all five required-for-non-Draft fields present and valid. Individual
-   tests mutate a copy of this to knock out one field at a time. */
+/* Minimal conversation type for tests that only exercise property rules; other fields are
+   irrelevant to isConversationDraft, so a single cast keeps the injections free of `any`. */
+function stubType(name: string, properties: ConfigProperty[]): ConversationType {
+  return { name, properties } as unknown as ConversationType
+}
+
+/* A scheduled eventAssistant conversation with everything a non-Draft event needs. The
+   eventAssistant type declares zoomMeetingUrl as its one required property, so a complete
+   fixture carries a valid Zoom link. Individual tests mutate a copy to knock out one field. */
 function completeConversation() {
   return {
     name: 'Tech Conference Q&A',
     topic: 'topic-id',
+    conversationType: 'eventAssistant',
     scheduledTime: new Date('2030-01-01T10:00:00Z'),
     scheduledEndTime: new Date('2030-01-01T11:00:00Z'),
     properties: { zoomMeetingUrl: 'https://zoom.us/j/123456789' }
@@ -13,6 +23,10 @@ function completeConversation() {
 }
 
 describe('isConversationDraft', () => {
+  afterEach(() => {
+    resetConversationTypes()
+  })
+
   test('returns false when all required fields are present and valid', () => {
     expect(isConversationDraft(completeConversation())).toBe(false)
   })
@@ -38,6 +52,13 @@ describe('isConversationDraft', () => {
   test('returns true when zoomMeetingUrl is not a parseable URL', () => {
     const conversation = completeConversation()
     conversation.properties.zoomMeetingUrl = 'not-a-url'
+    expect(isConversationDraft(conversation)).toBe(true)
+  })
+
+  test('returns true when zoomMeetingUrl uses userinfo to spoof the host', () => {
+    const conversation = completeConversation()
+    // Real host here is evil.com; the text before @ is userinfo, not the host.
+    conversation.properties.zoomMeetingUrl = 'https://zoom.us@evil.com/j/123456789'
     expect(isConversationDraft(conversation)).toBe(true)
   })
 
@@ -92,5 +113,69 @@ describe('isConversationDraft', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(conversation as any).topic = undefined
     expect(isConversationDraft(conversation)).toBe(true)
+  })
+
+  /* Required properties come from the conversation type definition, so a scheduled type that
+     does not declare a Zoom link (or any other property) is not held Draft for lacking one. */
+  test('does not require a Zoom link for a scheduled type that does not declare one', () => {
+    setConversationTypes({
+      surveyBot: stubType('surveyBot', [{ name: 'surveyId', required: true, type: 'string' }])
+    })
+    const conversation = {
+      name: 'Weekly survey',
+      topic: 'topic-id',
+      conversationType: 'surveyBot',
+      scheduledTime: new Date('2030-01-01T10:00:00Z'),
+      scheduledEndTime: new Date('2030-01-01T11:00:00Z'),
+      properties: { surveyId: 'abc-123' }
+    }
+    expect(isConversationDraft(conversation)).toBe(false)
+  })
+
+  test('returns true when a property the type marks required is missing', () => {
+    setConversationTypes({
+      surveyBot: stubType('surveyBot', [{ name: 'surveyId', required: true, type: 'string' }])
+    })
+    const conversation = {
+      name: 'Weekly survey',
+      topic: 'topic-id',
+      conversationType: 'surveyBot',
+      scheduledTime: new Date('2030-01-01T10:00:00Z'),
+      scheduledEndTime: new Date('2030-01-01T11:00:00Z'),
+      properties: {}
+    }
+    expect(isConversationDraft(conversation)).toBe(true)
+  })
+
+  /* Format validation follows the property's declared format, not its name, so any property
+     can carry the Zoom-host rule (or a future format) rather than only zoomMeetingUrl. */
+  test('flags a scheduled conversation whose formatted property holds an invalid value', () => {
+    setConversationTypes({
+      surveyBot: stubType('surveyBot', [{ name: 'meetingLink', required: true, type: 'string', format: 'zoomUrl' }])
+    })
+    const conversation = {
+      name: 'Weekly survey',
+      topic: 'topic-id',
+      conversationType: 'surveyBot',
+      scheduledTime: new Date('2030-01-01T10:00:00Z'),
+      scheduledEndTime: new Date('2030-01-01T11:00:00Z'),
+      properties: { meetingLink: 'https://evil.com/j/1' }
+    }
+    expect(isConversationDraft(conversation)).toBe(true)
+  })
+
+  test('treats a required property with a declared default as satisfied', () => {
+    setConversationTypes({
+      surveyBot: stubType('surveyBot', [{ name: 'cadence', required: true, type: 'string', default: 'weekly' }])
+    })
+    const conversation = {
+      name: 'Weekly survey',
+      topic: 'topic-id',
+      conversationType: 'surveyBot',
+      scheduledTime: new Date('2030-01-01T10:00:00Z'),
+      scheduledEndTime: new Date('2030-01-01T11:00:00Z'),
+      properties: {}
+    }
+    expect(isConversationDraft(conversation)).toBe(false)
   })
 })

--- a/tests/services/conversation.service/lifecycle.test.ts
+++ b/tests/services/conversation.service/lifecycle.test.ts
@@ -54,10 +54,29 @@ describe('isConversationDraft', () => {
     expect(isConversationDraft(conversation)).toBe(true)
   })
 
-  test('returns true when scheduledTime is missing', () => {
+  test('returns false when scheduledTime is missing but name and topic are present (instant-start)', () => {
     const conversation = completeConversation()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(conversation as any).scheduledTime = undefined
+    expect(isConversationDraft(conversation)).toBe(false)
+  })
+
+  test('returns false for an instant-start conversation with no Zoom link or scheduledEndTime', () => {
+    const conversation = completeConversation()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(conversation as any).scheduledTime = undefined
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(conversation as any).scheduledEndTime = undefined
+    conversation.properties = {} as { zoomMeetingUrl: string }
+    expect(isConversationDraft(conversation)).toBe(false)
+  })
+
+  test('returns true when scheduledTime and name are both missing', () => {
+    const conversation = completeConversation()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(conversation as any).scheduledTime = undefined
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(conversation as any).name = undefined
     expect(isConversationDraft(conversation)).toBe(true)
   })
 


### PR DESCRIPTION
## What is in this PR?

Calendar-invite events sometimes arrive before they are ready to run: no scheduled end time, or an incomplete invite from the upcoming email intake. This PR adds a server-computed `draft` status that marks such a conversation as incomplete, keeps it from starting while it stays draft, and locks it from edits once its scheduled start is within six minutes. The event creation form stays strict: a missing or invalid Zoom link is rejected with a 400, not saved as a draft. Only trusted internal callers (the planned inbound-email webhook) can turn an incomplete invite into a draft instead of an error.

## Changes in the codebase

- Conversations carry a `draft` flag the server computes. Clients cannot set it; a `draft` value in a request body is ignored and recomputed.
- A conversation stays draft until it has a name, a topic, and, once a start time is scheduled, a valid Zoom link and a scheduled end time. The server validates Zoom links by parsing the URL and checking the host is `zoom.us` or one of its subdomains, so a spoof like `https://zoom.us@evil.com` is rejected.
- Conversation types can declare a `format` on a property (currently `zoomUrl`). Creation from a type enforces it and returns a 400 when a value fails its format.
- Starting a draft conversation returns a 400 until the missing fields are filled in.
- A draft conversation cannot be edited once its scheduled start is within six minutes or already past; the organizer is told to create a new event instead.
- Creation from a type accepts an internal `allowDraft` flag. When the future email webhook sets it, a missing required property or a malformed Zoom link produces a draft instead of a 400. The HTTP route never sets it, so form submissions stay strict.
- Conversations with no scheduled time keep their instant-start behavior and stay non-draft once they have a name and topic.
- The `draft` field is exposed as read-only in the API schema.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [x] update the README and docs to be clear and easy to use for end users and developers? (OpenAPI schema only)
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

Draft status is computed on every creation and update path from whether a scheduled conversation has a name, a topic, an end time, and a valid required property such as the Zoom link. `POST /v1/conversations/from-type` (the event form) validates required properties up front, so a missing or invalid Zoom link returns a 400 there; name and topic are schema-required. That leaves a scheduled invite with no end time as the draft case reachable through the form endpoint.

### Manually testable over HTTP

Using Hoppscotch against a topic you own:

1. **Draft creation.** POST `/v1/conversations/from-type` with `type: "eventAssistant"`, a `topicId`, a future `scheduledTime`, a valid `zoomMeetingUrl` (`https://zoom.us/j/123456789`), and no `scheduledEndTime`. Expect a 201 with `draft: true`.
2. **Start gate.** POST `/v1/conversations/:id/start` for that draft. Expect a 400: "Cannot start a draft conversation until required fields are filled in."
3. **Draft clears.** PATCH `/v1/conversations/:id` with a `scheduledEndTime` after the start time. Expect `draft: false`. 
4. **Edit lockout.** Create another draft as in step 1 but with `scheduledTime` about five minutes out. PATCH it (any field). Expect a 400: "This draft event is too close to its scheduled start time to edit. Please create a new event instead."
5. **Client cannot set draft.** PATCH a draft with `draft: false` in the body and nothing that completes it. Expect the response still has `draft: true`; the server recomputes it.
6. **Strict validation still rejects bad input.** POST `/from-type` with a missing or invalid Zoom link (`https://example.com/j/1`, or the spoof `https://zoom.us@evil.com`). Expect a 400, no conversation created. Rejecting a missing required property is pre-existing; rejecting a malformed or host-spoofed Zoom link is new in this PR's format validator.

### Regression checks (existing behavior preserved)
7. **Instant-start unaffected.** POST `/from-type` with a name, topic, and valid Zoom link but no `scheduledTime`. Expect `draft: false`, and the conversation starts immediately.

The existing creation, start, and job-handler suites were updated so their fixtures set `draft: false`, confirming the new start gate does not block already-complete conversations.

### Covered by automated tests only (not reachable over HTTP on this branch)

`allowDraft` is an internal argument of `createConversationFromType`. The HTTP controller never sets it, so over `/from-type` a missing or invalid required property always returns a 400. The scenario where a missing required property or malformed Zoom link becomes a draft instead of an error, is exercised by resolver and service unit tests that pass the flag directly. It has no production caller yet: the inbound email webhook that will pass `allowDraft: true` is a separate, later change. 

## Additional information
- Out of scope: showing draft events in the default status filter on the admin events page is a nextspace change and needs its own follow-up.
- Related frontend work: the event view redesign on nextspace branch `cj/event-detail-view` (no PR open yet).
