### PR TITLE
When creating a conversation from a calendar invite, determine owner and which topic it belongs to

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,9 +65,7 @@ JWT_RESET_PASSWORD_EXPIRATION_MINUTES=120
 # HANDOFF_TOKEN_EXPIRATION_MINUTES=60
 
 # SMTP configuration options for the email service.
-# On real deployments, point these at Postmark's SMTP interface so outbound mail (event
-# confirmations, signup invites) leaves through the same provider as the inbound invite webhook:
-# host smtp.postmarkapp.com, with your Postmark server API token as both username and password.
+# On real deployments, point these at interfaces like Postmark's SMTP interface
 # For testing, you can use a fake SMTP service like Ethereal: https://ethereal.email/create
 SMTP_HOST=email-server
 SMTP_PORT=587

--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,10 @@ JWT_RESET_PASSWORD_EXPIRATION_MINUTES=120
 # Short by design: the token is meant to be clicked from Slack within an hour.
 # HANDOFF_TOKEN_EXPIRATION_MINUTES=60
 
-# SMTP configuration options for the email service
+# SMTP configuration options for the email service.
+# On real deployments, point these at Postmark's SMTP interface so outbound mail (event
+# confirmations, signup invites) leaves through the same provider as the inbound invite webhook:
+# host smtp.postmarkapp.com, with your Postmark server API token as both username and password.
 # For testing, you can use a fake SMTP service like Ethereal: https://ethereal.email/create
 SMTP_HOST=email-server
 SMTP_PORT=587
@@ -77,6 +80,11 @@ EMAIL_FROM=support@yourapp.com
 # The secret is a random string you generate (e.g. `openssl rand -base64 32`), not a human password.
 #POSTMARK_WEBHOOK_AUTH_USER=
 #POSTMARK_WEBHOOK_AUTH_SECRET=
+
+# Comma-separated email domains whose senders, if they have no account yet, get a "please sign up"
+# reply to an inbound calendar invite. Invites from any other domain are rejected (no event, no reply).
+# Unset means no domains are allowlisted, so no signup invites are sent.
+#ALLOWED_ORGANIZER_EMAIL_DOMAINS=example.edu
 
 # Public URL of the Nextspace frontend. Used to build links for password
 # reset emails, channel archive emails, and the Slack event-setup handoff

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -131,7 +131,10 @@ const envVarsSchema = Joi.object()
       .description('Minutes after scheduledEndTime to auto-stop a conversation'),
     SYSTEM_USERS: Joi.string()
       .default('event-setup-bot:serviceAccount')
-      .description('Comma-separated list of system accounts to create on startup, in username:role format')
+      .description('Comma-separated list of system accounts to create on startup, in username:role format'),
+    ALLOWED_ORGANIZER_EMAIL_DOMAINS: Joi.string().description(
+      'Comma-separated email domains whose senders, if they have no account yet, get a "please sign up" reply to an inbound invite. Invites from any other domain are rejected: no event, no reply. Unset means none, so no signup invites are ever sent.'
+    )
   })
   .unknown()
 
@@ -280,6 +283,10 @@ const config = {
   systemUsers: envVars.SYSTEM_USERS.split(',').map((entry: string) => {
     const [username, role] = entry.trim().split(':')
     return { username, role }
-  })
+  }),
+  allowedOrganizerEmailDomains: (envVars.ALLOWED_ORGANIZER_EMAIL_DOMAINS ?? '')
+    .split(',')
+    .map((domain: string) => domain.trim().toLowerCase())
+    .filter((domain: string) => domain.length > 0)
 }
 export default config

--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -759,7 +759,6 @@ components:
         - enableDMs
         - experiments
         - owner
-        - topic
       properties:
         id:
           type: string

