### PR TITLE
Create email webhook to process calendar invites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,12 @@ SMTP_USERNAME=email-server-username
 SMTP_PASSWORD=email-server-password
 EMAIL_FROM=support@yourapp.com
 
+# Basic Auth on the Postmark inbound webhook: the handler checks incoming requests against
+# these to confirm they came from Postmark. Set the same pair on the webhook in Postmark.
+# The secret is a random string you generate (e.g. `openssl rand -base64 32`), not a human password.
+#POSTMARK_WEBHOOK_AUTH_USER=
+#POSTMARK_WEBHOOK_AUTH_SECRET=
+
 # Public URL of the Nextspace frontend. Used to build links for password
 # reset emails, channel archive emails, and the Slack event-setup handoff
 # link the bot posts when an organizer asks to create an event.

--- a/docs/pages/installing/index.md
+++ b/docs/pages/installing/index.md
@@ -82,3 +82,7 @@ If you would like to use LLM Engine with the Nextspace client, see our [nextspac
 ## Optional: Zoom integration
 
 If you would like to use LLM Engine with Zoom, see our [zoom guide](../platforms/zoom.md).
+
+## Optional: Email integration
+
+If you would like LLM Engine to receive calendar invites by email, see our [email guide](../platforms/email.md).

--- a/docs/pages/platforms/email.md
+++ b/docs/pages/platforms/email.md
@@ -1,0 +1,55 @@
+## Email integration
+
+LLM Engine can receive calendar invites by email. An event organizer adds the event setup bot as an attendee on a meeting invite, and the invite arrives here as an inbound webhook.
+
+Email integration requires the use of [Postmark](https://postmarkapp.com), a third party service that receives mail on your behalf and posts it to your server as JSON.
+
+> **Current scope:** the webhook verifies the request, parses the attached calendar file, and logs what it found. It does not create events or send mail yet.
+
+### Set up Postmark
+
+#### One Time Setup
+
+1. Create a Postmark account and a server with an inbound stream.
+2. Choose a username and generate a secret for the webhook. The secret is a random string, not a hand-picked password:
+
+   ```
+   openssl rand -base64 32
+   ```
+
+3. Set the inbound webhook URL to `[baseUrl]/v1/webhooks/email`, with the credentials from step 2 embedded in it:
+
+   ```
+   https://[username]:[secret]@[baseUrl]/v1/webhooks/email
+   ```
+
+   Postmark sends those as an HTTP Basic Auth header on every inbound message. If you create the webhook through Postmark's API instead of the dashboard, use the `HttpAuth` field rather than embedding them in the URL.
+
+4. Set the same pair in the LLM Engine `.env` file. The handler compares every incoming request against these, so a mismatch between Postmark and `.env` rejects the message as a 401.
+
+#### Add environment variables
+
+| Variable                       | Required | Purpose                                                                                                                      |
+| ------------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `POSTMARK_WEBHOOK_AUTH_USER`   | yes      | Username half of the Basic Auth credentials configured on the Postmark inbound webhook. Must match the value Postmark sends. |
+| `POSTMARK_WEBHOOK_AUTH_SECRET` | yes      | Secret half of the same credentials. Generate it randomly and rotate it periodically. Must match the value Postmark sends.   |
+
+Both are required to use this endpoint, but neither is required to boot the server. If either is unset, the handler rejects every request rather than accepting unverified ones, and logs that it is not configured.
+
+### How verification works
+
+Postmark does not sign inbound webhooks, so there is no signature to check. Basic Auth over TLS is the verification method Postmark's documentation recommends for inbound, and it is what this handler implements.
+
+Rejected requests return `401`, never `403`. Postmark stops retrying a message permanently once it sees a `403`, so that status is reserved for messages that should never be delivered again.
+
+### Reading the logs
+
+The handler answers `200` on every path, including failures, because Postmark retries any non-`200` up to 10 times over roughly 10.5 hours. A `200` therefore means the message was accepted, not that it parsed. The log is where the outcome shows up:
+
+| Log line                                            | Meaning                                                         |
+| --------------------------------------------------- | --------------------------------------------------------------- |
+| `parsed invite "..." (UID ...) ...`                 | The calendar attachment parsed. Start and end times are in UTC. |
+| `inbound message had no calendar (.ics) attachment` | The message arrived but carried nothing to process.             |
+| `failed to parse inbound invite: ...`               | A calendar attachment was present but unreadable.               |
+
+Start and end times log as UTC. Calendar files state times in the organizer's zone, and Outlook names zones the Windows way (`Eastern Standard Time`) rather than the IANA way, shipping the matching definition inside the file. Those resolve through the file's own definition, so no timezone configuration is needed on this side. Times that look an hour off in the log point at that resolution failing.

--- a/package.json
+++ b/package.json
@@ -17,12 +17,10 @@
     "build:up": "tsc && NODE_ENV=development node dist/src/index.js",
     "start": "NODE_ENV=production node dist/src/index.js",
     "dev": "cross-env NODE_ENV=development nodemon --watch 'src/**/*.ts' --exec node --loader ts-node/esm src/index.ts",
-
     "test": "NODE_ENV=test node --max-old-space-size=8192 --experimental-vm-modules ./node_modules/.bin/jest -i --colors --verbose --forceExit --bail",
     "test:agents": "NODE_ENV=test node --max-old-space-size=7168 --experimental-vm-modules ./node_modules/.bin/jest -i --colors --verbose --forceExit --bail --config jest.agent.config.ts",
     "test:agents:all-models": "NODE_ENV=test node --loader ts-node/esm scripts/test-all-models.ts",
     "test:agents:development": "NODE_ENV=test node --max-old-space-size=8192 --experimental-vm-modules ./node_modules/.bin/jest -i --colors --verbose --forceExit --config jest.agent.development.config.ts",
-
     "test:watch": "NODE_ENV=test node --experimental-vm-modules ./node_modules/.bin/jest -i --watchAll",
     "evaluate:event-assistant": "NODE_ENV=test node --loader ts-node/esm evaluations/event-assistant/runEventAssistantEvaluations.ts",
     "redteam:event-assistant-personality": "yarn build; NODE_ENV=test npx promptfoo redteam run --config promptfoo/promptfooconfig-event-assistant-trust-and-safety.yaml",
@@ -83,6 +81,7 @@
     "handlebars": "^4.7.9",
     "helmet": "^8.0.0",
     "http-status": "^1",
+    "ical.js": "^2.2.1",
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
     "langchain": "^1.0.0",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -35,6 +35,12 @@ const envVarsSchema = Joi.object()
     SMTP_PORT: Joi.number().description('port to connect to the email server'),
     SMTP_USERNAME: Joi.string().description('username for email server'),
     SMTP_PASSWORD: Joi.string().description('password for email server'),
+    POSTMARK_WEBHOOK_AUTH_USER: Joi.string().description(
+      'Username set on the Postmark inbound webhook Basic Auth; the handler checks it to confirm a request came from Postmark'
+    ),
+    POSTMARK_WEBHOOK_AUTH_SECRET: Joi.string().description(
+      'Random secret set as the password on the Postmark inbound webhook Basic Auth (not a human password); rotate periodically'
+    ),
     EMAIL_FROM: Joi.string().description('the from field in the emails sent by the app'),
     APP_HOST: Joi.string().description('the host url for the frontend app'),
     NEXTSPACE_URL: Joi.string().description(
@@ -239,6 +245,10 @@ const config = {
   },
   slack: {
     signingSecret: envVars.SLACK_SIGNING_SECRET
+  },
+  postmark: {
+    authUser: envVars.POSTMARK_WEBHOOK_AUTH_USER,
+    authSecret: envVars.POSTMARK_WEBHOOK_AUTH_SECRET
   },
   matomo: {
     baseUrl: envVars.MATOMO_BASE_URL,

--- a/src/handlers/email.ts
+++ b/src/handlers/email.ts
@@ -1,0 +1,128 @@
+import httpStatus from 'http-status'
+import crypto from 'crypto'
+import { Buffer } from 'buffer'
+import ICAL from 'ical.js'
+import ApiError from '../utils/ApiError.js'
+import config from '../config/config.js'
+import logger from '../config/logger.js'
+import { ParsedInvite } from '../types/index.types.js'
+
+/** A single entry from a Postmark inbound webhook's `Attachments` array. */
+interface PostmarkAttachment {
+  Name?: string
+  Content?: string // base64-encoded file bytes
+  ContentType?: string
+  ContentLength?: number
+  ContentID?: string
+}
+
+/**
+ * A calendar invite arrives either with a `text/calendar` content type or, when a mail relay
+ * rewrites it to something generic, only as a `.ics` filename. Match on either.
+ */
+const isCalendarAttachment = (attachment: PostmarkAttachment): boolean => {
+  const contentType = (attachment?.ContentType ?? '').toLowerCase()
+  const name = (attachment?.Name ?? '').toLowerCase()
+  return contentType.startsWith('text/calendar') || contentType.includes('application/ics') || name.endsWith('.ics')
+}
+
+/** ORGANIZER values look like `mailto:jane@example.com`; return just the address. */
+const organizerEmail = (organizer: string | null): string | undefined =>
+  organizer ? organizer.replace(/^mailto:/i, '') : undefined
+
+/**
+ * Pull the calendar fields out of a Postmark inbound payload's base64 `.ics` attachment.
+ * Returns null when the message has no calendar attachment or no event component. Reads only
+ * the fields the .ics states outright; nothing here interprets the free-text body.
+ */
+export const parseInviteFromPayload = (payload: {
+  Attachments?: PostmarkAttachment[]
+  [key: string]: unknown
+}): ParsedInvite | null => {
+  const attachment = (payload?.Attachments ?? []).find(isCalendarAttachment)
+  if (!attachment?.Content) return null
+
+  const icsBody = Buffer.from(attachment.Content, 'base64').toString('utf8')
+  const calendar = new ICAL.Component(ICAL.parse(icsBody))
+
+  const vevent = calendar.getFirstSubcomponent('vevent')
+  if (!vevent) return null
+  const event = new ICAL.Event(vevent)
+
+  return {
+    uid: event.uid ?? undefined,
+    summary: event.summary ?? undefined,
+    description: event.description ?? undefined,
+    location: event.location ?? undefined,
+    startDate: event.startDate?.toJSDate(),
+    endDate: event.endDate?.toJSDate(),
+    organizer: organizerEmail(event.organizer)
+  }
+}
+
+/** Compare in constant time so response timing can't leak the secret a byte at a time. */
+const credentialsMatch = (provided: string, expected: string): boolean => {
+  const providedBuffer = Buffer.from(provided)
+  const expectedBuffer = Buffer.from(expected)
+  if (providedBuffer.length !== expectedBuffer.length) return false
+  return crypto.timingSafeEqual(new Uint8Array(providedBuffer), new Uint8Array(expectedBuffer))
+}
+
+const handleEvent = async (req, res) => {
+  // Postmark retries any non-200 (10 times over ~10.5 hours), so acknowledge before parsing.
+  res.status(httpStatus.OK).send('ok')
+
+  try {
+    const invite = parseInviteFromPayload(req.body)
+    if (!invite) {
+      logger.warn('Email webhook: inbound message had no calendar (.ics) attachment; nothing to process')
+      return
+    }
+    logger.info(
+      `Email webhook: parsed invite "${invite.summary ?? '(no summary)'}" (UID ${invite.uid ?? 'none'}) ` +
+        `from ${req.body?.From ?? 'unknown sender'}, organizer ${invite.organizer ?? 'none'}`
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    logger.error(`Email webhook: failed to parse inbound invite: ${message}`)
+  }
+}
+
+const middleware = async (req, res, next) => {
+  try {
+    const { authUser, authSecret } = config.postmark
+    // Fail closed if the credentials aren't configured, rather than accepting every caller.
+    if (!authUser || !authSecret) {
+      logger.error('Email webhook: Postmark webhook credentials are not configured; rejecting request')
+      throw new ApiError(httpStatus.UNAUTHORIZED, 'Postmark webhook is not configured')
+    }
+
+    const authHeader = req.headers.authorization
+    if (!authHeader) {
+      throw new ApiError(httpStatus.UNAUTHORIZED, 'Missing Postmark webhook credentials')
+    }
+    const [scheme, encoded] = authHeader.split(' ')
+    if (scheme !== 'Basic' || !encoded) {
+      throw new ApiError(httpStatus.UNAUTHORIZED, 'Unsupported Postmark webhook authorization scheme')
+    }
+
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8')
+    const separatorIndex = decoded.indexOf(':')
+    const username = separatorIndex === -1 ? decoded : decoded.slice(0, separatorIndex)
+    const password = separatorIndex === -1 ? '' : decoded.slice(separatorIndex + 1)
+
+    // Evaluate both halves regardless of the first result so the reject path can't be timed.
+    const usernameValid = credentialsMatch(username, authUser)
+    const passwordValid = credentialsMatch(password, authSecret)
+    if (!usernameValid || !passwordValid) {
+      // 401, never 403: Postmark stops retrying a message forever once it sees a 403.
+      throw new ApiError(httpStatus.UNAUTHORIZED, 'Invalid Postmark webhook credentials')
+    }
+
+    next()
+  } catch (err) {
+    next(err)
+  }
+}
+
+export default { middleware, handleEvent }

--- a/src/handlers/email.ts
+++ b/src/handlers/email.ts
@@ -78,9 +78,11 @@ const handleEvent = async (req, res) => {
       logger.warn('Email webhook: inbound message had no calendar (.ics) attachment; nothing to process')
       return
     }
+    // Times log as UTC; a bad zone conversion is otherwise invisible until the event runs an hour off.
     logger.info(
       `Email webhook: parsed invite "${invite.summary ?? '(no summary)'}" (UID ${invite.uid ?? 'none'}) ` +
-        `from ${req.body?.From ?? 'unknown sender'}, organizer ${invite.organizer ?? 'none'}`
+        `from ${req.body?.From ?? 'unknown sender'}, organizer ${invite.organizer ?? 'none'}, ` +
+        `starts ${invite.startDate?.toISOString() ?? 'unknown'}, ends ${invite.endDate?.toISOString() ?? 'unknown'}`
     )
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error'

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from 'express'
 import recall from './recall.js'
 import slack from './slack.js'
 import zoom from './zoom.js'
+import email from './email.js'
 import config from '../config/config.js'
 
 export interface Handler {
@@ -14,5 +15,6 @@ export default {
   ...(config.enableDevelopmentAdapters ? development : {}),
   recall,
   zoom,
-  slack
+  slack,
+  email
 }

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -2,6 +2,19 @@ import { z } from 'zod'
 
 import mongoose from 'mongoose'
 
+/* The structured fields an Outlook invite's .ics attachment states outright, parsed by the email
+   webhook with no LLM involved. uid identifies a recurring series (every instance shares one) and
+   pairs with startDate to recognize an invite already handled. */
+export interface ParsedInvite {
+  uid?: string
+  summary?: string
+  description?: string
+  location?: string
+  startDate?: Date
+  endDate?: Date
+  organizer?: string // organizer email from the .ics ORGANIZER field, mailto: stripped
+}
+
 export interface PaginateResults<T> {
   results: Array<T>
   page: number

--- a/tests/handlers/email.handler.test.ts
+++ b/tests/handlers/email.handler.test.ts
@@ -2,6 +2,7 @@ import httpStatus from 'http-status'
 import request from 'supertest'
 import app from '../../src/app.js'
 import config from '../../src/config/config.js'
+import logger from '../../src/config/logger.js'
 import setupIntTest from '../utils/setupIntTest.js'
 import { parseInviteFromPayload } from '../../src/handlers/email.js'
 
@@ -121,6 +122,27 @@ describe('POST /v1/webhooks/email', () => {
       const payload = buildPostmarkPayload(buildIcs())
       payload.Attachments = []
       await request(app).post('/v1/webhooks/email').auth(webhookUser, webhookSecret).send(payload).expect(httpStatus.OK)
+    })
+  })
+
+  describe('logging', () => {
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    test('logs the invite start and end times as UTC', async () => {
+      // The log is this handler's only output, so a timezone mistake is invisible without the times.
+      const infoSpy = jest.spyOn(logger, 'info').mockReturnValue(logger)
+
+      await request(app)
+        .post('/v1/webhooks/email')
+        .auth(webhookUser, webhookSecret)
+        .send(buildPostmarkPayload(buildIcs()))
+        .expect(httpStatus.OK)
+
+      const logged = infoSpy.mock.calls.map(([message]) => String(message)).join('\n')
+      expect(logged).toContain('2026-09-01T17:00:00.000Z')
+      expect(logged).toContain('2026-09-01T18:00:00.000Z')
     })
   })
 

--- a/tests/handlers/email.handler.test.ts
+++ b/tests/handlers/email.handler.test.ts
@@ -1,0 +1,212 @@
+import httpStatus from 'http-status'
+import request from 'supertest'
+import app from '../../src/app.js'
+import config from '../../src/config/config.js'
+import setupIntTest from '../utils/setupIntTest.js'
+import { parseInviteFromPayload } from '../../src/handlers/email.js'
+
+setupIntTest()
+
+const webhookUser = 'postmark-webhook'
+const webhookSecret = 'test-webhook-secret'
+
+/**
+ * Build a raw iCalendar (.ics) VEVENT body, the kind Outlook attaches to a meeting invite.
+ * Any field passed as null is omitted, so tests can exercise partial invites.
+ */
+const buildIcs = (
+  fields: {
+    uid?: string | null
+    summary?: string | null
+    description?: string | null
+    location?: string | null
+    dtstart?: string | null
+    dtend?: string | null
+    organizer?: string | null
+  } = {}
+): string => {
+  const {
+    uid = '040000008200E00074C5B7101A82E00800000000ABCDEF01',
+    summary = 'Quarterly Strategy Roundtable',
+    description = 'Join on Zoom: https://acme.example.com/j/9876543210',
+    location = 'https://acme.example.com/j/9876543210',
+    dtstart = '20260901T170000Z',
+    dtend = '20260901T180000Z',
+    organizer = 'CN=Jane Organizer:mailto:jane@example.com'
+  } = fields
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'PRODID:-//Microsoft Corporation//Outlook 16.0 MIMEDIR//EN',
+    'VERSION:2.0',
+    'METHOD:REQUEST',
+    'BEGIN:VEVENT'
+  ]
+  if (uid !== null) lines.push(`UID:${uid}`)
+  if (summary !== null) lines.push(`SUMMARY:${summary}`)
+  if (description !== null) lines.push(`DESCRIPTION:${description}`)
+  if (location !== null) lines.push(`LOCATION:${location}`)
+  if (dtstart !== null) lines.push(`DTSTART:${dtstart}`)
+  if (dtend !== null) lines.push(`DTEND:${dtend}`)
+  if (organizer !== null) lines.push(`ORGANIZER;${organizer}`)
+  lines.push('END:VEVENT', 'END:VCALENDAR')
+  return lines.join('\r\n')
+}
+
+/** Wrap an .ics body in a Postmark inbound webhook payload as its base64 .ics attachment. */
+const buildPostmarkPayload = (icsBody: string, attachmentOverrides = {}) => ({
+  FromName: 'Jane Organizer',
+  From: 'jane@example.com',
+  Subject: 'Quarterly Strategy Roundtable',
+  MessageID: '73e6d360-66eb-11e1-8e72-a8206ea7d3ea',
+  TextBody: 'You are invited.',
+  Attachments: [
+    {
+      Name: 'invite.ics',
+      Content: Buffer.from(icsBody, 'utf8').toString('base64'),
+      ContentType: 'text/calendar; method=REQUEST; name="invite.ics"',
+      ContentLength: icsBody.length,
+      ContentID: '',
+      ...attachmentOverrides
+    }
+  ]
+})
+
+describe('POST /v1/webhooks/email', () => {
+  let originalUser
+  let originalSecret
+
+  beforeAll(() => {
+    originalUser = config.postmark.authUser
+    originalSecret = config.postmark.authSecret
+    config.postmark.authUser = webhookUser
+    config.postmark.authSecret = webhookSecret
+  })
+
+  afterAll(() => {
+    config.postmark.authUser = originalUser
+    config.postmark.authSecret = originalSecret
+  })
+
+  describe('Basic Auth', () => {
+    test('accepts a request with valid credentials and responds 200', async () => {
+      await request(app)
+        .post('/v1/webhooks/email')
+        .auth(webhookUser, webhookSecret)
+        .send(buildPostmarkPayload(buildIcs()))
+        .expect(httpStatus.OK)
+    })
+
+    test('rejects a request with no Authorization header before parsing', async () => {
+      await request(app).post('/v1/webhooks/email').send(buildPostmarkPayload(buildIcs())).expect(httpStatus.UNAUTHORIZED)
+    })
+
+    test('rejects a request with the wrong password', async () => {
+      await request(app)
+        .post('/v1/webhooks/email')
+        .auth(webhookUser, 'wrong-secret')
+        .send(buildPostmarkPayload(buildIcs()))
+        .expect(httpStatus.UNAUTHORIZED)
+    })
+
+    test('rejects a request with the wrong username', async () => {
+      await request(app)
+        .post('/v1/webhooks/email')
+        .auth('impostor', webhookSecret)
+        .send(buildPostmarkPayload(buildIcs()))
+        .expect(httpStatus.UNAUTHORIZED)
+    })
+
+    test('responds 200 even when the message carries no calendar attachment', async () => {
+      const payload = buildPostmarkPayload(buildIcs())
+      payload.Attachments = []
+      await request(app).post('/v1/webhooks/email').auth(webhookUser, webhookSecret).send(payload).expect(httpStatus.OK)
+    })
+  })
+
+  describe('parseInviteFromPayload', () => {
+    test('extracts the calendar fields from the base64-encoded .ics attachment', () => {
+      const invite = parseInviteFromPayload(buildPostmarkPayload(buildIcs()))
+
+      expect(invite).not.toBeNull()
+      expect(invite?.uid).toBe('040000008200E00074C5B7101A82E00800000000ABCDEF01')
+      expect(invite?.summary).toBe('Quarterly Strategy Roundtable')
+      expect(invite?.description).toBe('Join on Zoom: https://acme.example.com/j/9876543210')
+      expect(invite?.location).toBe('https://acme.example.com/j/9876543210')
+      expect(invite?.organizer).toBe('jane@example.com')
+      expect(invite?.startDate?.toISOString()).toBe('2026-09-01T17:00:00.000Z')
+      expect(invite?.endDate?.toISOString()).toBe('2026-09-01T18:00:00.000Z')
+    })
+
+    test('resolves a TZID-based DTSTART/DTEND through the embedded VTIMEZONE', () => {
+      // Outlook names zones the Windows way ("Eastern Standard Time"), not the IANA way, and
+      // defines them in the file. Sept 1 2026 is daylight there (UTC-4), so 13:00 local is 17:00 UTC.
+      const ics = [
+        'BEGIN:VCALENDAR',
+        'PRODID:-//Microsoft Corporation//Outlook 16.0 MIMEDIR//EN',
+        'VERSION:2.0',
+        'METHOD:REQUEST',
+        'BEGIN:VTIMEZONE',
+        'TZID:Eastern Standard Time',
+        'BEGIN:STANDARD',
+        'DTSTART:16011104T020000',
+        'TZOFFSETFROM:-0400',
+        'TZOFFSETTO:-0500',
+        'RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=11',
+        'END:STANDARD',
+        'BEGIN:DAYLIGHT',
+        'DTSTART:16010311T020000',
+        'TZOFFSETFROM:-0500',
+        'TZOFFSETTO:-0400',
+        'RRULE:FREQ=YEARLY;BYDAY=2SU;BYMONTH=3',
+        'END:DAYLIGHT',
+        'END:VTIMEZONE',
+        'BEGIN:VEVENT',
+        'UID:040000008200E00074C5B7101A82E00800000000ABCDEF01',
+        'SUMMARY:Quarterly Strategy Roundtable',
+        'DESCRIPTION:Join on Zoom: https://acme.example.com/j/9876543210',
+        'LOCATION:https://acme.example.com/j/9876543210',
+        'DTSTART;TZID=Eastern Standard Time:20260901T130000',
+        'DTEND;TZID=Eastern Standard Time:20260901T140000',
+        'ORGANIZER;CN=Jane Organizer:mailto:jane@example.com',
+        'END:VEVENT',
+        'END:VCALENDAR'
+      ].join('\r\n')
+
+      const invite = parseInviteFromPayload(buildPostmarkPayload(ics))
+
+      expect(invite?.startDate?.toISOString()).toBe('2026-09-01T17:00:00.000Z')
+      expect(invite?.endDate?.toISOString()).toBe('2026-09-01T18:00:00.000Z')
+    })
+
+    test('identifies the .ics attachment by filename when the content type is generic', () => {
+      const payload = buildPostmarkPayload(buildIcs(), {
+        Name: 'meeting.ics',
+        ContentType: 'application/octet-stream'
+      })
+
+      const invite = parseInviteFromPayload(payload)
+
+      expect(invite?.summary).toBe('Quarterly Strategy Roundtable')
+    })
+
+    test('returns null when there is no calendar attachment', () => {
+      const payload = buildPostmarkPayload(buildIcs())
+      payload.Attachments = [
+        {
+          Name: 'photo.png',
+          Content: Buffer.from('not-a-calendar', 'utf8').toString('base64'),
+          ContentType: 'image/png',
+          ContentLength: 14,
+          ContentID: ''
+        }
+      ]
+
+      expect(parseInviteFromPayload(payload)).toBeNull()
+    })
+
+    test('returns null when the attachments array is missing', () => {
+      expect(parseInviteFromPayload({ From: 'jane@example.com' })).toBeNull()
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6668,6 +6668,11 @@ husky@^9.1.7:
   resolved "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz"
   integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
 
+ical.js@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ical.js/-/ical.js-2.2.1.tgz#f06fe9b32498d948893ec994e6964379dac6a907"
+  integrity sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
@@ -9657,14 +9662,7 @@ python-shell@^5.0.0:
   resolved "https://registry.npmjs.org/python-shell/-/python-shell-5.0.0.tgz"
   integrity sha512-RUOOOjHLhgR1MIQrCtnEqz/HJ1RMZBIN+REnpSUrfft2bXqXy69fwJASVziWExfFXsR1bCY0TznnHooNsCo0/w==
 
-qs@6.11.2, qs@6.13.0, qs@>=6.5.3, qs@^6.11.2, qs@^6.13.1, qs@^6.14.0, qs@^6.7.0, qs@~6.5.2:
-  version "6.15.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
-  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
-  dependencies:
-    side-channel "^1.1.0"
-
-qs@^6.15.2:
+qs@6.11.2, qs@6.13.0, qs@>=6.5.3, qs@^6.11.2, qs@^6.13.1, qs@^6.14.0, qs@^6.15.2, qs@^6.7.0, qs@~6.5.2:
   version "6.15.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
   integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==


### PR DESCRIPTION
## What is in this PR?

First backend piece of the email-to-events feature, where an organizer will eventually create a Nextspace event by adding Berkie (the event-setup bot) as an attendee on an Outlook meeting invite. This PR receives those invite emails from Postmark (our inbound email provider), verifies they really came from Postmark, and parses the attached calendar file into structured fields. It creates no event and sends no mail; that comes later.

Part of berkmancenter/nextspace_archive#260.

## Changes in the codebase

- New endpoint at `POST /v1/webhooks/email` that accepts Postmark's inbound email webhook.
- The handler verifies every request with HTTP Basic Auth, checking the username and secret against two new environment variables, and rejects bad or missing credentials before parsing anything. Rejections return 401, since a 403 would stop Postmark retrying that message forever.
- It acknowledges with 200 immediately and parses afterward, because Postmark retries any non-200 for hours.
- It decodes the base64 calendar attachment and reads UID, summary, description, location, start and end times, and organizer. Times stamped in a local zone resolve through the invite's embedded VTIMEZONE.
- The parsed invite is logged, with start and end times in UTC. Since this handler answers 200 on every path, the log is the only place a parse failure or a bad timezone conversion shows up.
- Adds ical.js for the calendar parsing.
- New docs page for the integration, covering Postmark setup and both environment variables.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages? (none)
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [x] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [x] update team documentation of any new or changed environment variables? (new `docs/pages/platforms/email.md`, linked from the installing guide)

## Testing this PR

There's no UI for this yet, so testing goes through the Hoppscotch collection for `POST /v1/webhooks/email` (see existing endpoint under EventAssistant). The collection already contains the request body, including the base64-encoded calendar attachment, so there's nothing to build or encode. The only thing you supply is credentials.

- [x] Pick any username and secret for local testing. Add them to your local `.env`:

      POSTMARK_WEBHOOK_AUTH_USER=<your choice>
      POSTMARK_WEBHOOK_AUTH_SECRET=<your choice>

- [x] Enter that same pair in Hoppscotch under Authorization, using Basic Auth. The two have to match: the handler compares what the request sends against what's in `.env`.
- [x] Start the server with `yarn dev`.

For reference, here's what the collection sends. It's a Postmark inbound webhook payload:

| Field | Value |
|---|---|
| `From` | `jane@example.com` |
| `Subject` | Quarterly Strategy Roundtable |
| `Attachments[0].Name` | `invite.ics` |
| `Attachments[0].ContentType` | `text/calendar; method=REQUEST` |
| `Attachments[0].Content` | the calendar file below, base64-encoded |

The attachment is an Outlook-shaped meeting request containing:

| Property | Value |
|---|---|
| `METHOD` | `REQUEST` |
| `UID` | `040...` |
| `SUMMARY` | Quarterly Strategy Roundtable |
| `DESCRIPTION` | Join on Zoom: `https://acme.example.com/j/9876543210` |
| `LOCATION` | `https://acme.example.com/j/9876543210` |
| `DTSTART` | `20260901T130000` with `TZID=Eastern Standard Time` |
| `DTEND` | `20260901T140000` with `TZID=Eastern Standard Time` |
| `ORGANIZER` | `CN=Jane Organizer:mailto:jane@example.com` |
| `VTIMEZONE` | defines `Eastern Standard Time` (standard `-0500`, daylight `-0400`) |

Outlook names zones the Windows way rather than the IANA way, and ships the matching `VTIMEZONE` in the file, so that payload mirrors what a real invite looks like. Then:

- [x] Send it. Expect `200` with body `ok`, and a log line reading:

      Email webhook: parsed invite "Quarterly Strategy Roundtable" (UID 040...) from jane@example.com, organizer jane@example.com, starts 2026-09-01T17:00:00.000Z, ends 2026-09-01T18:00:00.000Z

  Check the times. September 1 is daylight time in the Eastern zone, so a 13:00 local start is 17:00 UTC, resolved off the invite's own `VTIMEZONE` with no timezone config on our side. An 18:00 start would mean the `VTIMEZONE` was ignored.
- [x] Change the secret in Hoppscotch so it no longer matches your `.env`, then send again with Basic Auth switched off entirely. Expect `401` both times and no parse line in the log.
- [x] Restore your credentials, edit the body to `"Attachments": []`, and send. Expect `200` (a non-200 would make Postmark retry for hours) and a warning that there was no calendar attachment.

## Additional information

Postmark doesn't sign inbound webhooks, so Basic Auth is the verification method its docs recommend. On a real deployment the same user and secret pair goes on the Postmark webhook (via the dashboard, or the `HttpAuth` field when creating it through the API) and in the server env, with the secret generated by `openssl rand -base64 32` rather than chosen by hand. The draft-status PR #200 (merged) is a prerequisite for the event-creation work, not for this one. The event detail view organizers will eventually land on is nextspace#157.