### PR TITLE
Refactor event fields schema

### DIFF
--- a/src/services/eventSetup/eventFieldsSchema.ts
+++ b/src/services/eventSetup/eventFieldsSchema.ts
@@ -1,0 +1,55 @@
+/*
+ * The field-extraction schema shared by every LLM consumer that pulls
+ * structured event fields out of free-form text.
+ *
+ * Two consumers use it today:
+ *   - the Slack/web event planner (planSchema.ts), which embeds
+ *     ExtractedFieldsSchema in its larger EventSetupPlanSchema
+ *   - the email-invite flow, which extends it via InviteExtractedFieldsSchema
+ *     to also carry the Topic an inbound invite was matched to
+ *
+ * ExtractedFieldsSchema is kept manually in sync with the Conversation
+ * model (src/models/conversation.model.ts), the canonical event record.
+ * When that model gains a new user-supplied field, decide whether the LLM
+ * should try to extract it and add it here so both consumers pick it up
+ * at once instead of drifting apart.
+ *
+ * Using Zod forces the LLM into structured output. Anything the LLM is
+ * not confident about is omitted rather than guessed.
+ */
+
+import { z } from 'zod'
+
+export const speakerSchema = z.object({
+  name: z.string(),
+  bio: z.string(),
+  alternateName: z.string().optional().describe('Nickname or stage name the speaker also goes by')
+})
+
+export const ExtractedFieldsSchema = z.object({
+  eventName: z.string().optional(),
+  dateTime: z.string().optional().describe('ISO 8601 datetime string'),
+  duration: z.number().optional().describe('Duration in minutes'),
+  description: z.string().optional(),
+  zoomLink: z.string().optional(),
+  topicName: z.string().optional(),
+  speakers: z.array(speakerSchema).optional(),
+  moderators: z.array(speakerSchema).optional(),
+  timeZone: z
+    .string()
+    .optional()
+    .describe(
+      'IANA timezone (e.g. America/New_York) inferred from any timezone the organizer mentioned, like ET, Eastern, PST, or GMT+1'
+    )
+})
+
+/* The invite flow's variant: the same fields the planner extracts, plus
+   the Topic an inbound calendar invite was matched to (null when no
+   existing Topic fit and a new one should be created). */
+export const InviteExtractedFieldsSchema = ExtractedFieldsSchema.extend({
+  matchedTopicId: z.string().nullable()
+})
+
+export type ExtractedFields = z.infer<typeof ExtractedFieldsSchema>
+export type InviteExtractedFields = z.infer<typeof InviteExtractedFieldsSchema>
+export type Speaker = z.infer<typeof speakerSchema>

--- a/src/services/eventSetup/eventFieldsSchema.ts
+++ b/src/services/eventSetup/eventFieldsSchema.ts
@@ -5,8 +5,8 @@
  * Two consumers use it today:
  *   - the Slack/web event planner (planSchema.ts), which embeds
  *     ExtractedFieldsSchema in its larger EventSetupPlanSchema
- *   - the email-invite flow, which extends it via InviteExtractedFieldsSchema
- *     to also carry the Topic an inbound invite was matched to
+ *   - the email-invite flow, which reuses it to pull the same fields out
+ *     of an inbound calendar invite
  *
  * ExtractedFieldsSchema is kept manually in sync with the Conversation
  * model (src/models/conversation.model.ts), the canonical event record.
@@ -43,13 +43,5 @@ export const ExtractedFieldsSchema = z.object({
     )
 })
 
-/* The invite flow's variant: the same fields the planner extracts, plus
-   the Topic an inbound calendar invite was matched to (null when no
-   existing Topic fit and a new one should be created). */
-export const InviteExtractedFieldsSchema = ExtractedFieldsSchema.extend({
-  matchedTopicId: z.string().nullable()
-})
-
 export type ExtractedFields = z.infer<typeof ExtractedFieldsSchema>
-export type InviteExtractedFields = z.infer<typeof InviteExtractedFieldsSchema>
 export type Speaker = z.infer<typeof speakerSchema>

--- a/src/services/eventSetup/planSchema.ts
+++ b/src/services/eventSetup/planSchema.ts
@@ -14,42 +14,20 @@
  * Using Zod here forces the LLM into structured output. Anything the
  * LLM is not confident about is omitted rather than guessed.
  *