--- a/src/models/conversation.model.ts
+++ b/src/models/conversation.model.ts
@@ -119,7 +119,8 @@ const conversationSchema = new mongoose.Schema<IConversation, ConversationModel>
     topic: {
       type: mongoose.SchemaTypes.ObjectId,
       ref: 'Topic',
-      required: true,
+      // Optional so a draft created from an inbound invite with no matching Topic can be saved with a
+      // blank topic for the organizer to fill in. Non-draft conversations still get one at creation.
       index: true
     },
     scheduledTime: {

--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -12,6 +12,7 @@ import config from '../../config/config.js'
 import adapterService from '../adapter.service.js'
 import channelService from '../channel.service.js'
 import { ConversationDocument } from '../../models/conversation.model.js'
+import { TopicDocument } from '../../models/topic.model.js'
 import { getConversationType } from '../../conversations/index.js'
 import adapterTypes from '../../adapters/index.js'
 import resolveConversationType from '../../conversations/resolver.js'
@@ -60,7 +61,7 @@ const startConversation = async (conversationOrId, user) => {
   await conversation.populate(['topic', 'agents', 'adapters'])
   if (
     user._id.toString() !== conversation.owner._id.toString() &&
-    user._id.toString() !== conversation.topic.owner._id.toString()
+    user._id.toString() !== conversation.topic?.owner?._id.toString()
   ) {
     throw new ApiError(httpStatus.FORBIDDEN, 'Only conversation or topic owner can start conversation')
   }
@@ -76,7 +77,10 @@ const stopConversation = async (conversationOrId, user) => {
     }
   }
   await conversation.populate(['topic', 'agents', 'adapters'])
-  if (user._id.toString() !== conversation.owner.toString() && user._id.toString() !== conversation.topic.owner.toString()) {
+  if (
+    user._id.toString() !== conversation.owner.toString() &&
+    user._id.toString() !== conversation.topic?.owner?.toString()
+  ) {
     throw new ApiError(httpStatus.FORBIDDEN, 'Only conversation or topic owner can stop conversation')
   }
   return doStopConversation(conversation)
@@ -141,17 +145,25 @@ async function scheduleConversationEndingSoon(conversation) {
 /**
  * Create a conversation
  * @param {Object} conversationBody
+ * @param {Object} user
+ * @param {Object} [options]
+ * @param {boolean} [options.allowDraft] trusted internal callers only; lets a conversation be created
+ *   with no topic, saved as a draft for the owner to complete (see createConversationFromType)
  * @returns {Promise<Conversation>}
  */
-const createConversation = async (conversationBody, user) => {
-  if (!conversationBody.topicId) throw new ApiError(httpStatus.BAD_REQUEST, 'topic id must be passed in request body')
-  const topicId = new mongoose.Types.ObjectId(conversationBody.topicId)
-  const topic = await Topic.findById(topicId)
-  if (!topic) {
-    throw new ApiError(httpStatus.BAD_REQUEST, 'No such topic')
-  }
-  if (!topic?.conversationCreationAllowed && user._id.toString() !== topic?.owner.toString()) {
-    throw new ApiError(httpStatus.FORBIDDEN, 'Conversation creation not allowed.')
+const createConversation = async (conversationBody, user, { allowDraft = false } = {}) => {
+  let topic: TopicDocument | null = null
+  if (conversationBody.topicId) {
+    const topicId = new mongoose.Types.ObjectId(conversationBody.topicId)
+    topic = await Topic.findById(topicId)
+    if (!topic) {
+      throw new ApiError(httpStatus.BAD_REQUEST, 'No such topic')
+    }
+    if (!topic.conversationCreationAllowed && user._id.toString() !== topic.owner.toString()) {
+      throw new ApiError(httpStatus.FORBIDDEN, 'Conversation creation not allowed.')
+    }
+  } else if (!allowDraft) {
+    throw new ApiError(httpStatus.BAD_REQUEST, 'topic id must be passed in request body')
   }
 
   if (conversationBody.scheduledTime && new Date(conversationBody.scheduledTime) <= new Date()) {
@@ -167,7 +179,7 @@ const createConversation = async (conversationBody, user) => {
   const conversation = new Conversation({
     name: conversationBody.name,
     owner: user,
-    topic,
+    ...(topic && { topic }),
     enableAgents: !!conversationBody.agentTypes?.length,
     ...(conversationBody.enableDMs !== undefined && { enableDMs: conversationBody.enableDMs }),
     ...(conversationBody.conversationType !== undefined && { conversationType: conversationBody.conversationType }),
@@ -212,8 +224,13 @@ const createConversation = async (conversationBody, user) => {
     await channelService.createChannel(conversation, channelProps)
   }
 
-  topic.conversations.push(conversation.toObject())
-  await Promise.all([conversation.save(), topic.save()])
+  // A topicless draft has nothing to link back to, so only touch the topic when one resolved.
+  if (topic) {
+    topic.conversations.push(conversation.toObject())
+    await Promise.all([conversation.save(), topic.save()])
+  } else {
+    await conversation.save()
+  }
   await transcript.loadEventMetadataIntoVectorStore(conversation)
 
   websocketGateway.broadcastNewConversation(conversation)
@@ -253,7 +270,7 @@ const createConversationFromType = async (params, user, { allowDraft = false } =
   }
 
   const resolved = resolveConversationType(params, conversationType, allowDraft)
-  return createConversation({ ...params, conversationType: type, ...resolved }, user)
+  return createConversation({ ...params, conversationType: type, ...resolved }, user, { allowDraft })
 }
 
 /**
@@ -269,7 +286,7 @@ const updateConversation = async (conversationBody, user) => {
   }
   if (
     user._id.toString() !== conversationDoc.owner.toString() &&
-    user._id.toString() !== conversationDoc.topic.owner.toString()
+    user._id.toString() !== conversationDoc.topic?.owner?.toString()
   ) {
     throw new ApiError(httpStatus.FORBIDDEN, 'Only conversation or topic owner can update.')
   }
@@ -702,7 +719,10 @@ const deleteConversation = async (id, user) => {
   if (!conversation) {
     throw new ApiError(httpStatus.NOT_FOUND, `Conversation with id ${id} not found`)
   }
-  if (user._id.toString() !== conversation.owner.toString() && user._id.toString() !== conversation.topic.owner.toString()) {
+  if (
+    user._id.toString() !== conversation.owner.toString() &&
+    user._id.toString() !== conversation.topic?.owner?.toString()
+  ) {
     throw new ApiError(httpStatus.FORBIDDEN, 'Only conversation or topic owner can delete.')
   }
   if (conversation.active) {
@@ -737,7 +757,10 @@ const patchConversationAgent = async (id, agentId, body, user) => {
     throw new ApiError(httpStatus.NOT_FOUND, `Conversation with id ${id} not found`)
   }
   const agentIdStr = agentId.toString() ? agentId.toString() : agentId
-  if (user._id.toString() !== conversation.owner.toString() && user._id.toString() !== conversation.topic.owner.toString()) {
+  if (
+    user._id.toString() !== conversation.owner.toString() &&
+    user._id.toString() !== conversation.topic?.owner?.toString()
+  ) {
     throw new ApiError(httpStatus.FORBIDDEN, 'Only conversation or topic owner can patch agents')
   }
   const agent = conversation.agents.find((a) => a._id!.toString() === agentIdStr)

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -109,13 +109,13 @@ To prevent archival and keep your channel on Conversations, please copy and past
  * @returns {Promise}
  */
 const sendSignupInviteEmail = async (to) => {
-  const subject = 'Set up your Nextspace account to create your event'
+  const subject = 'Set up your account to create your event'
   const signupUrl = `${config.appHost}/signup`
   const text = `Hello,
-We received your calendar invite, but there's no Nextspace account for this email address yet.
+We received your calendar invite, but there's no account for this email address yet.
 To finish setting up your event, sign up here and then resend the invite: ${signupUrl}`
   const html = `<p>Hello,</p>
-<p>We received your calendar invite, but there's no Nextspace account for this email address yet.</p>
+<p>We received your calendar invite, but there's no account for this email address yet.</p>
 <p>To finish setting up your event, <a href="${signupUrl}">sign up here</a> and then resend the invite.</p>`
   await sendEmailAsync(to, subject, text, html)
 }

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -101,12 +101,32 @@ To prevent archival and keep your channel on Conversations, please copy and past
   await sendEmailAsync(to, subject, text, html)
 }
 
+/**
+ * Invite an inbound-invite sender who has no account yet to sign up.
+ * Only sent to senders inside an allowlisted domain (see emailSetup.service); an event is created
+ * only once they have an account, so this is the reply that unblocks them.
+ * @param {string} to
+ * @returns {Promise}
+ */
+const sendSignupInviteEmail = async (to) => {
+  const subject = 'Set up your Nextspace account to create your event'
+  const signupUrl = `${config.appHost}/signup`
+  const text = `Hello,
+We received your calendar invite, but there's no Nextspace account for this email address yet.
+To finish setting up your event, sign up here and then resend the invite: ${signupUrl}`
+  const html = `<p>Hello,</p>
+<p>We received your calendar invite, but there's no Nextspace account for this email address yet.</p>
+<p>To finish setting up your event, <a href="${signupUrl}">sign up here</a> and then resend the invite.</p>`
+  await sendEmailAsync(to, subject, text, html)
+}
+
 const emailService = {
   transport,
   sendEmail,
   sendEmailAsync,
   sendPasswordResetEmail,
   sendPasswordResetEmailAsync,
-  sendArchiveTopicEmail
+  sendArchiveTopicEmail,
+  sendSignupInviteEmail
 }
 export default emailService

--- a/src/services/eventSetup/emailSetup.service.ts
+++ b/src/services/eventSetup/emailSetup.service.ts
@@ -1,0 +1,108 @@
+/**
+ * Resolves the two things an inbound calendar invite doesn't state directly: who owns the event
+ * (the organizer) and which Topic it belongs to. Both are decided deterministically here, with no
+ * LLM involved (see the plan's "Topic matching never uses the LLM"). The fuzzy fields (Zoom link,
+ * speakers, etc.) are extracted separately.
+ */
+import config from '../../config/config.js'
+import logger from '../../config/logger.js'
+import { Topic } from '../../models/index.js'
+import { TopicDocument } from '../../models/topic.model.js'
+import userService from '../user.service.js'
+import topicService from '../topic.service.js'
+import emailService from '../email.service.js'
+import { InboundInvite } from '../../types/index.types.js'
+
+/**
+ * The Topic prefix an invite's SUMMARY points at: the substring before the first colon, trimmed.
+ * Conversations in a series are named "<topic>: <additional info>", so "Team Sync: Jane Presents"
+ * points at the "Team Sync" topic. Returns null when there's no colon or the prefix is empty, which
+ * the caller reads as "no prefix to match, fall back to a new Topic."
+ */
+export const topicPrefixFromSummary = (summary?: string): string | null => {
+  if (!summary) return null
+  const colonIndex = summary.indexOf(':')
+  if (colonIndex === -1) return null
+  const prefix = summary.slice(0, colonIndex).trim()
+  return prefix.length > 0 ? prefix : null
+}
+
+/**
+ * Pick the candidate Topic whose name exactly equals the invite SUMMARY's prefix, comparing
+ * case-insensitively and ignoring surrounding whitespace. Exact match only: "Team Sync" must not
+ * match a "Team Syncs" Topic. Returns null when there's no prefix or nothing matches. The candidate
+ * list is the permission boundary; the caller decides which Topics go in it.
+ */
+export const matchTopicByPrefix = <T extends { name?: string }>(summary: string | undefined, candidates: T[]): T | null => {
+  const prefix = topicPrefixFromSummary(summary)
+  if (!prefix) return null
+  const target = prefix.toLowerCase()
+  return candidates.find((candidate) => (candidate.name ?? '').trim().toLowerCase() === target) ?? null
+}
+
+/** The lowercased domain of an email address, or null if it isn't shaped like `local@domain`. */
+const emailDomain = (address: string): string | null => {
+  const atIndex = address.lastIndexOf('@')
+  if (atIndex === -1) return null
+  const domain = address
+    .slice(atIndex + 1)
+    .trim()
+    .toLowerCase()
+  return domain.length > 0 ? domain : null
+}
+
+/** True when the sender is inside a domain we invite to sign up (see ALLOWED_ORGANIZER_EMAIL_DOMAINS). */
+const isAllowedOrganizerDomain = (address: string): boolean => {
+  const domain = emailDomain(address)
+  return domain !== null && config.allowedOrganizerEmailDomains.includes(domain)
+}
+
+/**
+ * Find the Nextspace account that owns this invite, keying off the envelope From that Postmark
+ * received (never the spoofable .ics ORGANIZER). Returns the organizer, or null when no event should
+ * be created. The allowlisted domain is a hard gate checked first: any sender outside it is rejected
+ * outright, account or not, with no reply (confirming the address "just needs to sign up" would be a
+ * small information leak to arbitrary outsiders). Inside the allowlist, a known sender is the
+ * organizer and an unknown one gets a "please sign up" reply.
+ */
+export const resolveOrganizer = async (inboundInvite: InboundInvite) => {
+  const { fromAddress, invite } = inboundInvite
+
+  if (!isAllowedOrganizerDomain(fromAddress)) {
+    logger.warn(`Email webhook: sender ${fromAddress} is outside the allowlisted domains; rejecting, no event created`)
+    return null
+  }
+
+  const organizer = await userService.getUserByEmail(fromAddress)
+  if (organizer) {
+    // A mismatch is worth watching (a spoof attempt, or a relay rewriting headers) but not worth
+    // blocking a real organizer's event over, so log and proceed on the trusted From.
+    if (invite.organizer && invite.organizer.toLowerCase() !== fromAddress.toLowerCase()) {
+      logger.warn(
+        `Email webhook: .ics ORGANIZER ${invite.organizer} differs from envelope From ${fromAddress}; trusting From`
+      )
+    }
+    return organizer
+  }
+
+  await emailService.sendSignupInviteEmail(fromAddress)
+  logger.info(`Email webhook: no account for ${fromAddress} (allowlisted domain); sent signup invite`)
+  return null
+}
+
+/**
+ * Decide which existing Topic this invite belongs to, deterministically. Match the SUMMARY's
+ * "<topic>:" prefix against the sender's candidate set (public Topics plus their own private ones),
+ * case-insensitively; the candidate set is the permission boundary. Returns the matched Topic, or
+ * null when nothing matches. On null the draft event is created with a blank topic for the organizer
+ * to fill in later, rather than inventing a Topic from a one-off invite.
+ */
+export const resolveTopic = async (inboundInvite: InboundInvite, organizer): Promise<TopicDocument | null> => {
+  const { invite } = inboundInvite
+
+  const candidates = await topicService.allTopicsByUser(organizer)
+  const matched = matchTopicByPrefix(invite.summary, candidates)
+  if (!matched?.id) return null
+
+  return Topic.findById(matched.id)
+}

--- a/src/services/eventSetup/emailSetup.service.ts
+++ b/src/services/eventSetup/emailSetup.service.ts
@@ -58,7 +58,7 @@ const isAllowedOrganizerDomain = (address: string): boolean => {
 }
 
 /**
- * Find the Nextspace account that owns this invite, keying off the envelope From that Postmark
+ * Find the account that owns this invite, keying off the envelope From that Postmark
  * received (never the spoofable .ics ORGANIZER). Returns the organizer, or null when no event should
  * be created. The allowlisted domain is a hard gate checked first: any sender outside it is rejected
  * outright, account or not, with no reply (confirming the address "just needs to sign up" would be a

--- a/src/services/eventSetup/emailSetup.service.ts
+++ b/src/services/eventSetup/emailSetup.service.ts
@@ -73,7 +73,9 @@ export const resolveOrganizer = async (inboundInvite: InboundInvite) => {
     return null
   }
 
-  const organizer = await userService.getUserByEmail(fromAddress)
+  // Match the organizer case-insensitively: the domain gate above already lowercases, and a
+  // lowercase-stored account would otherwise be missed by a mixed-case From and wrongly bounced.
+  const organizer = await userService.getUserByEmail(fromAddress.toLowerCase())
   if (organizer) {
     // A mismatch is worth watching (a spoof attempt, or a relay rewriting headers) but not worth
     // blocking a real organizer's event over, so log and proceed on the trusted From.

--- a/src/services/resource.service.ts
+++ b/src/services/resource.service.ts
@@ -100,7 +100,7 @@ const savePdf = async (conversationId: string, resourceId: string, fileBuffer: B
 
   const userId = user._id.toString()
   const isConvOwner = conv.owner.toString() === userId
-  const isTopicOwner = conv.topic.owner.toString() === userId
+  const isTopicOwner = conv.topic?.owner?.toString() === userId
   if (!isConvOwner && !isTopicOwner) {
     throw new ApiError(httpStatus.FORBIDDEN, 'Only conversation or topic owner can upload resources')
   }

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -15,6 +15,14 @@ export interface ParsedInvite {
   organizer?: string // organizer email from the .ics ORGANIZER field, mailto: stripped
 }
 
+/* The trust boundary in one shape: `invite` is attacker-supplied .ics file content (anyone can put
+   any UID or ORGANIZER in a raw .ics), while `fromAddress` is the envelope From that Postmark actually
+   received. Identity resolution keys off fromAddress; ORGANIZER is only ever compared against it. */
+export interface InboundInvite {
+  fromAddress: string
+  invite: ParsedInvite
+}
+
 export interface PaginateResults<T> {
   results: Array<T>
   page: number

--- a/src/websockets/websocketGateway.ts
+++ b/src/websockets/websocketGateway.ts
@@ -74,10 +74,13 @@ class WebsocketGateway {
   }
 
   async broadcastNewConversation(conversation) {
+    // A topicless draft (e.g. from an unmatched inbound invite) has no topic room to broadcast into.
+    if (!conversation.topic) return
     await this.broadcast(conversation.topic._id.toString(), 'conversation:new', conversation)
   }
 
   async broadcastConversationUpdate(conversation) {
+    if (!conversation.topic) return
     await this.broadcast(conversation.topic._id.toString(), 'conversation:update', conversation)
   }
 

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -746,6 +746,37 @@ describe('Conversation service methods', () => {
         expect(conversation.draft).toBe(true)
         expect(conversation.active).toBe(false)
       })
+
+      // An inbound invite with no matching Topic resolves to no topicId; the draft is created with a
+      // blank topic for the organizer to fill in, but only for trusted allowDraft callers.
+      const completeParamsNoTopic = {
+        type: 'eventAssistant',
+        name: 'Topicless Event',
+        platforms: ['zoom'],
+        scheduledTime: new Date(Date.now() + 3600000),
+        scheduledEndTime: new Date(Date.now() + 7200000),
+        properties: {
+          zoomMeetingUrl: 'https://zoom.us/j/123456789?pwd=12345',
+          llmModel: supportedModels[1]
+        }
+      }
+
+      test('throws when topicId is missing and allowDraft is not set', async () => {
+        await expect(
+          conversationService.createConversationFromType({ ...completeParamsNoTopic }, registeredUser)
+        ).rejects.toMatchObject({ statusCode: httpStatus.BAD_REQUEST })
+      })
+
+      test('saves a draft with a blank topic when topicId is missing and allowDraft is set', async () => {
+        const conversation = await conversationService.createConversationFromType(
+          { ...completeParamsNoTopic },
+          registeredUser,
+          { allowDraft: true }
+        )
+
+        expect(conversation.draft).toBe(true)
+        expect(conversation.topic).toBeFalsy()
+      })
     })
 
     describe('feature agent inclusion and property resolution', () => {

--- a/tests/unit/services/email.service.test.ts
+++ b/tests/unit/services/email.service.test.ts
@@ -1,0 +1,29 @@
+import { jest } from '@jest/globals'
+import emailService from '../../../src/services/email.service.js'
+import config from '../../../src/config/config.js'
+
+describe('email.service', () => {
+  describe('sendSignupInviteEmail', () => {
+    let sendMailSpy
+
+    beforeEach(() => {
+      sendMailSpy = jest.spyOn(emailService.transport, 'sendMail').mockResolvedValue(undefined as never)
+    })
+
+    afterEach(() => {
+      sendMailSpy.mockRestore()
+    })
+
+    it('sends to the given address with a signup link', async () => {
+      await emailService.sendSignupInviteEmail('newcomer@cyber.harvard.edu')
+
+      expect(sendMailSpy).toHaveBeenCalledTimes(1)
+      const msg = sendMailSpy.mock.calls[0][0]
+      expect(msg.to).toBe('newcomer@cyber.harvard.edu')
+      expect(msg.from).toBe(config.email.from)
+      expect(msg.subject).toEqual(expect.any(String))
+      expect(msg.text).toContain(`${config.appHost}/signup`)
+      expect(msg.html).toContain(`${config.appHost}/signup`)
+    })
+  })
+})

--- a/tests/unit/services/eventSetup/emailSetup.matcher.test.ts
+++ b/tests/unit/services/eventSetup/emailSetup.matcher.test.ts
@@ -1,0 +1,61 @@
+import { topicPrefixFromSummary, matchTopicByPrefix } from '../../../../src/services/eventSetup/emailSetup.service.js'
+
+/* These exercise the deterministic topic matcher in isolation: no webhook, no database. The candidate
+   list is just plain objects with a name, standing in for the topics a sender can see. */
+describe('emailSetup topic matcher', () => {
+  describe('topicPrefixFromSummary', () => {
+    it('returns the trimmed substring before the first colon', () => {
+      expect(topicPrefixFromSummary('BKCircle: Jane Doe Presents')).toBe('BKCircle')
+    })
+
+    it('splits on the first colon only', () => {
+      expect(topicPrefixFromSummary('BKCircle: Part 2: The Sequel')).toBe('BKCircle')
+    })
+
+    it('returns null when there is no colon', () => {
+      expect(topicPrefixFromSummary('BKCircle Jane Doe Presents')).toBeNull()
+    })
+
+    it('returns null when the prefix is empty', () => {
+      expect(topicPrefixFromSummary(': orphaned')).toBeNull()
+    })
+
+    it('returns null for an undefined summary', () => {
+      expect(topicPrefixFromSummary(undefined)).toBeNull()
+    })
+  })
+
+  describe('matchTopicByPrefix', () => {
+    const candidates = [{ name: 'BKCircle' }, { name: 'Team Syncs' }, { name: 'Ethics Seminar' }]
+
+    it('returns the topic whose name equals the summary prefix', () => {
+      expect(matchTopicByPrefix('BKCircle: Jane Doe Presents', candidates)).toBe(candidates[0])
+    })
+
+    it('matches case-insensitively', () => {
+      expect(matchTopicByPrefix('bkcircle: whatever', candidates)).toBe(candidates[0])
+    })
+
+    it('ignores surrounding whitespace on both sides', () => {
+      const spaced = [{ name: '  Team Syncs  ' }]
+      expect(matchTopicByPrefix('team syncs :   notes', spaced)).toBe(spaced[0])
+    })
+
+    it('does NOT match a near-miss prefix', () => {
+      // "Team Sync" (singular) must not match the "Team Syncs" topic.
+      expect(matchTopicByPrefix('Team Sync: standup', candidates)).toBeNull()
+    })
+
+    it('returns null when the summary has no colon', () => {
+      expect(matchTopicByPrefix('BKCircle standup', candidates)).toBeNull()
+    })
+
+    it('returns null when no candidate matches the prefix', () => {
+      expect(matchTopicByPrefix('Unknown Topic: hello', candidates)).toBeNull()
+    })
+
+    it('returns null for an empty candidate list', () => {
+      expect(matchTopicByPrefix('BKCircle: hello', [])).toBeNull()
+    })
+  })
+})

--- a/tests/unit/services/eventSetup/emailSetup.service.test.ts
+++ b/tests/unit/services/eventSetup/emailSetup.service.test.ts
@@ -1,0 +1,182 @@
+import { jest } from '@jest/globals'
+import mongoose from 'mongoose'
+import setupIntTest from '../../../utils/setupIntTest.js'
+import config from '../../../../src/config/config.js'
+import logger from '../../../../src/config/logger.js'
+import emailService from '../../../../src/services/email.service.js'
+import transcript from '../../../../src/agents/helpers/transcript.js'
+import { Topic } from '../../../../src/models/index.js'
+import { insertUsers } from '../../../fixtures/user.fixture.js'
+import { resolveOrganizer, resolveTopic } from '../../../../src/services/eventSetup/emailSetup.service.js'
+import { InboundInvite } from '../../../../src/types/index.types.js'
+
+setupIntTest()
+
+// Set the allowlist explicitly so these tests don't depend on an ambient env var.
+const allowedDomain = 'example.edu'
+config.allowedOrganizerEmailDomains = [allowedDomain]
+const OUTSIDE_DOMAIN = 'not-an-org.invalid'
+
+const buildInvite = (
+  overrides: Partial<InboundInvite['invite']> = {},
+  fromAddress = `organizer@${allowedDomain}`
+): InboundInvite => ({
+  fromAddress,
+  invite: {
+    uid: 'UID-DEFAULT',
+    summary: 'Some Event: additional info',
+    ...overrides
+  }
+})
+
+const newUser = (email: string) => ({
+  _id: new mongoose.Types.ObjectId(),
+  username: email.split('@')[0],
+  email,
+  password: 'password1',
+  role: 'user',
+  isEmailVerified: false
+})
+
+describe('emailSetup.service', () => {
+  let sendSignupSpy
+  let loggerWarnSpy
+
+  beforeEach(() => {
+    jest.spyOn(emailService.transport, 'sendMail').mockResolvedValue(undefined as never)
+    sendSignupSpy = jest.spyOn(emailService, 'sendSignupInviteEmail').mockResolvedValue(undefined as never)
+    jest.spyOn(transcript, 'loadTopicMetadataIntoVectorStore').mockResolvedValue(undefined as never)
+    loggerWarnSpy = jest.spyOn(logger, 'warn').mockReturnValue(undefined as never)
+    jest.spyOn(logger, 'info').mockReturnValue(undefined as never)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('resolveOrganizer', () => {
+    it('returns the account matching the envelope From address', async () => {
+      const email = `known@${allowedDomain}`
+      await insertUsers([newUser(email)])
+
+      const organizer = await resolveOrganizer(buildInvite({}, email))
+
+      expect(organizer).not.toBeNull()
+      expect(organizer!.email).toBe(email)
+      expect(sendSignupSpy).not.toHaveBeenCalled()
+    })
+
+    it('sends the signup invite and returns null for an unknown sender inside an allowlisted domain', async () => {
+      const email = `newcomer@${allowedDomain}`
+
+      const organizer = await resolveOrganizer(buildInvite({}, email))
+
+      expect(organizer).toBeNull()
+      expect(sendSignupSpy).toHaveBeenCalledWith(email)
+    })
+
+    it('sends no email and returns null for an unknown sender outside the allowlist', async () => {
+      const email = `stranger@${OUTSIDE_DOMAIN}`
+
+      const organizer = await resolveOrganizer(buildInvite({}, email))
+
+      expect(organizer).toBeNull()
+      expect(sendSignupSpy).not.toHaveBeenCalled()
+    })
+
+    it('rejects a sender outside the allowlist even when they have an account (domain is a hard gate)', async () => {
+      const email = `has-account@${OUTSIDE_DOMAIN}`
+      await insertUsers([newUser(email)])
+
+      const organizer = await resolveOrganizer(buildInvite({}, email))
+
+      expect(organizer).toBeNull()
+      expect(sendSignupSpy).not.toHaveBeenCalled()
+    })
+
+    it('logs a warning when the .ics ORGANIZER differs from the envelope From', async () => {
+      const email = `known@${allowedDomain}`
+      await insertUsers([newUser(email)])
+
+      await resolveOrganizer(buildInvite({ organizer: `someone-else@${allowedDomain}` }, email))
+
+      expect(loggerWarnSpy).toHaveBeenCalledWith(expect.stringContaining('someone-else'))
+    })
+
+    it('does not warn about a mismatch when ORGANIZER equals From', async () => {
+      const email = `known@${allowedDomain}`
+      await insertUsers([newUser(email)])
+
+      await resolveOrganizer(buildInvite({ organizer: email }, email))
+
+      expect(loggerWarnSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('resolveTopic', () => {
+    const insertTopic = (fields) =>
+      Topic.create({
+        name: 'placeholder',
+        votingAllowed: false,
+        conversationCreationAllowed: true,
+        private: false,
+        archivable: true,
+        ...fields
+      })
+
+    it('matches a public Topic by exact prefix regardless of who owns it', async () => {
+      const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])
+      const [other] = await insertUsers([newUser(`other@${allowedDomain}`)])
+      const publicTopic = await insertTopic({ name: 'BKCircle', owner: other._id, private: false })
+
+      const topic = await resolveTopic(buildInvite({ summary: 'BKCircle: Jane Presents' }), organizer)
+
+      expect(topic?.id).toBe(publicTopic.id)
+    })
+
+    it('matches despite case and whitespace differences in the prefix', async () => {
+      const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])
+      const publicTopic = await insertTopic({ name: 'BKCircle', owner: organizer._id, private: false })
+
+      const topic = await resolveTopic(buildInvite({ summary: '  bkcircle :  week 5' }), organizer)
+
+      expect(topic?.id).toBe(publicTopic.id)
+    })
+
+    it('returns null on a near-miss prefix, so the draft topic is left blank', async () => {
+      const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])
+      await insertTopic({ name: 'Team Syncs', owner: organizer._id, private: false })
+
+      const topic = await resolveTopic(buildInvite({ summary: 'Team Sync: standup' }), organizer)
+
+      expect(topic).toBeNull()
+    })
+
+    it('returns null when the only exact-prefix match is a Topic the sender cannot access', async () => {
+      const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])
+      const [other] = await insertUsers([newUser(`other@${allowedDomain}`)])
+      // Private topic owned by someone else: outside the sender's candidate set.
+      await insertTopic({ name: 'Secret', owner: other._id, private: true })
+
+      const topic = await resolveTopic(buildInvite({ summary: 'Secret: leak' }), organizer)
+
+      expect(topic).toBeNull()
+    })
+
+    it('returns null when the SUMMARY has no colon, rather than inventing a Topic', async () => {
+      const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])
+
+      const topic = await resolveTopic(buildInvite({ summary: 'One Off Meeting' }), organizer)
+
+      expect(topic).toBeNull()
+    })
+
+    it('creates no Topic when nothing matches', async () => {
+      const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])
+
+      await resolveTopic(buildInvite({ summary: 'Nothing Matches: here' }), organizer)
+
+      expect(await Topic.countDocuments()).toBe(0)
+    })
+  })
+})

--- a/tests/unit/services/eventSetup/emailSetup.service.test.ts
+++ b/tests/unit/services/eventSetup/emailSetup.service.test.ts
@@ -66,6 +66,17 @@ describe('emailSetup.service', () => {
       expect(sendSignupSpy).not.toHaveBeenCalled()
     })
 
+    it('recognizes a known organizer when the envelope From differs only in letter case', async () => {
+      const storedEmail = `known@${allowedDomain}`
+      await insertUsers([newUser(storedEmail)])
+
+      const organizer = await resolveOrganizer(buildInvite({}, `Known@${allowedDomain.toUpperCase()}`))
+
+      expect(organizer).not.toBeNull()
+      expect(organizer!.email).toBe(storedEmail)
+      expect(sendSignupSpy).not.toHaveBeenCalled()
+    })
+
     it('sends the signup invite and returns null for an unknown sender inside an allowlisted domain', async () => {
       const email = `newcomer@${allowedDomain}`
 


### PR DESCRIPTION
## What is in this PR?

When an inbound calendar invite arrives, the system now works out who owns the event and which Topic it belongs to, without asking an LLM. The owner is taken from the sender's authenticated email address, and invites from domains we haven't approved are turned away. The Topic is chosen by matching the invite's title against Topics the sender can already see; if none match, the event is left without a Topic rather than guessing at one. To support that, an event can now be saved with no Topic when it is created as a draft on the organizer's behalf. Nothing here creates events yet; that and the confirmation email are the next step.

## Changes in the codebase

- Identifies the event owner from the sender's authenticated email, not the calendar file's stated organizer, which anyone can forge. A disagreement between the two is logged, not blocked.
- Only accepts invites from an approved list of sender domains. An approved-domain sender with no account gets a "please sign up" email; everyone else is turned away with no reply and no event.
- Picks the matching Topic from the invite title's leading label (the text before the first colon), matched case-insensitively against the Topics the sender can access. No confident match leaves the Topic blank.
- Allows a draft event to be saved with no Topic, while the normal event-creation path still requires one.
- Adds a signup-invite email and a setting for the approved sender domains.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages? (none in this PR)
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers? (no user-facing surface yet; docs land with Chunk 6)
- [x] add and/or update automated tests?
- [x] update team documentation of any new or changed environment variables? (ALLOWED_ORGANIZER_EMAIL_DOMAINS added to .env.example)

## Testing this PR

This can't be tested manually yet: nothing calls the new resolution logic until event creation lands next chunk, and the draft path has no HTTP route. It is covered by automated tests instead.

## Additional information

The alternative to making Topic optional was to keep Topic required and invent a placeholder Topic for unmatched invites. That fails toward silent data pollution: junk Topics accumulate and nobody notices. Leaving the field blank fails toward a visibly-incomplete draft the organizer must complete before it can start. The blank-draft failure is the cheaper one to catch, so that is what we picked. The cost we accept: every place that reads an event's topic owner now has to tolerate a missing Topic. We've already made those changes. 

### Deployment

- New env var `ALLOWED_ORGANIZER_EMAIL_DOMAINS`: comma-separated domains (e.g. "example.harvard.edu`). Server boots without it, but unset or empty rejects every sender and sends no signup invites. Set it once this merges.
- No SMTP vars changed, but the signup-invite email is a new consumer of existing SMTP config.
- Carryover from #207: the webhook stays fail-closed until `POSTMARK_WEBHOOK_AUTH_USER` and `POSTMARK_WEBHOOK_AUTH_SECRET` are set.

## Related PRs

- Builds on #207 (Chunk 4, inbound webhook plumbing)
- No paired nextspace PR. The frontend that renders these drafts is already done.
- Event creation, idempotency, and the confirmation email (Chunk 6) follow in the next PR.