- * The field-extraction half of this schema (ExtractedFieldsSchema) is
- * kept manually in sync with the Conversation model
- * (src/models/conversation.model.ts), which is the canonical event
- * record. When that model gains a new user-supplied field, decide
- * whether the LLM should try to extract it and add it below.
- *
- * If a second Zod consumer ever appears in the codebase (e.g. a Zod
- * port of the conversation Joi validator), pull ExtractedFieldsSchema
- * into a shared eventFieldsSchema module so both consumers can .pick()
- * from it instead of drifting.
+ * The field-extraction half of this schema (ExtractedFieldsSchema) now
+ * lives in the shared eventFieldsSchema module, since the email-invite
+ * flow is a second consumer that extends it. That module is where the
+ * field set is kept in sync with the Conversation model
+ * (src/models/conversation.model.ts); add new extractable fields there,
+ * not here, so both consumers pick them up at once.
  */
 
 import { z } from 'zod'
+import { ExtractedFieldsSchema, type ExtractedFields, type Speaker } from './eventFieldsSchema.js'
 
-const speakerSchema = z.object({
-  name: z.string(),
-  bio: z.string(),
-  alternateName: z.string().optional().describe('Nickname or stage name the speaker also goes by')
-})
-
-export const ExtractedFieldsSchema = z.object({
-  eventName: z.string().optional(),
-  dateTime: z.string().optional().describe('ISO 8601 datetime string'),
-  duration: z.number().optional().describe('Duration in minutes'),
-  description: z.string().optional(),
-  zoomLink: z.string().optional(),
-  topicName: z.string().optional(),
-  speakers: z.array(speakerSchema).optional(),
-  moderators: z.array(speakerSchema).optional(),
-  timeZone: z
-    .string()
-    .optional()
-    .describe(
-      'IANA timezone (e.g. America/New_York) inferred from any timezone the organizer mentioned, like ET, Eastern, PST, or GMT+1'
-    )
-})
+// Re-exported so existing importers of these names keep resolving them here.
+export { ExtractedFieldsSchema }
+export type { ExtractedFields, Speaker }
 
 export const StepHintSchema = z.object({
   key: z.string().describe('Stable identifier for the step, e.g. "schedule", "speakers", "resources"'),
@@ -63,7 +41,7 @@ export const StepHintSchema = z.object({
 const SKIPPABLE_SECTION_IDS = ['basic', 'when', 'where', 'who', 'res', 'feat'] as const
 
 export const SkippedSectionSchema = z.object({
-  id: z.enum(SKIPPABLE_SECTION_IDS).describe('Section identifier matching the form\'s section renderer keys'),
+  id: z.enum(SKIPPABLE_SECTION_IDS).describe("Section identifier matching the form's section renderer keys"),
   label: z.string().describe('Human-readable section name (e.g. "Speakers", "Resources")'),
   reason: z.string().describe('Brief plain-language explanation of why this section was hidden')
 })
@@ -114,7 +92,5 @@ export const EventSetupPlanSchema = z.object({
 })
 
 export type EventSetupPlan = z.infer<typeof EventSetupPlanSchema>
-export type ExtractedFields = z.infer<typeof ExtractedFieldsSchema>
-export type Speaker = z.infer<typeof speakerSchema>
 export type SkippedSection = z.infer<typeof SkippedSectionSchema>
 export type FeatureDecision = z.infer<typeof FeatureDecisionSchema>

--- a/tests/unit/services/eventSetup/eventFieldsSchema.test.ts
+++ b/tests/unit/services/eventSetup/eventFieldsSchema.test.ts
@@ -1,4 +1,4 @@
-import { ExtractedFieldsSchema, InviteExtractedFieldsSchema } from '../../../../src/services/eventSetup/eventFieldsSchema.js'
+import { ExtractedFieldsSchema } from '../../../../src/services/eventSetup/eventFieldsSchema.js'
 
 describe('eventFieldsSchema', () => {
   const baseFields = {
@@ -20,28 +20,14 @@ describe('eventFieldsSchema', () => {
       expect(result).toEqual(baseFields)
     })
 
-    it('does not accept matchedTopicId (it belongs to the invite variant)', () => {
-      const parsed = ExtractedFieldsSchema.parse({ ...baseFields, matchedTopicId: 'topic-1' })
+    it('parses an empty object, since the LLM omits anything it is unsure of', () => {
+      const result = ExtractedFieldsSchema.parse({})
 
-      expect(parsed).not.toHaveProperty('matchedTopicId')
-    })
-  })
-
-  describe('InviteExtractedFieldsSchema', () => {
-    it('accepts every base field plus a string matchedTopicId', () => {
-      const result = InviteExtractedFieldsSchema.parse({ ...baseFields, matchedTopicId: 'topic-1' })
-
-      expect(result).toEqual({ ...baseFields, matchedTopicId: 'topic-1' })
+      expect(result).toEqual({})
     })
 
-    it('accepts a null matchedTopicId', () => {
-      const result = InviteExtractedFieldsSchema.parse({ ...baseFields, matchedTopicId: null })
-
-      expect(result.matchedTopicId).toBeNull()
-    })
-
-    it('requires matchedTopicId to be present', () => {
-      expect(() => InviteExtractedFieldsSchema.parse(baseFields)).toThrow()
+    it('rejects a field of the wrong type', () => {
+      expect(() => ExtractedFieldsSchema.parse({ ...baseFields, duration: '60 minutes' })).toThrow()
     })
   })
 })

--- a/tests/unit/services/eventSetup/eventFieldsSchema.test.ts
+++ b/tests/unit/services/eventSetup/eventFieldsSchema.test.ts
@@ -1,0 +1,47 @@
+import { ExtractedFieldsSchema, InviteExtractedFieldsSchema } from '../../../../src/services/eventSetup/eventFieldsSchema.js'
+
+describe('eventFieldsSchema', () => {
+  const baseFields = {
+    eventName: 'Weekly Sync',
+    dateTime: '2026-07-20T15:00:00.000Z',
+    duration: 60,
+    description: 'A recurring team sync',
+    zoomLink: 'https://zoom.us/j/123456789',
+    topicName: 'Team Syncs',
+    speakers: [{ name: 'Ada Lovelace', bio: 'Mathematician', alternateName: 'Ada' }],
+    moderators: [{ name: 'Grace Hopper', bio: 'Computer scientist' }],
+    timeZone: 'America/New_York'
+  }
+
+  describe('ExtractedFieldsSchema', () => {
+    it('parses the current field set', () => {
+      const result = ExtractedFieldsSchema.parse(baseFields)
+
+      expect(result).toEqual(baseFields)
+    })
+
+    it('does not accept matchedTopicId (it belongs to the invite variant)', () => {
+      const parsed = ExtractedFieldsSchema.parse({ ...baseFields, matchedTopicId: 'topic-1' })
+
+      expect(parsed).not.toHaveProperty('matchedTopicId')
+    })
+  })
+
+  describe('InviteExtractedFieldsSchema', () => {
+    it('accepts every base field plus a string matchedTopicId', () => {
+      const result = InviteExtractedFieldsSchema.parse({ ...baseFields, matchedTopicId: 'topic-1' })
+
+      expect(result).toEqual({ ...baseFields, matchedTopicId: 'topic-1' })
+    })
+
+    it('accepts a null matchedTopicId', () => {
+      const result = InviteExtractedFieldsSchema.parse({ ...baseFields, matchedTopicId: null })
+
+      expect(result.matchedTopicId).toBeNull()
+    })
+
+    it('requires matchedTopicId to be present', () => {
+      expect(() => InviteExtractedFieldsSchema.parse(baseFields)).toThrow()
+    })
+  })
+})


### PR DESCRIPTION
## What is in this PR?

`ExtractedFieldsSchema` moves out of `planSchema.ts` into a new shared `eventFieldsSchema.ts` module, so the upcoming email-to-events invite flow can reuse the field set the Slack/web planner already extracts instead of copying it. 

## Changes in the codebase

- New `src/services/eventSetup/eventFieldsSchema.ts` holds the field-extraction schema, the speaker sub-schema it depends on, and their inferred types, moved across unchanged.
- `planSchema.ts` imports the schema from there and re-exports it along with the two types, so anything importing those names from `planSchema.ts` keeps resolving.
- The comment in `planSchema.ts` that anticipated this split now points at the module that exists, instead of describing a hypothetical one.
- The new module documents a non-obvious property of this schema: it gets serialized and sent to the model as the JSON schema it must fill, so field names and `.describe()` strings are prompt text, not just types.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

N/A - this is a refactor, automated tests were updated and run to check for regressions. 

## Additional information