### PR TITLE
Connect webhook to event creation form end-to-end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,9 +74,10 @@ SMTP_USERNAME=email-server-username
 SMTP_PASSWORD=email-server-password
 EMAIL_FROM=support@yourapp.com
 
-# Basic Auth on the Postmark inbound webhook: the handler checks incoming requests against
-# these to confirm they came from Postmark. Set the same pair on the webhook in Postmark.
-# The secret is a random string you generate (e.g. `openssl rand -base64 32`), not a human password.
+# Basic Auth on the inbound email webhook: the handler checks incoming requests against these to
+# confirm they came from the configured provider. Set the same pair on the provider's webhook
+# (e.g. Postmark). The secret is a random string you generate (e.g. `openssl rand -base64 32`),
+# not a human password.
 #POSTMARK_WEBHOOK_AUTH_USER=
 #POSTMARK_WEBHOOK_AUTH_SECRET=
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,14 @@
 `@berkmancenter/llm_engine` — Node 20/22, ESM, TypeScript. **Use `yarn`** (npm is
 blocked). Tests: see [tests/CLAUDE.md](tests/CLAUDE.md).
 
+## Stay client-agnostic
+
+llm_engine serves more than one frontend. Don't reference a specific client (e.g.
+"Nextspace") by name in backend code, comments, copy, or log lines — those assumptions
+belong in the client repo, not here. Third-party services llm_engine talks to directly
+(Zoom, Matomo, Postmark, ...) are fine to name; the rule is about the client consuming
+this API, not the services it calls out to.
+
 ## Committing (non-interactive)
 
 Commit with `-m` and a [Conventional Commit](https://www.conventionalcommits.org/)

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -39,10 +39,10 @@ const envVarsSchema = Joi.object()
     SMTP_USERNAME: Joi.string().description('username for email server'),
     SMTP_PASSWORD: Joi.string().description('password for email server'),
     POSTMARK_WEBHOOK_AUTH_USER: Joi.string().description(
-      'Username set on the Postmark inbound webhook Basic Auth; the handler checks it to confirm a request came from Postmark'
+      'Username set on the inbound email webhook Basic Auth; the handler checks it to confirm a request came from the configured provider'
     ),
     POSTMARK_WEBHOOK_AUTH_SECRET: Joi.string().description(
-      'Random secret set as the password on the Postmark inbound webhook Basic Auth (not a human password); rotate periodically'
+      'Random secret set as the password on the inbound email webhook Basic Auth (not a human password); rotate periodically'
     ),
     EMAIL_FROM: Joi.string().description('the from field in the emails sent by the app'),
     APP_HOST: Joi.string().description('the host url for the frontend app'),
@@ -256,7 +256,7 @@ const config = {
   slack: {
     signingSecret: envVars.SLACK_SIGNING_SECRET
   },
-  postmark: {
+  emailWebhook: {
     authUser: envVars.POSTMARK_WEBHOOK_AUTH_USER,
     authSecret: envVars.POSTMARK_WEBHOOK_AUTH_SECRET
   },

--- a/src/handlers/email.ts
+++ b/src/handlers/email.ts
@@ -8,8 +8,8 @@ import logger from '../config/logger.js'
 import { createConversationFromInvite } from '../services/eventSetup/emailSetup.service.js'
 import { ParsedInvite } from '../types/index.types.js'
 
-/** A single entry from a Postmark inbound webhook's `Attachments` array. */
-interface PostmarkAttachment {
+/** A single entry from an inbound email webhook's `Attachments` array (Postmark's shape, for example). */
+interface InboundEmailAttachment {
   Name?: string
   Content?: string // base64-encoded file bytes
   ContentType?: string
@@ -21,7 +21,7 @@ interface PostmarkAttachment {
  * A calendar invite arrives either with a `text/calendar` content type or, when a mail relay
  * rewrites it to something generic, only as a `.ics` filename. Match on either.
  */
-const isCalendarAttachment = (attachment: PostmarkAttachment): boolean => {
+const isCalendarAttachment = (attachment: InboundEmailAttachment): boolean => {
   const contentType = (attachment?.ContentType ?? '').toLowerCase()
   const name = (attachment?.Name ?? '').toLowerCase()
   return contentType.startsWith('text/calendar') || contentType.includes('application/ics') || name.endsWith('.ics')
@@ -32,12 +32,12 @@ const organizerEmail = (organizer: string | null): string | undefined =>
   organizer ? organizer.replace(/^mailto:/i, '') : undefined
 
 /**
- * Pull the calendar fields out of a Postmark inbound payload's base64 `.ics` attachment.
+ * Pull the calendar fields out of an inbound email webhook payload's base64 `.ics` attachment.
  * Returns null when the message has no calendar attachment or no event component. Reads only
  * the fields the .ics states outright; nothing here interprets the free-text body.
  */
 export const parseInviteFromPayload = (payload: {
-  Attachments?: PostmarkAttachment[]
+  Attachments?: InboundEmailAttachment[]
   [key: string]: unknown
 }): ParsedInvite | null => {
   const attachment = (payload?.Attachments ?? []).find(isCalendarAttachment)
@@ -70,7 +70,8 @@ const credentialsMatch = (provided: string, expected: string): boolean => {
 }
 
 const handleEvent = async (req, res) => {
-  // Postmark retries any non-200 (10 times over ~10.5 hours), so acknowledge before parsing.
+  // Inbound email webhook providers retry a non-200 response (Postmark: 10 times over ~10.5
+  // hours), so acknowledge before parsing.
   res.status(httpStatus.OK).send('ok')
 
   try {
@@ -86,8 +87,9 @@ const handleEvent = async (req, res) => {
         `starts ${invite.startDate?.toISOString() ?? 'unknown'}, ends ${invite.endDate?.toISOString() ?? 'unknown'}`
     )
 
-    // Postmark's own docs confirm From is always a clean address (display name travels separately
-    // in FromName/FromFull.Name), but req.body is unvalidated wire input, so check the shape anyway.
+    // The provider's docs may confirm From is always a clean address (Postmark's does; the display
+    // name travels separately in FromName/FromFull.Name), but req.body is unvalidated wire input,
+    // so check the shape anyway.
     const fromAddress = req.body?.From
     if (typeof fromAddress !== 'string' || fromAddress.length === 0) {
       logger.warn('Email webhook: inbound message had no From address; cannot resolve an organizer')
@@ -103,20 +105,20 @@ const handleEvent = async (req, res) => {
 
 const middleware = async (req, res, next) => {
   try {
-    const { authUser, authSecret } = config.postmark
+    const { authUser, authSecret } = config.emailWebhook
     // Fail closed if the credentials aren't configured, rather than accepting every caller.
     if (!authUser || !authSecret) {
-      logger.error('Email webhook: Postmark webhook credentials are not configured; rejecting request')
-      throw new ApiError(httpStatus.UNAUTHORIZED, 'Postmark webhook is not configured')
+      logger.error('Email webhook: credentials are not configured; rejecting request')
+      throw new ApiError(httpStatus.UNAUTHORIZED, 'Email webhook is not configured')
     }
 
     const authHeader = req.headers.authorization
     if (!authHeader) {
-      throw new ApiError(httpStatus.UNAUTHORIZED, 'Missing Postmark webhook credentials')
+      throw new ApiError(httpStatus.UNAUTHORIZED, 'Missing email webhook credentials')
     }
     const [scheme, encoded] = authHeader.split(' ')
     if (scheme !== 'Basic' || !encoded) {
-      throw new ApiError(httpStatus.UNAUTHORIZED, 'Unsupported Postmark webhook authorization scheme')
+      throw new ApiError(httpStatus.UNAUTHORIZED, 'Unsupported email webhook authorization scheme')
     }
 
     const decoded = Buffer.from(encoded, 'base64').toString('utf8')
@@ -128,8 +130,9 @@ const middleware = async (req, res, next) => {
     const usernameValid = credentialsMatch(username, authUser)
     const passwordValid = credentialsMatch(password, authSecret)
     if (!usernameValid || !passwordValid) {
-      // 401, never 403: Postmark stops retrying a message forever once it sees a 403.
-      throw new ApiError(httpStatus.UNAUTHORIZED, 'Invalid Postmark webhook credentials')
+      // 401, never 403: some providers (Postmark included) stop retrying a message forever once
+      // they see a 403, so a wrong-credentials response has to leave room for a retry.
+      throw new ApiError(httpStatus.UNAUTHORIZED, 'Invalid email webhook credentials')
     }
 
     next()

--- a/src/handlers/email.ts
+++ b/src/handlers/email.ts
@@ -5,6 +5,7 @@ import ICAL from 'ical.js'
 import ApiError from '../utils/ApiError.js'
 import config from '../config/config.js'
 import logger from '../config/logger.js'
+import { createConversationFromInvite } from '../services/eventSetup/emailSetup.service.js'
 import { ParsedInvite } from '../types/index.types.js'
 
 /** A single entry from a Postmark inbound webhook's `Attachments` array. */
@@ -84,6 +85,16 @@ const handleEvent = async (req, res) => {
         `from ${req.body?.From ?? 'unknown sender'}, organizer ${invite.organizer ?? 'none'}, ` +
         `starts ${invite.startDate?.toISOString() ?? 'unknown'}, ends ${invite.endDate?.toISOString() ?? 'unknown'}`
     )
+
+    // Postmark's own docs confirm From is always a clean address (display name travels separately
+    // in FromName/FromFull.Name), but req.body is unvalidated wire input, so check the shape anyway.
+    const fromAddress = req.body?.From
+    if (typeof fromAddress !== 'string' || fromAddress.length === 0) {
+      logger.warn('Email webhook: inbound message had no From address; cannot resolve an organizer')
+      return
+    }
+
+    await createConversationFromInvite({ fromAddress, invite })
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error'
     logger.error(`Email webhook: failed to parse inbound invite: ${message}`)

--- a/src/models/conversation.model.ts
+++ b/src/models/conversation.model.ts
@@ -127,7 +127,7 @@ const conversationSchema = new mongoose.Schema<IConversation, ConversationModel>
       type: String,
       // Non-unique: most conversations have no invite UID at all, and a unique index would treat
       // every missing value as a colliding duplicate. Dedup against Postmark retries happens in
-      // createEventFromInvite (a findOne before create), not via a DB constraint.
+      // createConversationFromInvite (a findOne before create), not via a DB constraint.
       index: true
     },
     scheduledTime: {

--- a/src/models/conversation.model.ts
+++ b/src/models/conversation.model.ts
@@ -123,6 +123,13 @@ const conversationSchema = new mongoose.Schema<IConversation, ConversationModel>
       // blank topic for the organizer to fill in. Non-draft conversations still get one at creation.
       index: true
     },
+    sourceInviteUid: {
+      type: String,
+      // Non-unique: most conversations have no invite UID at all, and a unique index would treat
+      // every missing value as a colliding duplicate. Dedup against Postmark retries happens in
+      // createEventFromInvite (a findOne before create), not via a DB constraint.
+      index: true
+    },
     scheduledTime: {
       type: Date
     },

--- a/src/models/conversation.model.ts
+++ b/src/models/conversation.model.ts
@@ -123,15 +123,12 @@ const conversationSchema = new mongoose.Schema<IConversation, ConversationModel>
       // blank topic for the organizer to fill in. Non-draft conversations still get one at creation.
       index: true
     },
+    // How this conversation was created, when not the standard event-creation form. Deliberately
+    // untyped (Mixed) rather than a fixed sub-schema, so a future creation path can store whatever
+    // shape it needs without a migration; see the 'source.inviteUid' index below for the one shape
+    // in use today.
     source: {
-      inviteUid: {
-        type: String,
-        // Non-unique: most conversations have no invite UID at all, and a unique index would
-        // treat every missing value as a colliding duplicate. Dedup against webhook retries
-        // happens in createConversationFromInvite (a findOne before create), not via a DB
-        // constraint.
-        index: true
-      }
+      type: mongoose.SchemaTypes.Mixed
     },
     scheduledTime: {
       type: Date
@@ -218,6 +215,11 @@ conversationSchema.plugin(lock)
 // index timestamps
 conversationSchema.index({ createdAt: 1 })
 conversationSchema.index({ updatedAt: 1 })
+// Explicit path index: source is Mixed, so it has no fixed sub-schema to hang a field-level
+// index off of. Non-unique: most conversations have no invite UID at all, and a unique index
+// would treat every missing value as a colliding duplicate. Dedup against webhook retries
+// happens in createConversationFromInvite (a findOne before create), not via a DB constraint.
+conversationSchema.index({ 'source.inviteUid': 1 })
 conversationSchema.pre('validate', function (next) {
   this.slug = slugify(this.name)
   next()

--- a/src/models/conversation.model.ts
+++ b/src/models/conversation.model.ts
@@ -123,12 +123,15 @@ const conversationSchema = new mongoose.Schema<IConversation, ConversationModel>
       // blank topic for the organizer to fill in. Non-draft conversations still get one at creation.
       index: true
     },
-    sourceInviteUid: {
-      type: String,
-      // Non-unique: most conversations have no invite UID at all, and a unique index would treat
-      // every missing value as a colliding duplicate. Dedup against Postmark retries happens in
-      // createConversationFromInvite (a findOne before create), not via a DB constraint.
-      index: true
+    source: {
+      inviteUid: {
+        type: String,
+        // Non-unique: most conversations have no invite UID at all, and a unique index would
+        // treat every missing value as a colliding duplicate. Dedup against webhook retries
+        // happens in createConversationFromInvite (a findOne before create), not via a DB
+        // constraint.
+        index: true
+      }
     },
     scheduledTime: {
       type: Date

--- a/src/services/adapter.service.ts
+++ b/src/services/adapter.service.ts
@@ -6,17 +6,19 @@ export const maxScheduledInterval = 10 * 60 * 1000 // 10 minutes in milliseconds
 
 const start = async (adapter) => {
   const keys = Adapter.getUniqueKeys(adapter.type)
-  const query = {
-    ...Object.fromEntries(keys.map((key) => [key, key.split('.').reduce((obj, k) => obj?.[k], adapter)])),
-    active: true,
-    conversation: { $ne: adapter.conversation }
-  }
+  if (keys.length > 0) {
+    const query = {
+      ...Object.fromEntries(keys.map((key) => [key, key.split('.').reduce((obj, k) => obj?.[k], adapter)])),
+      active: true,
+      conversation: { $ne: adapter.conversation }
+    }
 
-  const adapters = await Adapter.find(query)
-  if (adapters.length > 0) {
-    throw new Error(
-      `Cannot start adapter. Another conversation with the same unique keys: ${keys.join(', ')} is currently active.`
-    )
+    const adapters = await Adapter.find(query)
+    if (adapters.length > 0) {
+      throw new Error(
+        `Cannot start adapter. Another conversation with the same unique keys: ${keys.join(', ')} is currently active.`
+      )
+    }
   }
   await adapter.start()
 }
@@ -36,26 +38,28 @@ const resumeRecording = async (adapter) => {
 const createAdapter = async (adapter, conversation) => {
   if (conversation.scheduledTime) {
     const keys = Adapter.getUniqueKeys(adapter.type)
-    const query = Object.fromEntries(keys.map((key) => [key, key.split('.').reduce((obj, k) => obj?.[k], adapter)]))
-    const adapters = await Adapter.find({
-      ...query,
-      conversation: { $ne: conversation._id }
-    }).populate('conversation')
+    if (keys.length > 0) {
+      const query = Object.fromEntries(keys.map((key) => [key, key.split('.').reduce((obj, k) => obj?.[k], adapter)]))
+      const adapters = await Adapter.find({
+        ...query,
+        conversation: { $ne: conversation._id }
+      }).populate('conversation')
 
-    if (adapters.length > 0) {
-      const startTime = new Date(conversation.scheduledTime.getTime() - maxScheduledInterval)
-      const endTime = new Date(conversation.scheduledTime.getTime() + maxScheduledInterval)
+      if (adapters.length > 0) {
+        const startTime = new Date(conversation.scheduledTime.getTime() - maxScheduledInterval)
+        const endTime = new Date(conversation.scheduledTime.getTime() + maxScheduledInterval)
 
-      const conversationAdapters = adapters.filter(
-        (a) => a.conversation.scheduledTime! >= startTime && a.conversation.scheduledTime! <= endTime
-      )
-      if (conversationAdapters.length > 0) {
-        throw new ApiError(
-          httpStatus.BAD_REQUEST,
-          `Cannot create a Conversation scheduled for +- ${
-            maxScheduledInterval / (60 * 1000)
-          } minutes within another Conversation with same unique adapter keys: ${keys.join(', ')}`
+        const conversationAdapters = adapters.filter(
+          (a) => a.conversation.scheduledTime! >= startTime && a.conversation.scheduledTime! <= endTime
         )
+        if (conversationAdapters.length > 0) {
+          throw new ApiError(
+            httpStatus.BAD_REQUEST,
+            `Cannot create a Conversation scheduled for +- ${
+              maxScheduledInterval / (60 * 1000)
+            } minutes within another Conversation with same unique adapter keys: ${keys.join(', ')}`
+          )
+        }
       }
     }
   }

--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -308,6 +308,7 @@ const updateConversation = async (conversationBody, user) => {
     throw new ApiError(httpStatus.NOT_FOUND, `Conversation with id ${conversationBody.id} not found`)
   }
   if (
+    user.role !== 'admin' &&
     user._id.toString() !== conversationDoc.owner.toString() &&
     user._id.toString() !== conversationDoc.topic?.owner?.toString()
   ) {

--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -176,10 +176,17 @@ const createConversation = async (conversationBody, user, { allowDraft = false }
       throw new Error('No such supported embedding model')
   }
 
+  /* Trusted-caller-only, same as allowDraft itself: the public routes never pass allowDraft:true,
+     so a client can never set sourceInviteUid on a conversation it creates. Without this gate, an
+     ordinary user could squat on a future invite's UID via the public API and make a legitimate
+     invite silently no-op against their decoy (see createConversationFromInvite's dedup check). */
+  const canSetSourceInviteUid = allowDraft && conversationBody.sourceInviteUid !== undefined
+
   const conversation = new Conversation({
     name: conversationBody.name,
     owner: user,
     ...(topic && { topic }),
+    ...(canSetSourceInviteUid && { sourceInviteUid: conversationBody.sourceInviteUid }),
     enableAgents: !!conversationBody.agentTypes?.length,
     ...(conversationBody.enableDMs !== undefined && { enableDMs: conversationBody.enableDMs }),
     ...(conversationBody.conversationType !== undefined && { conversationType: conversationBody.conversationType }),
@@ -215,9 +222,17 @@ const createConversation = async (conversationBody, user, { allowDraft = false }
     conversation.agents.push(agent)
   }
 
-  for (const adapterProps of conversationBody.adapters || []) {
-    const adapter = await adapterService.createAdapter(adapterProps, conversation)
-    conversation.adapters.push(adapter)
+  /* A draft conversation can be missing a property an adapter's config depends on (e.g. a Zoom
+     event with no zoomMeetingUrl yet). allowDraft relaxes the property check, but adapter config
+     is rendered from a template and saved independently, so an adapter built from a missing
+     property would save with an empty required field and fail its own validation. Skip adapter
+     creation entirely while draft; updateConversation's configSyncMap handling creates it once
+     the missing property arrives (see the "backfill" branch there). */
+  if (!conversation.draft) {
+    for (const adapterProps of conversationBody.adapters || []) {
+      const adapter = await adapterService.createAdapter(adapterProps, conversation)
+      conversation.adapters.push(adapter)
+    }
   }
 
   for (const channelProps of conversationBody.channels || []) {
@@ -349,10 +364,40 @@ const updateConversation = async (conversationBody, user) => {
       }
       if (Object.keys(configUpdates).length > 0) {
         const adapters = await Adapter.find({ conversation: conversationDoc._id, type: adapterType })
-        for (const adapter of adapters) {
-          adapter.config = { ...adapter.config, ...configUpdates }
-          adapter.markModified('config')
-          await adapter.save()
+        if (adapters.length > 0) {
+          for (const adapter of adapters) {
+            adapter.config = { ...adapter.config, ...configUpdates }
+            adapter.markModified('config')
+            await adapter.save()
+          }
+        } else if (
+          conversationDoc.platforms?.includes(adapterType) &&
+          Object.values(configUpdates).every((value) => value !== undefined && value !== null && value !== '')
+        ) {
+          /* This adapter type was skipped at creation time (see createConversation) because a
+             property it depends on was missing under allowDraft. Every property this update just
+             synced into configUpdates is now present, so the adapter can be created for real.
+             allowDraft here too: some other, unrelated required property may still be missing,
+             and that must not block this adapter from finally getting created. */
+          const conversationType = conversationDoc.conversationType
+            ? getConversationType(conversationDoc.conversationType)
+            : null
+          if (conversationType) {
+            const resolved = resolveConversationType(
+              {
+                platforms: conversationDoc.platforms,
+                properties: conversationDoc.properties,
+                features: incomingFeatures ?? conversationDoc.features
+              },
+              conversationType,
+              true
+            )
+            const adapterProps = resolved.adapters.find((a) => (a as { type?: string }).type === adapterType)
+            if (adapterProps) {
+              const adapter = await adapterService.createAdapter(adapterProps, conversationDoc)
+              conversationDoc.adapters.push(adapter)
+            }
+          }
         }
       }
     }

--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -660,7 +660,7 @@ const findByIdFull = async (id, user) => {
     .populate('agents')
     .populate('channels')
     .populate('adapters')
-    .populate({ path: 'topic', select: 'name slug description owner' })
+    .populate({ path: 'topic', select: 'name slug description owner private' })
     .exec()
   if (!conversation) {
     throw new ApiError(httpStatus.NOT_FOUND, `Conversation with id ${id} not found`)

--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -183,16 +183,17 @@ const createConversation = async (conversationBody, user, { allowDraft = false }
   }
 
   /* Trusted-caller-only, same as allowDraft itself: the public routes never pass allowDraft:true,
-     so a client can never set sourceInviteUid on a conversation it creates. Without this gate, an
-     ordinary user could squat on a future invite's UID via the public API and make a legitimate
-     invite silently no-op against their decoy (see createConversationFromInvite's dedup check). */
-  const canSetSourceInviteUid = allowDraft && conversationBody.sourceInviteUid !== undefined
+     so a client can never set source.inviteUid on a conversation it creates. Without this gate,
+     an ordinary user could squat on a future invite's UID via the public API and make a
+     legitimate invite silently no-op against their decoy (see createConversationFromInvite's
+     dedup check). */
+  const canSetSourceInviteUid = allowDraft && conversationBody.source?.inviteUid !== undefined
 
   const conversation = new Conversation({
     name: conversationBody.name,
     owner: user,
     ...(topic && { topic }),
-    ...(canSetSourceInviteUid && { sourceInviteUid: conversationBody.sourceInviteUid }),
+    ...(canSetSourceInviteUid && { source: { inviteUid: conversationBody.source.inviteUid } }),
     enableAgents: !!conversationBody.agentTypes?.length,
     ...(conversationBody.enableDMs !== undefined && { enableDMs: conversationBody.enableDMs }),
     ...(conversationBody.conversationType !== undefined && { conversationType: conversationBody.conversationType }),

--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -19,7 +19,13 @@ import resolveConversationType from '../../conversations/resolver.js'
 import { supportedModels } from '../../agents/helpers/getEmbeddings.js'
 import transcript from '../../agents/helpers/transcript.js'
 import reportService from '../report.service.js'
-import { doStartConversation, doStopConversation, updateTranscriptStatus, isConversationDraft } from './lifecycle.js'
+import {
+  doStartConversation,
+  doStopConversation,
+  updateTranscriptStatus,
+  isConversationDraft,
+  satisfiesTypeProperties
+} from './lifecycle.js'
 import resourceService from '../resource.service.js'
 
 export { updateTranscriptStatus }
@@ -222,13 +228,15 @@ const createConversation = async (conversationBody, user, { allowDraft = false }
     conversation.agents.push(agent)
   }
 
-  /* A draft conversation can be missing a property an adapter's config depends on (e.g. a Zoom
-     event with no zoomMeetingUrl yet). allowDraft relaxes the property check, but adapter config
-     is rendered from a template and saved independently, so an adapter built from a missing
-     property would save with an empty required field and fail its own validation. Skip adapter
-     creation entirely while draft; updateConversation's configSyncMap handling creates it once
-     the missing property arrives (see the "backfill" branch there). */
-  if (!conversation.draft) {
+  /* allowDraft relaxes the property check, so a draft conversation can be missing a property an
+     adapter's config depends on (e.g. a Zoom event with no zoomMeetingUrl yet). Adapter config is
+     rendered from a template and saved independently, so an adapter built from a missing property
+     would save with an empty required field and fail its own validation. satisfiesTypeProperties
+     checks only conversation properties (never topic or scheduledEndTime, see resolver.ts's
+     resolvePropertyReferences, which never receives either), so a conversation that's draft for
+     one of those unrelated reasons still gets its adapters created here; updateConversation's
+     backfill block creates them once a still-missing property arrives. */
+  if (satisfiesTypeProperties(conversation)) {
     for (const adapterProps of conversationBody.adapters || []) {
       const adapter = await adapterService.createAdapter(adapterProps, conversation)
       conversation.adapters.push(adapter)
@@ -364,40 +372,10 @@ const updateConversation = async (conversationBody, user) => {
       }
       if (Object.keys(configUpdates).length > 0) {
         const adapters = await Adapter.find({ conversation: conversationDoc._id, type: adapterType })
-        if (adapters.length > 0) {
-          for (const adapter of adapters) {
-            adapter.config = { ...adapter.config, ...configUpdates }
-            adapter.markModified('config')
-            await adapter.save()
-          }
-        } else if (
-          conversationDoc.platforms?.includes(adapterType) &&
-          Object.values(configUpdates).every((value) => value !== undefined && value !== null && value !== '')
-        ) {
-          /* This adapter type was skipped at creation time (see createConversation) because a
-             property it depends on was missing under allowDraft. Every property this update just
-             synced into configUpdates is now present, so the adapter can be created for real.
-             allowDraft here too: some other, unrelated required property may still be missing,
-             and that must not block this adapter from finally getting created. */
-          const conversationType = conversationDoc.conversationType
-            ? getConversationType(conversationDoc.conversationType)
-            : null
-          if (conversationType) {
-            const resolved = resolveConversationType(
-              {
-                platforms: conversationDoc.platforms,
-                properties: conversationDoc.properties,
-                features: incomingFeatures ?? conversationDoc.features
-              },
-              conversationType,
-              true
-            )
-            const adapterProps = resolved.adapters.find((a) => (a as { type?: string }).type === adapterType)
-            if (adapterProps) {
-              const adapter = await adapterService.createAdapter(adapterProps, conversationDoc)
-              conversationDoc.adapters.push(adapter)
-            }
-          }
+        for (const adapter of adapters) {
+          adapter.config = { ...adapter.config, ...configUpdates }
+          adapter.markModified('config')
+          await adapter.save()
         }
       }
     }
@@ -514,11 +492,16 @@ const updateConversation = async (conversationBody, user) => {
     }
 
     /* Keep topic membership in sync on both sides. Without this, the old topic's
-       conversations list would still include this event after it's been reassigned. */
+       conversations list would still include this event after it's been reassigned.
+       oldTopic is undefined for a conversation that never had one, e.g. an invite-created
+       draft with no matching Topic at creation time (see emailSetup.service's resolveTopic),
+       so there is nothing to pull it from in that case. */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const oldTopic = conversationDoc.topic as any
     if (oldTopic?._id?.toString() !== topicId) {
-      await Topic.findByIdAndUpdate(oldTopic._id, { $pull: { conversations: conversationDoc._id } })
+      if (oldTopic?._id) {
+        await Topic.findByIdAndUpdate(oldTopic._id, { $pull: { conversations: conversationDoc._id } })
+      }
       newTopic.conversations.push(conversationDoc.toObject())
       await newTopic.save()
     }
@@ -588,6 +571,32 @@ const updateConversation = async (conversationBody, user) => {
     )
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     conversationDoc!.resources = reconciled as any
+  }
+
+  /* Whatever changed above (a property, the topic, ...) may have made an adapter that was
+     deferred at creation time (see createConversation's satisfiesTypeProperties guard) safe to
+     create now. This runs on every update, not just ones that flip overall draft status: an
+     adapter only depends on conversation properties, never on topic or scheduledEndTime, so it
+     can become ready well before the conversation as a whole is no longer Draft. The existence
+     check makes this a no-op on every update that doesn't need it. */
+  const conversationType = conversationDoc!.conversationType ? getConversationType(conversationDoc!.conversationType) : null
+  if (conversationType && satisfiesTypeProperties(conversationDoc!)) {
+    const resolved = resolveConversationType(
+      {
+        platforms: conversationDoc!.platforms,
+        properties: conversationDoc!.properties,
+        features: incomingFeatures ?? conversationDoc!.features
+      },
+      conversationType
+    )
+    for (const adapterProps of resolved.adapters) {
+      const adapterType = (adapterProps as { type?: string }).type
+      const exists = await Adapter.findOne({ conversation: conversationDoc!._id, type: adapterType })
+      if (!exists) {
+        const adapter = await adapterService.createAdapter(adapterProps, conversationDoc!)
+        conversationDoc!.adapters.push(adapter)
+      }
+    }
   }
 
   conversationDoc!.draft = isConversationDraft(conversationDoc!)

--- a/src/services/conversation.service/lifecycle.ts
+++ b/src/services/conversation.service/lifecycle.ts
@@ -79,7 +79,7 @@ export interface DraftStatusInput {
  * definition, so this stays correct as types change rather than naming any property here.
  * The same format validators back resolver.validateProperties, so the two paths agree.
  */
-function satisfiesTypeProperties(conversation: DraftStatusInput): boolean {
+export function satisfiesTypeProperties(conversation: DraftStatusInput): boolean {
   const type = conversation.conversationType ? getConversationType(conversation.conversationType) : undefined
   const propertyDefs = type?.properties ?? []
   return propertyDefs.every((property) => {

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -130,9 +130,11 @@ const sendEventCreatedEmail = async (to, conversation) => {
   const subject = 'Your event is ready on Nextspace'
   const eventUrl = `${config.appHost}/login?redirectTo=/admin/${conversation.conversationType}/view/${conversation._id}`
   const text = `Hello,
-We turned your calendar invite into a Nextspace event. To review and finish setting it up, copy and paste this link in your browser: ${eventUrl}`
+We turned your calendar invite into a Nextspace event. Please confirm the event details are correct: ${eventUrl}
+That page is also where you can edit any details and find the moderator and participant links to share.`
   const html = `<p>Hello,</p>
-<p>We turned your calendar invite into a Nextspace event. To review and finish setting it up, please <a href="${eventUrl}">click here</a>.</p>`
+<p>We turned your calendar invite into a Nextspace event. Please <a href="${eventUrl}">confirm the event details are correct</a>.</p>
+<p>That page is also where you can edit any details and find the moderator and participant links to share.</p>`
   await sendEmailAsync(to, subject, text, html)
 }
 

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -121,25 +121,25 @@ To finish setting up your event, sign up here and then resend the invite: ${sign
 }
 
 /**
- * Notify an organizer that their inbound calendar invite became a Nextspace event.
+ * Notify an organizer that their inbound calendar invite became an event.
  * @param {string} to
  * @param {Conversation} conversation
  * @returns {Promise}
  */
 const sendEventCreatedEmail = async (to, conversation) => {
-  const subject = 'Your event is ready on Nextspace'
+  const subject = 'Your event is ready'
   const eventUrl = `${config.appHost}/login?redirectTo=/admin/${conversation.conversationType}/view/${conversation._id}`
   const text = `Hello,
-We turned your calendar invite into a Nextspace event. Please confirm the event details are correct: ${eventUrl}
+We turned your calendar invite into an event. Please confirm the event details are correct: ${eventUrl}
 That page is also where you can edit any details and find the moderator and participant links to share.`
   const html = `<p>Hello,</p>
-<p>We turned your calendar invite into a Nextspace event. Please <a href="${eventUrl}">confirm the event details are correct</a>.</p>
+<p>We turned your calendar invite into an event. Please <a href="${eventUrl}">confirm the event details are correct</a>.</p>
 <p>That page is also where you can edit any details and find the moderator and participant links to share.</p>`
   await sendEmailAsync(to, subject, text, html)
 }
 
 /**
- * Notify an organizer that we couldn't turn their inbound calendar invite into a Nextspace event.
+ * Notify an organizer that we couldn't turn their inbound calendar invite into an event.
  * Deliberately excludes any error detail: the inbound address accepts mail from anyone, so the
  * reply body is not a safe place for stack traces or other internals. The full error goes to the
  * server log instead, keyed by the same referenceId so a report from the organizer is easy to

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -120,6 +120,43 @@ To finish setting up your event, sign up here and then resend the invite: ${sign
   await sendEmailAsync(to, subject, text, html)
 }
 
+/**
+ * Notify an organizer that their inbound calendar invite became a Nextspace event.
+ * @param {string} to
+ * @param {Conversation} conversation
+ * @returns {Promise}
+ */
+const sendEventCreatedEmail = async (to, conversation) => {
+  const subject = 'Your event is ready on Nextspace'
+  const eventUrl = `${config.appHost}/login?redirectTo=/admin/${conversation.conversationType}/view/${conversation._id}`
+  const text = `Hello,
+We turned your calendar invite into a Nextspace event. To review and finish setting it up, copy and paste this link in your browser: ${eventUrl}`
+  const html = `<p>Hello,</p>
+<p>We turned your calendar invite into a Nextspace event. To review and finish setting it up, please <a href="${eventUrl}">click here</a>.</p>`
+  await sendEmailAsync(to, subject, text, html)
+}
+
+/**
+ * Notify an organizer that we couldn't turn their inbound calendar invite into a Nextspace event.
+ * Deliberately excludes any error detail: the inbound address accepts mail from anyone, so the
+ * reply body is not a safe place for stack traces or other internals. The full error goes to the
+ * server log instead, keyed by the same referenceId so a report from the organizer is easy to
+ * trace back.
+ * @param {string} to
+ * @param {string} [referenceId]
+ * @returns {Promise}
+ */
+const sendEventCreationFailedEmail = async (to, referenceId?: string) => {
+  const subject = "We couldn't create your event"
+  const referenceLine = referenceId ? `\nReference: ${referenceId}` : ''
+  const referenceHtml = referenceId ? `<p>Reference: ${referenceId}</p>` : ''
+  const text = `Hello,
+We received your calendar invite, but ran into a problem creating your event. Please try again, or reach out to support if this keeps happening.${referenceLine}`
+  const html = `<p>Hello,</p>
+<p>We received your calendar invite, but ran into a problem creating your event. Please try again, or reach out to support if this keeps happening.</p>${referenceHtml}`
+  await sendEmailAsync(to, subject, text, html)
+}
+
 const emailService = {
   transport,
   sendEmail,
@@ -127,6 +164,8 @@ const emailService = {
   sendPasswordResetEmail,
   sendPasswordResetEmailAsync,
   sendArchiveTopicEmail,
-  sendSignupInviteEmail
+  sendSignupInviteEmail,
+  sendEventCreatedEmail,
+  sendEventCreationFailedEmail
 }
 export default emailService

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -121,14 +121,33 @@ To finish setting up your event, sign up here and then resend the invite: ${sign
 }
 
 /**
- * Notify an organizer that their inbound calendar invite became an event.
+ * Notify an organizer that their inbound calendar invite became an event. When `missing` names
+ * anything (e.g. a Zoom link, a series), the event was created as a draft that can't actually run
+ * yet: the subject calls that out directly rather than saying "ready" and burying the caveat,
+ * since a reviewer flagged that an organizer skimming "Your event is ready" could miss a required
+ * follow-up until it's too late to fix before the event starts.
  * @param {string} to
  * @param {Conversation} conversation
+ * @param {string[]} [missing]
  * @returns {Promise}
  */
-const sendEventCreatedEmail = async (to, conversation) => {
-  const subject = 'Your event is ready'
+const sendEventCreatedEmail = async (to, conversation, missing: string[] = []) => {
   const eventUrl = `${config.appHost}/login?redirectTo=/admin/${conversation.conversationType}/view/${conversation._id}`
+
+  if (missing.length > 0) {
+    const subject = 'Action needed: your event is missing required details'
+    const missingList = missing.join(', ')
+    const text = `Hello,
+We turned your calendar invite into an event, but it still needs ${missingList} before it can run. Please add that here: ${eventUrl}
+That page is also where you can edit any other details and find the moderator and participant links to share.`
+    const html = `<p>Hello,</p>
+<p>We turned your calendar invite into an event, but it still needs <strong>${missingList}</strong> before it can run. Please <a href="${eventUrl}">add that here</a>.</p>
+<p>That page is also where you can edit any other details and find the moderator and participant links to share.</p>`
+    await sendEmailAsync(to, subject, text, html)
+    return
+  }
+
+  const subject = 'Your event is ready'
   const text = `Hello,
 We turned your calendar invite into an event. Please confirm the event details are correct: ${eventUrl}
 That page is also where you can edit any details and find the moderator and participant links to share.`

--- a/src/services/eventSetup/emailSetup.service.ts
+++ b/src/services/eventSetup/emailSetup.service.ts
@@ -128,6 +128,27 @@ const defaultFeatures = (conversationType: ConversationType) =>
   (conversationType.features ?? []).map((feature) => ({ name: feature.name, enabled: feature.default }))
 
 /**
+ * Human-readable names of what's stopping this conversation from running as a scheduled event, or
+ * [] when nothing is. Mirrors lifecycle.ts's isConversationDraft/satisfiesTypeProperties rules but
+ * names each missing piece instead of collapsing them into a boolean, so the confirmation email
+ * can call them out directly rather than an organizer discovering it only once the event doesn't
+ * start.
+ */
+const missingRequirements = (
+  conversation: { topic?: unknown; properties?: Record<string, unknown> },
+  conversationType?: ConversationType
+): string[] => {
+  const missing: string[] = []
+  if (!conversation.topic) missing.push('a series')
+  ;(conversationType?.properties ?? []).forEach((property) => {
+    if (!property.required) return
+    const value = conversation.properties?.[property.name] ?? property.default
+    if (value === undefined || value === null || value === '') missing.push(property.label ?? property.name)
+  })
+  return missing
+}
+
+/**
  * Ties organizer resolution, Topic resolution, and the fuzzy-field extraction together into an
  * actual Conversation. Idempotent: an inbound email webhook can redeliver the same message
  * (Postmark, for example, retries up to 10 times over ~10.5 hours), so a retry must not create a
@@ -189,7 +210,11 @@ export const createConversationFromInvite = async (inboundInvite: InboundInvite)
       { allowDraft: true }
     )
 
-    await emailService.sendEventCreatedEmail(organizer.email, conversation)
+    await emailService.sendEventCreatedEmail(
+      organizer.email,
+      conversation,
+      missingRequirements(conversation, conversationType)
+    )
     return conversation
   } catch (err) {
     /* handlers/email.ts acknowledges the webhook with a 200 before any of this runs, so there is no

--- a/src/services/eventSetup/emailSetup.service.ts
+++ b/src/services/eventSetup/emailSetup.service.ts
@@ -6,12 +6,15 @@
  */
 import config from '../../config/config.js'
 import logger from '../../config/logger.js'
-import { Topic } from '../../models/index.js'
+import { Conversation, Topic } from '../../models/index.js'
 import { TopicDocument } from '../../models/topic.model.js'
 import userService from '../user.service.js'
 import topicService from '../topic.service.js'
 import emailService from '../email.service.js'
-import { InboundInvite } from '../../types/index.types.js'
+import conversationService from '../conversation.service/index.js'
+import plannerService from './planner.service.js'
+import { getConversationType } from '../../conversations/index.js'
+import { ConversationType, InboundInvite } from '../../types/index.types.js'
 
 /**
  * The Topic prefix an invite's SUMMARY points at: the substring before the first colon, trimmed.
@@ -107,4 +110,76 @@ export const resolveTopic = async (inboundInvite: InboundInvite, organizer): Pro
   if (!matched?.id) return null
 
   return Topic.findById(matched.id)
+}
+
+/* A .ics file without a title is a malformed edge case, not something worth rejecting the whole
+   invite over: the plan's own design is "best-effort data plus sane placeholders," and a
+   conversation the organizer can rename from the detail page beats none at all. */
+const PLACEHOLDER_CONVERSATION_NAME = 'Untitled event'
+
+/**
+ * Each of the type's features, enabled or disabled exactly as its own definition defaults it
+ * (e.g. moderatorSupport on, seriesHistory off). Leaving `features` unset resolves to zero
+ * feature agents rather than "apply each default" (see resolver.ts's resolveFeatures), so an
+ * invite-created event has to send this explicitly to end up with the same feature agents a
+ * manually-created event gets from the create form.
+ */
+const defaultFeatures = (conversationType: ConversationType) =>
+  (conversationType.features ?? []).map((feature) => ({ name: feature.name, enabled: feature.default }))
+
+/**
+ * Ties organizer resolution, Topic resolution, and the fuzzy-field extraction together into an
+ * actual Conversation. Idempotent: Postmark can redeliver the same message (up to 10 retries over
+ * ~10.5 hours), so a retry must not create a second conversation. Dedup keys off the invite's
+ * .ics UID, stored on the Conversation as sourceInviteUid, which only a trusted allowDraft caller
+ * can ever set (see conversation.service/index.ts createConversation) so a public API client
+ * cannot squat on a UID and cause a future legitimate invite to silently no-op.
+ *
+ * Returns the created (or already-existing) Conversation, or null when none should be created at
+ * all, i.e. resolveOrganizer rejected the sender.
+ */
+export const createConversationFromInvite = async (inboundInvite: InboundInvite) => {
+  const { invite } = inboundInvite
+
+  if (invite.uid) {
+    const existing = await Conversation.findOne({ sourceInviteUid: invite.uid })
+    if (existing) {
+      logger.info(`Email webhook: invite UID ${invite.uid} already created as conversation ${existing._id}, skipping`)
+      return existing
+    }
+  } else {
+    logger.warn('Email webhook: invite has no UID; cannot dedup a Postmark retry for this message')
+  }
+
+  const organizer = await resolveOrganizer(inboundInvite)
+  if (!organizer) return null
+
+  const topic = await resolveTopic(inboundInvite, organizer)
+  const extracted = await plannerService.planConversationFromInvite({ invite })
+
+  const conversationType = getConversationType('eventAssistant')
+
+  return conversationService.createConversationFromType(
+    {
+      type: 'eventAssistant',
+      name: invite.summary ?? PLACEHOLDER_CONVERSATION_NAME,
+      topicId: topic?.id,
+      sourceInviteUid: invite.uid,
+      platforms: ['nextspace'],
+      scheduledTime: invite.startDate,
+      scheduledEndTime: invite.endDate,
+      description: extracted.description,
+      properties: {
+        // Present-but-undefined would still satisfy the type's "required property" presence
+        // check (see resolver.ts's `prop.name in properties`), so the key must be fully absent
+        // rather than set to undefined when there is no Zoom link.
+        ...(extracted.zoomLink !== undefined && { zoomMeetingUrl: extracted.zoomLink })
+      },
+      features: conversationType ? defaultFeatures(conversationType) : undefined,
+      presenters: extracted.speakers,
+      moderators: extracted.moderators
+    },
+    organizer,
+    { allowDraft: true }
+  )
 }

--- a/src/services/eventSetup/emailSetup.service.ts
+++ b/src/services/eventSetup/emailSetup.service.ts
@@ -61,7 +61,7 @@ const isAllowedOrganizerDomain = (address: string): boolean => {
 }
 
 /**
- * Find the account that owns this invite, keying off the envelope From that Postmark
+ * Find the account that owns this invite, keying off the envelope From that the email webhook
  * received (never the spoofable .ics ORGANIZER). Returns the organizer, or null when no event should
  * be created. The allowlisted domain is a hard gate checked first: any sender outside it is rejected
  * outright, account or not, with no reply (confirming the address "just needs to sign up" would be a
@@ -129,9 +129,10 @@ const defaultFeatures = (conversationType: ConversationType) =>
 
 /**
  * Ties organizer resolution, Topic resolution, and the fuzzy-field extraction together into an
- * actual Conversation. Idempotent: Postmark can redeliver the same message (up to 10 retries over
- * ~10.5 hours), so a retry must not create a second conversation. Dedup keys off the invite's
- * .ics UID, stored on the Conversation as sourceInviteUid, which only a trusted allowDraft caller
+ * actual Conversation. Idempotent: an inbound email webhook can redeliver the same message
+ * (Postmark, for example, retries up to 10 times over ~10.5 hours), so a retry must not create a
+ * second conversation. Dedup keys off the invite's
+ * .ics UID, stored on the Conversation as source.inviteUid, which only a trusted allowDraft caller
  * can ever set (see conversation.service/index.ts createConversation) so a public API client
  * cannot squat on a UID and cause a future legitimate invite to silently no-op.
  *
@@ -142,13 +143,13 @@ export const createConversationFromInvite = async (inboundInvite: InboundInvite)
   const { invite } = inboundInvite
 
   if (invite.uid) {
-    const existing = await Conversation.findOne({ sourceInviteUid: invite.uid })
+    const existing = await Conversation.findOne({ 'source.inviteUid': invite.uid })
     if (existing) {
       logger.info(`Email webhook: invite UID ${invite.uid} already created as conversation ${existing._id}, skipping`)
       return existing
     }
   } else {
-    logger.warn('Email webhook: invite has no UID; cannot dedup a Postmark retry for this message')
+    logger.warn('Email webhook: invite has no UID; cannot dedup a webhook retry for this message')
   }
 
   const organizer = await resolveOrganizer(inboundInvite)
@@ -165,8 +166,12 @@ export const createConversationFromInvite = async (inboundInvite: InboundInvite)
         type: 'eventAssistant',
         name: invite.summary ?? PLACEHOLDER_CONVERSATION_NAME,
         topicId: topic?.id,
-        sourceInviteUid: invite.uid,
-        platforms: ['nextspace'],
+        source: { inviteUid: invite.uid },
+        // An invite-created event is always managed through the admin app, so it's a hybrid
+        // event by definition. 'nextspace' alone matches no key in eventAssistant's adapter
+        // defs and silently falls back to 'default' (audio-only, no dmChannels/chatChannels);
+        // this matches the 'nextspace,zoom' hybrid def instead.
+        platforms: ['nextspace', 'zoom'],
         scheduledTime: invite.startDate,
         scheduledEndTime: invite.endDate,
         description: extracted.description,
@@ -187,7 +192,7 @@ export const createConversationFromInvite = async (inboundInvite: InboundInvite)
     await emailService.sendEventCreatedEmail(organizer.email, conversation)
     return conversation
   } catch (err) {
-    /* handlers/email.ts acknowledges Postmark with a 200 before any of this runs, so there is no
+    /* handlers/email.ts acknowledges the webhook with a 200 before any of this runs, so there is no
        retry to fall back on: this email is the only way the organizer learns something went wrong.
        The error itself stays server-side (see email.service.ts's sendEventCreationFailedEmail),
        since the inbound address accepts mail from anyone and the reply body is not a safe place

--- a/src/services/eventSetup/emailSetup.service.ts
+++ b/src/services/eventSetup/emailSetup.service.ts
@@ -154,32 +154,46 @@ export const createConversationFromInvite = async (inboundInvite: InboundInvite)
   const organizer = await resolveOrganizer(inboundInvite)
   if (!organizer) return null
 
-  const topic = await resolveTopic(inboundInvite, organizer)
-  const extracted = await plannerService.planConversationFromInvite({ invite })
+  try {
+    const topic = await resolveTopic(inboundInvite, organizer)
+    const extracted = await plannerService.planConversationFromInvite({ invite })
 
-  const conversationType = getConversationType('eventAssistant')
+    const conversationType = getConversationType('eventAssistant')
 
-  return conversationService.createConversationFromType(
-    {
-      type: 'eventAssistant',
-      name: invite.summary ?? PLACEHOLDER_CONVERSATION_NAME,
-      topicId: topic?.id,
-      sourceInviteUid: invite.uid,
-      platforms: ['nextspace'],
-      scheduledTime: invite.startDate,
-      scheduledEndTime: invite.endDate,
-      description: extracted.description,
-      properties: {
-        // Present-but-undefined would still satisfy the type's "required property" presence
-        // check (see resolver.ts's `prop.name in properties`), so the key must be fully absent
-        // rather than set to undefined when there is no Zoom link.
-        ...(extracted.zoomLink !== undefined && { zoomMeetingUrl: extracted.zoomLink })
+    const conversation = await conversationService.createConversationFromType(
+      {
+        type: 'eventAssistant',
+        name: invite.summary ?? PLACEHOLDER_CONVERSATION_NAME,
+        topicId: topic?.id,
+        sourceInviteUid: invite.uid,
+        platforms: ['nextspace'],
+        scheduledTime: invite.startDate,
+        scheduledEndTime: invite.endDate,
+        description: extracted.description,
+        properties: {
+          // Present-but-undefined would still satisfy the type's "required property" presence
+          // check (see resolver.ts's `prop.name in properties`), so the key must be fully absent
+          // rather than set to undefined when there is no Zoom link.
+          ...(extracted.zoomLink !== undefined && { zoomMeetingUrl: extracted.zoomLink })
+        },
+        features: conversationType ? defaultFeatures(conversationType) : undefined,
+        presenters: extracted.speakers,
+        moderators: extracted.moderators
       },
-      features: conversationType ? defaultFeatures(conversationType) : undefined,
-      presenters: extracted.speakers,
-      moderators: extracted.moderators
-    },
-    organizer,
-    { allowDraft: true }
-  )
+      organizer,
+      { allowDraft: true }
+    )
+
+    await emailService.sendEventCreatedEmail(organizer.email, conversation)
+    return conversation
+  } catch (err) {
+    /* handlers/email.ts acknowledges Postmark with a 200 before any of this runs, so there is no
+       retry to fall back on: this email is the only way the organizer learns something went wrong.
+       The error itself stays server-side (see email.service.ts's sendEventCreationFailedEmail),
+       since the inbound address accepts mail from anyone and the reply body is not a safe place
+       for a stack trace. */
+    logger.error(`Email webhook: failed to create conversation from invite UID ${invite.uid ?? 'none'}`, err)
+    await emailService.sendEventCreationFailedEmail(organizer.email, invite.uid)
+    return null
+  }
 }

--- a/src/services/eventSetup/planner.service.ts
+++ b/src/services/eventSetup/planner.service.ts
@@ -32,7 +32,7 @@ import { EventSetupPlan, EventSetupPlanSchema } from './planSchema.js'
 import { ExtractedFields, ExtractedFieldsSchema } from './eventFieldsSchema.js'
 import { ParsedInvite } from '../../types/index.types.js'
 
-const SYSTEM_PROMPT = `You help an organizer set up an event in Nextspace. The organizer has written a free-form description of what they already know about the event in a web form. Your job is to (a) extract any structured fields you can, (b) judge whether the description is too vague to interpret confidently, (c) recommend the next steps for the rest of the form, (d) decide which form sections can be skipped entirely, and (e) recommend feature toggles.
+const SYSTEM_PROMPT = `You help an organizer set up an event. The organizer has written a free-form description of what they already know about the event in a web form. Your job is to (a) extract any structured fields you can, (b) judge whether the description is too vague to interpret confidently, (c) recommend the next steps for the rest of the form, (d) decide which form sections can be skipped entirely, and (e) recommend feature toggles.
 
 Today's date (for resolving relative dates like "tomorrow"): {today}
 

--- a/src/services/eventSetup/planner.service.ts
+++ b/src/services/eventSetup/planner.service.ts
@@ -158,7 +158,7 @@ Invite body: {description}
 
 Invite location: {location}`
 
-export interface PlanEventFromInviteInput {
+export interface PlanConversationFromInviteInput {
   invite: ParsedInvite
 }
 
@@ -177,7 +177,7 @@ const pickInviteExtractedFields = ({ zoomLink, speakers, moderators, description
   ...(description !== undefined && { description })
 })
 
-export const planEventFromInvite = async ({ invite }: PlanEventFromInviteInput): Promise<ExtractedFields> => {
+export const planConversationFromInvite = async ({ invite }: PlanConversationFromInviteInput): Promise<ExtractedFields> => {
   const llm = await getModelChat(config.classificationLLMPlatform, config.classificationLLMModel)
   try {
     const result = (await getChatPromptResponse(
@@ -194,9 +194,9 @@ export const planEventFromInvite = async ({ invite }: PlanEventFromInviteInput):
     )) as ExtractedFields
     return result ? pickInviteExtractedFields(result) : fallbackExtractedFields()
   } catch (err) {
-    logger.error(`eventSetup planEventFromInvite failed: ${(err as Error).message}`)
+    logger.error(`eventSetup planConversationFromInvite failed: ${(err as Error).message}`)
     return fallbackExtractedFields()
   }
 }
 
-export default { planEventSetup, planEventFromInvite }
+export default { planEventSetup, planConversationFromInvite }

--- a/src/services/eventSetup/planner.service.ts
+++ b/src/services/eventSetup/planner.service.ts
@@ -29,6 +29,8 @@ import { getModelChat } from '../../agents/helpers/getModelChat.js'
 import config from '../../config/config.js'
 import logger from '../../config/logger.js'
 import { EventSetupPlan, EventSetupPlanSchema } from './planSchema.js'
+import { ExtractedFields, ExtractedFieldsSchema } from './eventFieldsSchema.js'
+import { ParsedInvite } from '../../types/index.types.js'
 
 const SYSTEM_PROMPT = `You help an organizer set up an event in Nextspace. The organizer has written a free-form description of what they already know about the event in a web form. Your job is to (a) extract any structured fields you can, (b) judge whether the description is too vague to interpret confidently, (c) recommend the next steps for the rest of the form, (d) decide which form sections can be skipped entirely, and (e) recommend feature toggles.
 
@@ -96,10 +98,7 @@ const fallbackPlan = (): EventSetupPlan => ({
   featureDecisions: []
 })
 
-export const planEventSetup = async ({
-  description,
-  today = new Date()
-}: PlanEventSetupInput): Promise<EventSetupPlan> => {
+export const planEventSetup = async ({ description, today = new Date() }: PlanEventSetupInput): Promise<EventSetupPlan> => {
   const llm = await getModelChat(config.classificationLLMPlatform, config.classificationLLMModel)
   try {
     const result = (await getChatPromptResponse(
@@ -120,4 +119,84 @@ export const planEventSetup = async ({
   }
 }
 
-export default { planEventSetup }
+/*
+ * The LLM extraction that runs on an inbound calendar invite (see the plan's email-to-events
+ * "One LLM extraction call, not per-field regex"). Unlike planEventSetup above, this only fills in
+ * the fields the .ics file's own structured data cannot answer: a Zoom link (other video platforms
+ * are ignored), speakers, moderators, and description. Everything else about the event, name, time,
+ * and Topic, is already resolved deterministically elsewhere (see emailSetup.service.ts), so this
+ * never asks the model to guess dateTime, duration, topicName, timeZone, or eventName, and strips
+ * them if it answers anyway.
+ */
+
+const INVITE_SYSTEM_PROMPT = `You are a data extraction engine. Parse the three input fields below — **title**, **body**, and **location** — pulled directly from an inbound \`.ics\` calendar file, and return structured event metadata.
+
+**Extract exactly these four fields and no others:** \`zoomLink\`, \`speakers\`, \`moderators\`, \`description\`. Do not populate any other fields. The event's date, time, and topic are already resolved from the \`.ics\` structured fields and must not be derived from this text.
+
+---
+
+**Extraction rules:**
+
+- **\`zoomLink\`** — A Zoom URL only, if present in the location or body. Ignore all other video platforms. Leave undefined if absent.
+
+- **\`speakers\`** and **\`moderators\`** — Each is an array of objects with the shape \`{{ name, bio, alternateName? }}\`.
+  - Include an entry for every person mentioned by name, even if no bio is given — set \`bio\` to an empty string in that case.
+  - Default any unlabeled person to \`speakers\`. Only place a person in \`moderators\` if the text explicitly identifies them using the word "moderator" or "host."
+  - Set \`alternateName\` only when the text provides an explicit alias using language like "also goes by," "aka," or "nickname." Do not infer aliases.
+
+- **\`description\`** — A short summary of what the event is about, drawn from the body text. Leave undefined unless the body contains at least 2–3 sentences of substantive topical content. Do not populate it based solely on logistics such as Zoom links, dial-in numbers, or boilerplate.
+
+- Do not guess or invent any value. If a field is not clearly supported by the text, leave it undefined.
+
+---
+
+Return **only** valid JSON matching the response schema. No explanation, no commentary, no wrapper text.`
+
+const INVITE_USER_PROMPT = `Invite title: {summary}
+
+Invite body: {description}
+
+Invite location: {location}`
+
+export interface PlanEventFromInviteInput {
+  invite: ParsedInvite
+}
+
+/* A failed extraction should not block event creation: the deterministic fields (name, time,
+   Topic) already came from the .ics file, so the worst case here is a draft missing the Zoom
+   link, speakers, or description for the organizer to fill in themselves. */
+const fallbackExtractedFields = (): ExtractedFields => ({})
+
+/* Keep only the fields this flow actually asked for, even if the model answers with more. See
+   the module comment above for why dateTime/duration/topicName/timeZone/eventName must not
+   leak through here regardless of what the model returns. */
+const pickInviteExtractedFields = ({ zoomLink, speakers, moderators, description }: ExtractedFields): ExtractedFields => ({
+  ...(zoomLink !== undefined && { zoomLink }),
+  ...(speakers !== undefined && { speakers }),
+  ...(moderators !== undefined && { moderators }),
+  ...(description !== undefined && { description })
+})
+
+export const planEventFromInvite = async ({ invite }: PlanEventFromInviteInput): Promise<ExtractedFields> => {
+  const llm = await getModelChat(config.classificationLLMPlatform, config.classificationLLMModel)
+  try {
+    const result = (await getChatPromptResponse(
+      llm,
+      INVITE_SYSTEM_PROMPT,
+      INVITE_USER_PROMPT,
+      {
+        summary: invite.summary ?? '(none)',
+        description: invite.description ?? '(none)',
+        location: invite.location ?? '(none)'
+      },
+      [],
+      ExtractedFieldsSchema
+    )) as ExtractedFields
+    return result ? pickInviteExtractedFields(result) : fallbackExtractedFields()
+  } catch (err) {
+    logger.error(`eventSetup planEventFromInvite failed: ${(err as Error).message}`)
+    return fallbackExtractedFields()
+  }
+}
+
+export default { planEventSetup, planEventFromInvite }

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -463,12 +463,13 @@ export interface IConversation {
   enableAgents?: boolean
   owner: IUser
   topic: ITopic
-  // How this conversation was created, when not the standard event-creation form. Unset for
-  // every conversation not created by the email webhook.
+  // How this conversation was created, when not the standard event-creation form. Deliberately
+  // open-ended (mirrors the model's Mixed type) so a future creation path can store whatever
+  // shape it needs; inviteUid is the one shape in use today.
+  // The .ics UID of the inbound invite is stored at source.inviteUid; used to detect a webhook
+  // retry of the same invite before creating a duplicate (see emailSetup.service.ts).
   source?: {
-    // The .ics UID of the inbound invite; used to detect a webhook retry of the same invite
-    // before creating a duplicate (see emailSetup.service.ts).
-    inviteUid?: string
+    [key: string]: unknown
   }
   transcript?: ITranscript
   followed?: boolean

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -462,6 +462,10 @@ export interface IConversation {
   enableAgents?: boolean
   owner: IUser
   topic: ITopic
+  // The .ics UID of the inbound invite this conversation was created from. Unset for every
+  // conversation not created by the email webhook; used to detect a Postmark retry of the same
+  // invite before creating a duplicate (see emailSetup.service.ts).
+  sourceInviteUid?: string
   transcript?: ITranscript
   followed?: boolean
   resources: Resource[]

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -16,8 +16,9 @@ export interface ParsedInvite {
 }
 
 /* The trust boundary in one shape: `invite` is attacker-supplied .ics file content (anyone can put
-   any UID or ORGANIZER in a raw .ics), while `fromAddress` is the envelope From that Postmark actually
-   received. Identity resolution keys off fromAddress; ORGANIZER is only ever compared against it. */
+   any UID or ORGANIZER in a raw .ics), while `fromAddress` is the envelope From that the email
+   webhook actually received. Identity resolution keys off fromAddress; ORGANIZER is only ever
+   compared against it. */
 export interface InboundInvite {
   fromAddress: string
   invite: ParsedInvite
@@ -462,10 +463,13 @@ export interface IConversation {
   enableAgents?: boolean
   owner: IUser
   topic: ITopic
-  // The .ics UID of the inbound invite this conversation was created from. Unset for every
-  // conversation not created by the email webhook; used to detect a Postmark retry of the same
-  // invite before creating a duplicate (see emailSetup.service.ts).
-  sourceInviteUid?: string
+  // How this conversation was created, when not the standard event-creation form. Unset for
+  // every conversation not created by the email webhook.
+  source?: {
+    // The .ics UID of the inbound invite; used to detect a webhook retry of the same invite
+    // before creating a duplicate (see emailSetup.service.ts).
+    inviteUid?: string
+  }
   transcript?: ITranscript
   followed?: boolean
   resources: Resource[]

--- a/tests/handlers/email.handler.test.ts
+++ b/tests/handlers/email.handler.test.ts
@@ -16,7 +16,7 @@ import { parseInviteFromPayload } from '../../src/handlers/email.js'
 
 setupIntTest()
 
-const webhookUser = 'postmark-webhook'
+const webhookUser = 'email-webhook'
 const webhookSecret = 'test-webhook-secret'
 
 /**
@@ -62,8 +62,8 @@ const buildIcs = (
   return lines.join('\r\n')
 }
 
-/** Wrap an .ics body in a Postmark inbound webhook payload as its base64 .ics attachment. */
-const buildPostmarkPayload = (icsBody: string, attachmentOverrides = {}) => ({
+/** Wrap an .ics body in an inbound email webhook payload (Postmark's shape) as its base64 .ics attachment. */
+const buildInboundEmailPayload = (icsBody: string, attachmentOverrides = {}) => ({
   FromName: 'Jane Organizer',
   From: 'jane@example.com',
   Subject: 'Quarterly Strategy Roundtable',
@@ -86,15 +86,15 @@ describe('POST /v1/webhooks/email', () => {
   let originalSecret
 
   beforeAll(() => {
-    originalUser = config.postmark.authUser
-    originalSecret = config.postmark.authSecret
-    config.postmark.authUser = webhookUser
-    config.postmark.authSecret = webhookSecret
+    originalUser = config.emailWebhook.authUser
+    originalSecret = config.emailWebhook.authSecret
+    config.emailWebhook.authUser = webhookUser
+    config.emailWebhook.authSecret = webhookSecret
   })
 
   afterAll(() => {
-    config.postmark.authUser = originalUser
-    config.postmark.authSecret = originalSecret
+    config.emailWebhook.authUser = originalUser
+    config.emailWebhook.authSecret = originalSecret
   })
 
   describe('Basic Auth', () => {
@@ -102,19 +102,22 @@ describe('POST /v1/webhooks/email', () => {
       await request(app)
         .post('/v1/webhooks/email')
         .auth(webhookUser, webhookSecret)
-        .send(buildPostmarkPayload(buildIcs()))
+        .send(buildInboundEmailPayload(buildIcs()))
         .expect(httpStatus.OK)
     })
 
     test('rejects a request with no Authorization header before parsing', async () => {
-      await request(app).post('/v1/webhooks/email').send(buildPostmarkPayload(buildIcs())).expect(httpStatus.UNAUTHORIZED)
+      await request(app)
+        .post('/v1/webhooks/email')
+        .send(buildInboundEmailPayload(buildIcs()))
+        .expect(httpStatus.UNAUTHORIZED)
     })
 
     test('rejects a request with the wrong password', async () => {
       await request(app)
         .post('/v1/webhooks/email')
         .auth(webhookUser, 'wrong-secret')
-        .send(buildPostmarkPayload(buildIcs()))
+        .send(buildInboundEmailPayload(buildIcs()))
         .expect(httpStatus.UNAUTHORIZED)
     })
 
@@ -122,12 +125,12 @@ describe('POST /v1/webhooks/email', () => {
       await request(app)
         .post('/v1/webhooks/email')
         .auth('impostor', webhookSecret)
-        .send(buildPostmarkPayload(buildIcs()))
+        .send(buildInboundEmailPayload(buildIcs()))
         .expect(httpStatus.UNAUTHORIZED)
     })
 
     test('responds 200 even when the message carries no calendar attachment', async () => {
-      const payload = buildPostmarkPayload(buildIcs())
+      const payload = buildInboundEmailPayload(buildIcs())
       payload.Attachments = []
       await request(app).post('/v1/webhooks/email').auth(webhookUser, webhookSecret).send(payload).expect(httpStatus.OK)
     })
@@ -145,7 +148,7 @@ describe('POST /v1/webhooks/email', () => {
       await request(app)
         .post('/v1/webhooks/email')
         .auth(webhookUser, webhookSecret)
-        .send(buildPostmarkPayload(buildIcs()))
+        .send(buildInboundEmailPayload(buildIcs()))
         .expect(httpStatus.OK)
 
       const logged = infoSpy.mock.calls.map(([message]) => String(message)).join('\n')
@@ -156,7 +159,7 @@ describe('POST /v1/webhooks/email', () => {
 
   describe('parseInviteFromPayload', () => {
     test('extracts the calendar fields from the base64-encoded .ics attachment', () => {
-      const invite = parseInviteFromPayload(buildPostmarkPayload(buildIcs()))
+      const invite = parseInviteFromPayload(buildInboundEmailPayload(buildIcs()))
 
       expect(invite).not.toBeNull()
       expect(invite?.uid).toBe('040000008200E00074C5B7101A82E00800000000ABCDEF01')
@@ -203,14 +206,14 @@ describe('POST /v1/webhooks/email', () => {
         'END:VCALENDAR'
       ].join('\r\n')
 
-      const invite = parseInviteFromPayload(buildPostmarkPayload(ics))
+      const invite = parseInviteFromPayload(buildInboundEmailPayload(ics))
 
       expect(invite?.startDate?.toISOString()).toBe('2026-09-01T17:00:00.000Z')
       expect(invite?.endDate?.toISOString()).toBe('2026-09-01T18:00:00.000Z')
     })
 
     test('identifies the .ics attachment by filename when the content type is generic', () => {
-      const payload = buildPostmarkPayload(buildIcs(), {
+      const payload = buildInboundEmailPayload(buildIcs(), {
         Name: 'meeting.ics',
         ContentType: 'application/octet-stream'
       })
@@ -221,7 +224,7 @@ describe('POST /v1/webhooks/email', () => {
     })
 
     test('returns null when there is no calendar attachment', () => {
-      const payload = buildPostmarkPayload(buildIcs())
+      const payload = buildInboundEmailPayload(buildIcs())
       payload.Attachments = [
         {
           Name: 'photo.png',
@@ -282,7 +285,7 @@ describe('POST /v1/webhooks/email', () => {
       await request(app)
         .post('/v1/webhooks/email')
         .auth(webhookUser, webhookSecret)
-        .send(buildPostmarkPayload(buildIcs()))
+        .send(buildInboundEmailPayload(buildIcs()))
         .expect(httpStatus.OK)
 
       /* The response comes back before background processing finishes (see handlers/email.ts's
@@ -296,7 +299,7 @@ describe('POST /v1/webhooks/email', () => {
       })
 
       const conversation = await Conversation.findOne({
-        sourceInviteUid: '040000008200E00074C5B7101A82E00800000000ABCDEF01'
+        'source.inviteUid': '040000008200E00074C5B7101A82E00800000000ABCDEF01'
       })
       expect(conversation).not.toBeNull()
       expect(conversation!.name).toBe('Quarterly Strategy Roundtable')
@@ -304,7 +307,7 @@ describe('POST /v1/webhooks/email', () => {
 
     test('creates nothing when the sender is outside the allowlisted domain', async () => {
       const warnSpy = jest.spyOn(logger, 'warn').mockReturnValue(logger)
-      const payload = buildPostmarkPayload(buildIcs())
+      const payload = buildInboundEmailPayload(buildIcs())
       payload.From = 'stranger@not-an-org.invalid'
 
       await request(app).post('/v1/webhooks/email').auth(webhookUser, webhookSecret).send(payload).expect(httpStatus.OK)

--- a/tests/handlers/email.handler.test.ts
+++ b/tests/handlers/email.handler.test.ts
@@ -1,9 +1,17 @@
+import { jest } from '@jest/globals'
 import httpStatus from 'http-status'
 import request from 'supertest'
 import app from '../../src/app.js'
 import config from '../../src/config/config.js'
 import logger from '../../src/config/logger.js'
 import setupIntTest from '../utils/setupIntTest.js'
+import waitFor from '../utils/waitFor.js'
+import { insertUsers } from '../fixtures/user.fixture.js'
+import { Conversation } from '../../src/models/index.js'
+import websocketGateway from '../../src/websockets/websocketGateway.js'
+import transcript from '../../src/agents/helpers/transcript.js'
+import plannerService from '../../src/services/eventSetup/planner.service.js'
+import emailService from '../../src/services/email.service.js'
 import { parseInviteFromPayload } from '../../src/handlers/email.js'
 
 setupIntTest()
@@ -230,5 +238,84 @@ describe('POST /v1/webhooks/email', () => {
     test('returns null when the attachments array is missing', () => {
       expect(parseInviteFromPayload({ From: 'jane@example.com' })).toBeNull()
     })
+  })
+
+  describe('createConversationFromInvite wiring', () => {
+    let originalDomains
+
+    beforeAll(() => {
+      originalDomains = config.allowedOrganizerEmailDomains
+      config.allowedOrganizerEmailDomains = ['example.com']
+    })
+
+    afterAll(() => {
+      config.allowedOrganizerEmailDomains = originalDomains
+    })
+
+    let sendEventCreatedSpy
+
+    beforeEach(() => {
+      jest.spyOn(websocketGateway, 'broadcastNewConversation').mockResolvedValue(undefined as never)
+      jest.spyOn(transcript, 'loadTopicMetadataIntoVectorStore').mockResolvedValue(undefined as never)
+      jest.spyOn(transcript, 'loadEventMetadataIntoVectorStore').mockResolvedValue(undefined as never)
+      // The extraction call is unit-tested on its own (planner.service.test.ts); mocked here so
+      // this plumbing test isn't also exercising (or paying for) a real LLM call.
+      jest.spyOn(plannerService, 'planConversationFromInvite').mockResolvedValue({})
+      sendEventCreatedSpy = jest.spyOn(emailService, 'sendEventCreatedEmail').mockResolvedValue(undefined as never)
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    test('creates a draft conversation from a valid inbound invite', async () => {
+      await insertUsers([
+        {
+          username: 'jane',
+          email: 'jane@example.com',
+          password: 'password1',
+          role: 'user',
+          isEmailVerified: false
+        }
+      ])
+
+      await request(app)
+        .post('/v1/webhooks/email')
+        .auth(webhookUser, webhookSecret)
+        .send(buildPostmarkPayload(buildIcs()))
+        .expect(httpStatus.OK)
+
+      /* The response comes back before background processing finishes (see handlers/email.ts's
+           ack-before-processing comment), so poll for the confirmation email rather than the
+           Conversation document: that's the signal createConversationFromInvite is fully done
+           (channels, agents, and scheduling all settled), not just that the doc first appeared.
+           Racing ahead on the doc alone left background work from this test still running when
+           the next test's setupIntTest() beforeEach wiped the database out from under it. */
+      await waitFor(() => {
+        if (sendEventCreatedSpy.mock.calls.length === 0) throw new Error('not finished yet')
+      })
+
+      const conversation = await Conversation.findOne({
+        sourceInviteUid: '040000008200E00074C5B7101A82E00800000000ABCDEF01'
+      })
+      expect(conversation).not.toBeNull()
+      expect(conversation!.name).toBe('Quarterly Strategy Roundtable')
+    }, 10000)
+
+    test('creates nothing when the sender is outside the allowlisted domain', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockReturnValue(logger)
+      const payload = buildPostmarkPayload(buildIcs())
+      payload.From = 'stranger@not-an-org.invalid'
+
+      await request(app).post('/v1/webhooks/email').auth(webhookUser, webhookSecret).send(payload).expect(httpStatus.OK)
+
+      // Poll for the rejection log rather than sleeping a fixed amount: it's the observable proof
+      // that the background handling (parsing, then resolveOrganizer's domain check) has run.
+      await waitFor(() => {
+        const rejected = warnSpy.mock.calls.some(([msg]) => String(msg).includes('stranger@not-an-org.invalid'))
+        if (!rejected) throw new Error('rejection warning not logged yet')
+      })
+      expect(await Conversation.countDocuments()).toBe(0)
+    }, 10000)
   })
 })

--- a/tests/integration/docs.test.ts
+++ b/tests/integration/docs.test.ts
@@ -2,16 +2,16 @@ import request from 'supertest'
 import httpStatus from 'http-status'
 import setupIntTest from '../utils/setupIntTest.js'
 import app from '../../src/app.js'
-import config from '../../src/config/config.js'
 
 setupIntTest()
 
 describe('Auth routes', () => {
   describe('GET /v1/docs', () => {
-    test('should return 404 when running in production', async () => {
-      config.env = 'production'
-      await request(app).get('/v1/docs').expect(httpStatus.NOT_FOUND)
-      config.env = process.env.NODE_ENV
+    // The docs route used to be mounted only when config.env === 'development'; it's now
+    // unconditional (see src/routes/v1/index.ts), so this just confirms it's reachable.
+    test('is reachable', async () => {
+      const res = await request(app).get('/v1/docs')
+      expect(res.status).not.toBe(httpStatus.NOT_FOUND)
     })
   })
 })

--- a/tests/models/conversation.model.test.ts
+++ b/tests/models/conversation.model.test.ts
@@ -48,30 +48,30 @@ describe('conversation draft default', () => {
   })
 })
 
-describe('conversation sourceInviteUid', () => {
+describe('conversation source.inviteUid', () => {
   it('persists the .ics UID for a conversation created from an inbound invite', async () => {
     const conversation = await Conversation.create({
       ...baseConversation(),
-      sourceInviteUid: 'UID-ABC-123'
+      source: { inviteUid: 'UID-ABC-123' }
     })
 
     const reloaded = await Conversation.findById(conversation._id)
 
-    expect(reloaded!.sourceInviteUid).toBe('UID-ABC-123')
+    expect(reloaded!.source?.inviteUid).toBe('UID-ABC-123')
   })
 
-  it('leaves sourceInviteUid undefined for a conversation not created from an invite', async () => {
+  it('leaves source.inviteUid undefined for a conversation not created from an invite', async () => {
     const conversation = await Conversation.create(baseConversation())
 
     const reloaded = await Conversation.findById(conversation._id)
 
-    expect(reloaded!.sourceInviteUid).toBeUndefined()
+    expect(reloaded!.source?.inviteUid).toBeUndefined()
   })
 
   /* The field is intentionally non-unique: most conversations have no invite UID at all, and a
      unique index would treat every one of those missing values as a colliding duplicate. Dedup
-     against Postmark retries happens in createConversationFromInvite, not via a DB constraint. */
-  it('allows multiple conversations with no sourceInviteUid to coexist', async () => {
+     against webhook retries happens in createConversationFromInvite, not via a DB constraint. */
+  it('allows multiple conversations with no source.inviteUid to coexist', async () => {
     await Conversation.create(baseConversation())
     await expect(Conversation.create(baseConversation())).resolves.toBeTruthy()
   })

--- a/tests/models/conversation.model.test.ts
+++ b/tests/models/conversation.model.test.ts
@@ -47,3 +47,32 @@ describe('conversation draft default', () => {
     expect(reloaded!.draft).toBe(true)
   })
 })
+
+describe('conversation sourceInviteUid', () => {
+  it('persists the .ics UID for a conversation created from an inbound invite', async () => {
+    const conversation = await Conversation.create({
+      ...baseConversation(),
+      sourceInviteUid: 'UID-ABC-123'
+    })
+
+    const reloaded = await Conversation.findById(conversation._id)
+
+    expect(reloaded!.sourceInviteUid).toBe('UID-ABC-123')
+  })
+
+  it('leaves sourceInviteUid undefined for a conversation not created from an invite', async () => {
+    const conversation = await Conversation.create(baseConversation())
+
+    const reloaded = await Conversation.findById(conversation._id)
+
+    expect(reloaded!.sourceInviteUid).toBeUndefined()
+  })
+
+  /* The field is intentionally non-unique: most conversations have no invite UID at all, and a
+     unique index would treat every one of those missing values as a colliding duplicate. Dedup
+     against Postmark retries happens in createEventFromInvite, not via a DB constraint. */
+  it('allows multiple conversations with no sourceInviteUid to coexist', async () => {
+    await Conversation.create(baseConversation())
+    await expect(Conversation.create(baseConversation())).resolves.toBeTruthy()
+  })
+})

--- a/tests/models/conversation.model.test.ts
+++ b/tests/models/conversation.model.test.ts
@@ -70,7 +70,7 @@ describe('conversation sourceInviteUid', () => {
 
   /* The field is intentionally non-unique: most conversations have no invite UID at all, and a
      unique index would treat every one of those missing values as a colliding duplicate. Dedup
-     against Postmark retries happens in createEventFromInvite, not via a DB constraint. */
+     against Postmark retries happens in createConversationFromInvite, not via a DB constraint. */
   it('allows multiple conversations with no sourceInviteUid to coexist', async () => {
     await Conversation.create(baseConversation())
     await expect(Conversation.create(baseConversation())).resolves.toBeTruthy()

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -811,6 +811,66 @@ describe('Conversation service methods', () => {
         expect(adapters[0].type).toBe('zoom')
         expect(adapters[0].config.meetingUrl).toBe('https://zoom.us/j/555555555')
       })
+
+      /* isConversationDraft treats a missing topic as its own independent draft gate, separate
+         from the required-property check (see lifecycle.ts's isConversationDraft: a scheduled
+         conversation with no topic returns true regardless of satisfiesTypeProperties). An
+         adapter's config is rendered only from properties (resolver.ts's resolvePropertyReferences
+         never receives topic), so a missing topic has nothing to do with whether the adapter is
+         safe to create: it's created immediately since zoomMeetingUrl is already valid. Filling in
+         the topic afterward only clears the topic-specific draft gate; it doesn't touch the adapter,
+         which already existed. */
+      test('the adapter exists at creation time even with no topic, and filling in the topic only clears draft status', async () => {
+        jest.spyOn(websocketGateway, 'broadcastConversationUpdate').mockImplementation()
+        const conversation = await conversationService.createConversationFromType(
+          { ...completeParamsNoTopic },
+          registeredUser,
+          { allowDraft: true }
+        )
+        expect(conversation.draft).toBe(true)
+        const adaptersAtCreation = await Adapter.find({ conversation: conversation._id })
+        expect(adaptersAtCreation).toHaveLength(1)
+        expect(adaptersAtCreation[0].type).toBe('zoom')
+        expect(adaptersAtCreation[0].config.meetingUrl).toBe('https://zoom.us/j/123456789?pwd=12345')
+
+        const updated = await conversationService.updateConversation(
+          { id: conversation._id.toString(), topicId: topicOne._id.toString() },
+          registeredUser
+        )
+
+        expect(updated!.draft).toBe(false)
+        expect(await Adapter.countDocuments({ conversation: conversation._id })).toBe(1)
+      })
+
+      /* An adapter's config is rendered only from conversation properties (see resolver.ts's
+         resolvePropertyReferences, which never receives topic or scheduledEndTime), so whether
+         it's safe to create should depend only on those properties being valid, not on the
+         conversation's overall draft status. draft also covers things with nothing to do with
+         adapter config, like a missing topic or a missing scheduledEndTime (see lifecycle.ts's
+         isConversationDraft). A conversation that's draft only because scheduledEndTime hasn't
+         been picked yet, with an otherwise fully valid zoomMeetingUrl, should still get its Zoom
+         adapter created immediately: nothing about that adapter is actually incomplete. */
+      test('creates the adapter at creation time when properties are valid but the conversation is still Draft for an unrelated reason', async () => {
+        const params = {
+          type: 'eventAssistant',
+          name: 'No End Time Event',
+          platforms: ['zoom'],
+          topicId: topicOne._id.toString(),
+          scheduledTime: new Date(Date.now() + 3600000),
+          // scheduledEndTime intentionally omitted: draft for a reason unrelated to the adapter.
+          properties: {
+            zoomMeetingUrl: 'https://zoom.us/j/123456789?pwd=12345'
+          }
+        }
+
+        const conversation = await conversationService.createConversationFromType(params, registeredUser)
+
+        expect(conversation.draft).toBe(true)
+        const adapters = await Adapter.find({ conversation: conversation._id })
+        expect(adapters).toHaveLength(1)
+        expect(adapters[0].type).toBe('zoom')
+        expect(adapters[0].config.meetingUrl).toBe('https://zoom.us/j/123456789?pwd=12345')
+      })
     })
 
     describe('feature agent inclusion and property resolution', () => {

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -1656,6 +1656,15 @@ describe('Conversation service methods', () => {
       ).rejects.toMatchObject({ statusCode: httpStatus.FORBIDDEN })
     })
 
+    test('allows an admin to update an event they do not own', async () => {
+      const adminUser = { _id: new mongoose.Types.ObjectId(), role: 'admin' }
+      const updated = await conversationService.updateConversation(
+        { id: conversation._id.toString(), name: 'Updated By Admin' },
+        adminUser
+      )
+      expect(updated!.name).toBe('Updated By Admin')
+    })
+
     test('should reject updates to an event that is currently live', async () => {
       await conversation.updateOne({ active: true })
       await expect(

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -2057,6 +2057,30 @@ describe('Conversation service methods', () => {
       expect(result).toHaveProperty('followed')
     })
 
+    test('should include the topic private flag so clients can tell a private topic apart from a public one', async () => {
+      /* Override owner so registeredUser (the test caller) can create a conversation
+         on this private topic. Private topics only allow their owner to create events. */
+      const privateTopic = { ...newPrivateTopic(), owner: registeredUser._id }
+      await insertTopics([privateTopic])
+
+      const params = {
+        type: 'eventAssistant',
+        name: 'Private Topic Conversation',
+        platforms: ['zoom'],
+        topicId: privateTopic._id.toString(),
+        // Schedule 2 hours out so it doesn't conflict with the beforeEach conversation.
+        scheduledTime: new Date(Date.now() + 7200000),
+        properties: {
+          zoomMeetingUrl: 'https://zoom.us/j/555555556'
+        }
+      }
+      const privateConversation = await conversationService.createConversationFromType(params, registeredUser)
+
+      const result = await conversationService.findByIdFull(privateConversation._id.toString(), registeredUser)
+
+      expect(result.topic).toHaveProperty('private', true)
+    })
+
     test('should hide channel passcode from non-owner user', async () => {
       const nonOwner = {
         _id: new mongoose.Types.ObjectId(),

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -777,6 +777,40 @@ describe('Conversation service methods', () => {
         expect(conversation.draft).toBe(true)
         expect(conversation.topic).toBeFalsy()
       })
+
+      /* Rendering an adapter from a missing required property (e.g. zoomMeetingUrl) produces an
+         empty config value, which the real Zoom adapter's own validation hard-rejects (see
+         zoom.ts's validateBeforeUpdate). allowDraft relaxes the property check, but nothing about
+         it reaches adapter creation, so a draft missing a property an adapter depends on must not
+         attempt to create that adapter at all. */
+      test('creates no adapter when a required property backing it is missing and allowDraft is set', async () => {
+        const params = { ...incompleteParams, topicId: topicOne._id.toString() }
+
+        const conversation = await conversationService.createConversationFromType(params, registeredUser, {
+          allowDraft: true
+        })
+
+        expect(await Adapter.countDocuments({ conversation: conversation._id })).toBe(0)
+      })
+
+      test('creates the adapter once the missing required property is filled in via update', async () => {
+        jest.spyOn(websocketGateway, 'broadcastConversationUpdate').mockImplementation()
+        const params = { ...incompleteParams, topicId: topicOne._id.toString() }
+        const conversation = await conversationService.createConversationFromType(params, registeredUser, {
+          allowDraft: true
+        })
+        expect(await Adapter.countDocuments({ conversation: conversation._id })).toBe(0)
+
+        await conversationService.updateConversation(
+          { id: conversation._id.toString(), properties: { zoomMeetingUrl: 'https://zoom.us/j/555555555' } },
+          registeredUser
+        )
+
+        const adapters = await Adapter.find({ conversation: conversation._id })
+        expect(adapters).toHaveLength(1)
+        expect(adapters[0].type).toBe('zoom')
+        expect(adapters[0].config.meetingUrl).toBe('https://zoom.us/j/555555555')
+      })
     })
 
     describe('feature agent inclusion and property resolution', () => {
@@ -1694,19 +1728,34 @@ describe('Conversation service methods', () => {
     })
 
     test('should recreate the adapter with the correct config when platforms change', async () => {
-      /* The beforeEach conversation uses platforms: ['zoom'], which resolves to the
-         zoom-only adapter config (2 dmChannels: direct agent DM + moderator DM).
-         Switching to nextspace+zoom should produce the 'nextspace,zoom' config
-         (1 dmChannel: direct agent DM only — moderator DMs go through NextSpace). */
-      const adapterBefore = await Adapter.findOne({ conversation: conversation._id, type: 'zoom' })
-      expect(adapterBefore!.dmChannels).toHaveLength(2)
-
-      await conversationService.updateConversation(
-        { id: conversation._id.toString(), platforms: ['nextspace', 'zoom'] },
+      /* Needs its own conversation, not the shared beforeEach one: that one never gets
+         scheduledEndTime, so it's Draft and (correctly) has no adapter yet to recreate. This
+         conversation is complete, so its zoom adapter exists from creation, resolving to the
+         zoom-only config (2 dmChannels: direct agent DM + moderator DM). Switching to
+         nextspace+zoom should produce the 'nextspace,zoom' config (1 dmChannel: direct agent DM
+         only — moderator DMs go through NextSpace). */
+      const completeConversation = await conversationService.createConversationFromType(
+        {
+          type: 'eventAssistant',
+          name: 'Complete Event',
+          platforms: ['zoom'],
+          topicId: topicOne._id.toString(),
+          scheduledTime: new Date(Date.now() + 3600000),
+          scheduledEndTime: new Date(Date.now() + 7200000),
+          properties: { zoomMeetingUrl: 'https://zoom.us/j/222222222' }
+        },
         registeredUser
       )
 
-      const adapterAfter = await Adapter.findOne({ conversation: conversation._id, type: 'zoom' })
+      const adapterBefore = await Adapter.findOne({ conversation: completeConversation._id, type: 'zoom' })
+      expect(adapterBefore!.dmChannels).toHaveLength(2)
+
+      await conversationService.updateConversation(
+        { id: completeConversation._id.toString(), platforms: ['nextspace', 'zoom'] },
+        registeredUser
+      )
+
+      const adapterAfter = await Adapter.findOne({ conversation: completeConversation._id, type: 'zoom' })
       /* After the fix, the adapter should be recreated with the nextspace,zoom config
          (1 dmChannel). Before the fix, the old adapter is not recreated and still has 2. */
       expect(adapterAfter!.dmChannels).toHaveLength(1)

--- a/tests/unit/services/email.service.test.ts
+++ b/tests/unit/services/email.service.test.ts
@@ -83,6 +83,41 @@ describe('email.service', () => {
       const msg = sendMailSpy.mock.calls[0][0]
       expect(msg.html.match(/href="/g)).toHaveLength(1)
     })
+
+    it('uses an action-needed subject and names what is missing, when required fields are absent', async () => {
+      const conversation = { _id: 'conv-123', conversationType: 'eventAssistant' }
+
+      await emailService.sendEventCreatedEmail('organizer@example.com', conversation, ['a Zoom meeting link', 'a series'])
+
+      const msg = sendMailSpy.mock.calls[0][0]
+      expect(msg.subject).toMatch(/action needed/i)
+      expect(msg.subject).not.toBe('Your event is ready')
+      expect(msg.text).toContain('a Zoom meeting link')
+      expect(msg.text).toContain('a series')
+      expect(msg.html).toContain('a Zoom meeting link')
+      expect(msg.html).toContain('a series')
+    })
+
+    it('still links to where the organizer can add the missing details', async () => {
+      const conversation = { _id: 'conv-123', conversationType: 'eventAssistant' }
+
+      await emailService.sendEventCreatedEmail('organizer@example.com', conversation, ['a Zoom meeting link'])
+
+      const msg = sendMailSpy.mock.calls[0][0]
+      const expectedUrl = `${config.appHost}/login?redirectTo=/admin/eventAssistant/view/conv-123`
+      expect(msg.text).toContain(expectedUrl)
+      expect(msg.html).toContain(expectedUrl)
+      expect(msg.html.match(/href="/g)).toHaveLength(1)
+    })
+
+    it('uses the ready-to-run subject when nothing is missing', async () => {
+      const conversation = { _id: 'conv-123', conversationType: 'eventAssistant' }
+
+      await emailService.sendEventCreatedEmail('organizer@example.com', conversation, [])
+
+      const msg = sendMailSpy.mock.calls[0][0]
+      expect(msg.subject).toBe('Your event is ready')
+    })
   })
 
   describe('sendEventCreationFailedEmail', () => {

--- a/tests/unit/services/email.service.test.ts
+++ b/tests/unit/services/email.service.test.ts
@@ -26,4 +26,65 @@ describe('email.service', () => {
       expect(msg.html).toContain(`${config.appHost}/signup`)
     })
   })
+
+  describe('sendEventCreatedEmail', () => {
+    let sendMailSpy
+
+    beforeEach(() => {
+      sendMailSpy = jest.spyOn(emailService.transport, 'sendMail').mockResolvedValue(undefined as never)
+    })
+
+    afterEach(() => {
+      sendMailSpy.mockRestore()
+    })
+
+    it('sends to the given address with a link to the created event', async () => {
+      const conversation = { _id: 'conv-123', conversationType: 'eventAssistant' }
+
+      await emailService.sendEventCreatedEmail('organizer@cyber.harvard.edu', conversation)
+
+      expect(sendMailSpy).toHaveBeenCalledTimes(1)
+      const msg = sendMailSpy.mock.calls[0][0]
+      expect(msg.to).toBe('organizer@cyber.harvard.edu')
+      expect(msg.from).toBe(config.email.from)
+      expect(msg.subject).toEqual(expect.any(String))
+      const expectedUrl = `${config.appHost}/login?redirectTo=/admin/eventAssistant/view/conv-123`
+      expect(msg.text).toContain(expectedUrl)
+      expect(msg.html).toContain(expectedUrl)
+    })
+  })
+
+  describe('sendEventCreationFailedEmail', () => {
+    let sendMailSpy
+
+    beforeEach(() => {
+      sendMailSpy = jest.spyOn(emailService.transport, 'sendMail').mockResolvedValue(undefined as never)
+    })
+
+    afterEach(() => {
+      sendMailSpy.mockRestore()
+    })
+
+    it('sends to the given address and includes the reference ID when one is given', async () => {
+      await emailService.sendEventCreationFailedEmail('organizer@cyber.harvard.edu', 'UID-ABC-123')
+
+      expect(sendMailSpy).toHaveBeenCalledTimes(1)
+      const msg = sendMailSpy.mock.calls[0][0]
+      expect(msg.to).toBe('organizer@cyber.harvard.edu')
+      expect(msg.from).toBe(config.email.from)
+      expect(msg.subject).toEqual(expect.any(String))
+      expect(msg.text).toContain('UID-ABC-123')
+      expect(msg.html).toContain('UID-ABC-123')
+      expect(msg.text).not.toMatch(/at \w+\.\w+ \(/)
+    })
+
+    it('omits the reference line when no reference ID is given', async () => {
+      await emailService.sendEventCreationFailedEmail('organizer@cyber.harvard.edu')
+
+      expect(sendMailSpy).toHaveBeenCalledTimes(1)
+      const msg = sendMailSpy.mock.calls[0][0]
+      expect(msg.text).not.toContain('undefined')
+      expect(msg.html).not.toContain('undefined')
+    })
+  })
 })

--- a/tests/unit/services/email.service.test.ts
+++ b/tests/unit/services/email.service.test.ts
@@ -52,6 +52,37 @@ describe('email.service', () => {
       expect(msg.text).toContain(expectedUrl)
       expect(msg.html).toContain(expectedUrl)
     })
+
+    it('reminds the organizer to confirm the event details', async () => {
+      const conversation = { _id: 'conv-123', conversationType: 'eventAssistant' }
+
+      await emailService.sendEventCreatedEmail('organizer@cyber.harvard.edu', conversation)
+
+      const msg = sendMailSpy.mock.calls[0][0]
+      expect(msg.text).toMatch(/confirm/i)
+      expect(msg.html).toMatch(/confirm/i)
+    })
+
+    it('tells the organizer the link is where to edit details and find moderator and participant links', async () => {
+      const conversation = { _id: 'conv-123', conversationType: 'eventAssistant' }
+
+      await emailService.sendEventCreatedEmail('organizer@cyber.harvard.edu', conversation)
+
+      const msg = sendMailSpy.mock.calls[0][0]
+      expect(msg.text).toMatch(/moderator/i)
+      expect(msg.text).toMatch(/participant/i)
+      expect(msg.html).toMatch(/moderator/i)
+      expect(msg.html).toMatch(/participant/i)
+    })
+
+    it('includes only one link', async () => {
+      const conversation = { _id: 'conv-123', conversationType: 'eventAssistant' }
+
+      await emailService.sendEventCreatedEmail('organizer@cyber.harvard.edu', conversation)
+
+      const msg = sendMailSpy.mock.calls[0][0]
+      expect(msg.html.match(/href="/g)).toHaveLength(1)
+    })
   })
 
   describe('sendEventCreationFailedEmail', () => {

--- a/tests/unit/services/eventSetup/emailSetup.service.test.ts
+++ b/tests/unit/services/eventSetup/emailSetup.service.test.ts
@@ -6,7 +6,7 @@ import logger from '../../../../src/config/logger.js'
 import emailService from '../../../../src/services/email.service.js'
 import transcript from '../../../../src/agents/helpers/transcript.js'
 import websocketGateway from '../../../../src/websockets/websocketGateway.js'
-import { Conversation, Topic } from '../../../../src/models/index.js'
+import { Adapter, Conversation, Topic } from '../../../../src/models/index.js'
 import { insertUsers } from '../../../fixtures/user.fixture.js'
 import plannerService from '../../../../src/services/eventSetup/planner.service.js'
 import conversationService from '../../../../src/services/conversation.service/index.js'
@@ -251,10 +251,27 @@ describe('emailSetup.service', () => {
       expect(conversation!.presenters).toEqual([expect.objectContaining({ name: 'Jane Doe' })])
       expect(conversation!.moderators).toEqual([expect.objectContaining({ name: 'Mod Person' })])
       expect(conversation!.description).toBe('Weekly sync')
-      expect(conversation!.sourceInviteUid).toBe('UID-DEFAULT')
+      expect(conversation!.source?.inviteUid).toBe('UID-DEFAULT')
 
       const persisted = await Conversation.findById(conversation!._id)
       expect(persisted).not.toBeNull()
+    })
+
+    /* An invite-created event is always managed through the admin app, so it's a hybrid event by
+       definition once it also has a Zoom link. platforms: ['nextspace'] alone doesn't match any
+       key in eventAssistant's adapter defs and silently falls back to 'default' (audio-only, no
+       dmChannels or chatChannels); ['nextspace', 'zoom'] matches the 'nextspace,zoom' hybrid def,
+       which does have a dmChannel for the eventAssistant agent. */
+    it('creates the hybrid nextspace + zoom adapter, not the platform-less default fallback', async () => {
+      await insertUsers([newUser(`org@${allowedDomain}`)])
+      planConversationFromInviteSpy.mockResolvedValue({ zoomLink: 'https://zoom.us/j/123456789' })
+
+      const conversation = await createConversationFromInvite(buildInvite({}, `org@${allowedDomain}`))
+
+      expect(conversation!.platforms).toEqual(['nextspace', 'zoom'])
+      const adapter = await Adapter.findOne({ conversation: conversation!._id })
+      expect(adapter).not.toBeNull()
+      expect(adapter!.dmChannels).toHaveLength(1)
     })
 
     /* Leaving features unspecified resolves to an empty array (see resolver.ts's resolveFeatures),
@@ -313,7 +330,7 @@ describe('emailSetup.service', () => {
       const conversation = await createConversationFromInvite(buildInvite({ uid: undefined }, `org@${allowedDomain}`))
 
       expect(conversation).not.toBeNull()
-      expect(conversation!.sourceInviteUid).toBeUndefined()
+      expect(conversation!.source?.inviteUid).toBeUndefined()
       expect(loggerWarnSpy).toHaveBeenCalledWith(expect.stringContaining('no UID'))
     })
 
@@ -350,9 +367,9 @@ describe('emailSetup.service', () => {
       expect(sendEventCreatedSpy).not.toHaveBeenCalled()
     })
 
-    /* There is no retry path available to us here: handlers/email.ts acknowledges Postmark with a
+    /* There is no retry path available to us here: handlers/email.ts acknowledges the webhook with a
        200 before any processing runs (see the plan's ack-before-processing note), so a thrown error
-       here can never surface as a Postmark retry. A best-effort email to the organizer, plus a
+       here can never surface as a webhook retry. A best-effort email to the organizer, plus a
        server-side log carrying the invite UID for support to grep, is the only notification path. */
     it('logs the error and emails the organizer a generic failure notice, without exposing error detail, when creation throws', async () => {
       const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])

--- a/tests/unit/services/eventSetup/emailSetup.service.test.ts
+++ b/tests/unit/services/eventSetup/emailSetup.service.test.ts
@@ -9,6 +9,7 @@ import websocketGateway from '../../../../src/websockets/websocketGateway.js'
 import { Conversation, Topic } from '../../../../src/models/index.js'
 import { insertUsers } from '../../../fixtures/user.fixture.js'
 import plannerService from '../../../../src/services/eventSetup/planner.service.js'
+import conversationService from '../../../../src/services/conversation.service/index.js'
 import {
   resolveOrganizer,
   resolveTopic,
@@ -61,17 +62,25 @@ const insertTopic = (fields: Partial<{ name: string; owner: mongoose.Types.Objec
 
 describe('emailSetup.service', () => {
   let sendSignupSpy
+  let sendEventCreatedSpy
+  let sendEventCreationFailedSpy
   let loggerWarnSpy
+  let loggerErrorSpy
   let planConversationFromInviteSpy
 
   beforeEach(() => {
     jest.spyOn(emailService.transport, 'sendMail').mockResolvedValue(undefined as never)
     sendSignupSpy = jest.spyOn(emailService, 'sendSignupInviteEmail').mockResolvedValue(undefined as never)
+    sendEventCreatedSpy = jest.spyOn(emailService, 'sendEventCreatedEmail').mockResolvedValue(undefined as never)
+    sendEventCreationFailedSpy = jest
+      .spyOn(emailService, 'sendEventCreationFailedEmail')
+      .mockResolvedValue(undefined as never)
     jest.spyOn(transcript, 'loadTopicMetadataIntoVectorStore').mockResolvedValue(undefined as never)
     jest.spyOn(transcript, 'loadEventMetadataIntoVectorStore').mockResolvedValue(undefined as never)
     jest.spyOn(websocketGateway, 'broadcastNewConversation').mockResolvedValue(undefined as never)
     loggerWarnSpy = jest.spyOn(logger, 'warn').mockReturnValue(undefined as never)
     jest.spyOn(logger, 'info').mockReturnValue(undefined as never)
+    loggerErrorSpy = jest.spyOn(logger, 'error').mockReturnValue(undefined as never)
     // The extraction call is unit-tested on its own (planner.service.test.ts); here it is mocked
     // so createConversationFromInvite tests aren't also exercising (or paying for) a real LLM call.
     planConversationFromInviteSpy = jest.spyOn(plannerService, 'planConversationFromInvite').mockResolvedValue({})
@@ -315,6 +324,48 @@ describe('emailSetup.service', () => {
 
       expect(conversation).not.toBeNull()
       expect(conversation!.name).toBe('Untitled event')
+    })
+
+    it('emails the organizer a link to the new event once creation succeeds', async () => {
+      const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])
+
+      const conversation = await createConversationFromInvite(buildInvite({}, `org@${allowedDomain}`))
+
+      expect(sendEventCreatedSpy).toHaveBeenCalledWith(organizer.email, expect.objectContaining({ _id: conversation!._id }))
+    })
+
+    it('sends no confirmation email on a deduped retry, only on the original creation', async () => {
+      await insertUsers([newUser(`org@${allowedDomain}`)])
+      const invite = buildInvite({ uid: 'UID-RETRY-EMAIL' }, `org@${allowedDomain}`)
+
+      await createConversationFromInvite(invite)
+      await createConversationFromInvite(invite)
+
+      expect(sendEventCreatedSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('sends no confirmation email when the sender cannot be resolved to an organizer', async () => {
+      await createConversationFromInvite(buildInvite({}, `stranger@${OUTSIDE_DOMAIN}`))
+
+      expect(sendEventCreatedSpy).not.toHaveBeenCalled()
+    })
+
+    /* There is no retry path available to us here: handlers/email.ts acknowledges Postmark with a
+       200 before any processing runs (see the plan's ack-before-processing note), so a thrown error
+       here can never surface as a Postmark retry. A best-effort email to the organizer, plus a
+       server-side log carrying the invite UID for support to grep, is the only notification path. */
+    it('logs the error and emails the organizer a generic failure notice, without exposing error detail, when creation throws', async () => {
+      const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])
+      const thrown = new Error('boom: adapter validation failed')
+      jest.spyOn(conversationService, 'createConversationFromType').mockRejectedValueOnce(thrown)
+
+      const conversation = await createConversationFromInvite(buildInvite({ uid: 'UID-FAILURE' }, `org@${allowedDomain}`))
+
+      expect(conversation).toBeNull()
+      expect(await Conversation.countDocuments()).toBe(0)
+      expect(loggerErrorSpy).toHaveBeenCalledWith(expect.stringContaining('UID-FAILURE'), thrown)
+      expect(sendEventCreationFailedSpy).toHaveBeenCalledWith(organizer.email, 'UID-FAILURE')
+      expect(sendEventCreatedSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/services/eventSetup/emailSetup.service.test.ts
+++ b/tests/unit/services/eventSetup/emailSetup.service.test.ts
@@ -5,9 +5,15 @@ import config from '../../../../src/config/config.js'
 import logger from '../../../../src/config/logger.js'
 import emailService from '../../../../src/services/email.service.js'
 import transcript from '../../../../src/agents/helpers/transcript.js'
-import { Topic } from '../../../../src/models/index.js'
+import websocketGateway from '../../../../src/websockets/websocketGateway.js'
+import { Conversation, Topic } from '../../../../src/models/index.js'
 import { insertUsers } from '../../../fixtures/user.fixture.js'
-import { resolveOrganizer, resolveTopic } from '../../../../src/services/eventSetup/emailSetup.service.js'
+import plannerService from '../../../../src/services/eventSetup/planner.service.js'
+import {
+  resolveOrganizer,
+  resolveTopic,
+  createConversationFromInvite
+} from '../../../../src/services/eventSetup/emailSetup.service.js'
 import { InboundInvite } from '../../../../src/types/index.types.js'
 
 setupIntTest()
@@ -17,6 +23,9 @@ const allowedDomain = 'example.edu'
 config.allowedOrganizerEmailDomains = [allowedDomain]
 const OUTSIDE_DOMAIN = 'not-an-org.invalid'
 
+// DTSTART is mandatory in a well-formed .ics VEVENT (RFC 5545), so a real inbound invite always
+// has a start date; these defaults keep that realistic instead of exercising the no-scheduledTime
+// instant-start path, which createConversationFromInvite never actually takes.
 const buildInvite = (
   overrides: Partial<InboundInvite['invite']> = {},
   fromAddress = `organizer@${allowedDomain}`
@@ -25,6 +34,8 @@ const buildInvite = (
   invite: {
     uid: 'UID-DEFAULT',
     summary: 'Some Event: additional info',
+    startDate: new Date('2026-08-01T17:00:00Z'),
+    endDate: new Date('2026-08-01T18:00:00Z'),
     ...overrides
   }
 })
@@ -38,16 +49,32 @@ const newUser = (email: string) => ({
   isEmailVerified: false
 })
 
+const insertTopic = (fields: Partial<{ name: string; owner: mongoose.Types.ObjectId; private: boolean }> = {}) =>
+  Topic.create({
+    name: 'placeholder',
+    votingAllowed: false,
+    conversationCreationAllowed: true,
+    private: false,
+    archivable: true,
+    ...fields
+  })
+
 describe('emailSetup.service', () => {
   let sendSignupSpy
   let loggerWarnSpy
+  let planConversationFromInviteSpy
 
   beforeEach(() => {
     jest.spyOn(emailService.transport, 'sendMail').mockResolvedValue(undefined as never)
     sendSignupSpy = jest.spyOn(emailService, 'sendSignupInviteEmail').mockResolvedValue(undefined as never)
     jest.spyOn(transcript, 'loadTopicMetadataIntoVectorStore').mockResolvedValue(undefined as never)
+    jest.spyOn(transcript, 'loadEventMetadataIntoVectorStore').mockResolvedValue(undefined as never)
+    jest.spyOn(websocketGateway, 'broadcastNewConversation').mockResolvedValue(undefined as never)
     loggerWarnSpy = jest.spyOn(logger, 'warn').mockReturnValue(undefined as never)
     jest.spyOn(logger, 'info').mockReturnValue(undefined as never)
+    // The extraction call is unit-tested on its own (planner.service.test.ts); here it is mocked
+    // so createConversationFromInvite tests aren't also exercising (or paying for) a real LLM call.
+    planConversationFromInviteSpy = jest.spyOn(plannerService, 'planConversationFromInvite').mockResolvedValue({})
   })
 
   afterEach(() => {
@@ -125,16 +152,6 @@ describe('emailSetup.service', () => {
   })
 
   describe('resolveTopic', () => {
-    const insertTopic = (fields) =>
-      Topic.create({
-        name: 'placeholder',
-        votingAllowed: false,
-        conversationCreationAllowed: true,
-        private: false,
-        archivable: true,
-        ...fields
-      })
-
     it('matches a public Topic by exact prefix regardless of who owns it', async () => {
       const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])
       const [other] = await insertUsers([newUser(`other@${allowedDomain}`)])
@@ -188,6 +205,116 @@ describe('emailSetup.service', () => {
       await resolveTopic(buildInvite({ summary: 'Nothing Matches: here' }), organizer)
 
       expect(await Topic.countDocuments()).toBe(0)
+    })
+  })
+
+  describe('createConversationFromInvite', () => {
+    it('creates a draft conversation wiring in the organizer, topic, and extracted fields', async () => {
+      const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])
+      const topicDoc = await insertTopic({ name: 'BKCircle', owner: organizer._id, private: false })
+      planConversationFromInviteSpy.mockResolvedValue({
+        zoomLink: 'https://zoom.us/j/123456789',
+        speakers: [{ name: 'Jane Doe', bio: '' }],
+        moderators: [{ name: 'Mod Person', bio: '' }],
+        description: 'Weekly sync'
+      })
+
+      const conversation = await createConversationFromInvite(
+        buildInvite(
+          {
+            summary: 'BKCircle: Jane Presents',
+            startDate: new Date('2026-08-01T17:00:00Z'),
+            endDate: new Date('2026-08-01T18:00:00Z')
+          },
+          `org@${allowedDomain}`
+        )
+      )
+
+      expect(conversation).not.toBeNull()
+      expect(conversation!.name).toBe('BKCircle: Jane Presents')
+      // createConversation assigns the fetched Topic document directly (not just its id), so on
+      // this freshly-created, unrefetched conversation .topic is a real Document; .id is the safe
+      // comparison (Mongoose's Document#toString formats the whole document, not a hex string).
+      expect((conversation!.topic as unknown as { id: string }).id).toBe(topicDoc.id)
+      expect(conversation!.scheduledTime).toEqual(new Date('2026-08-01T17:00:00Z'))
+      expect(conversation!.scheduledEndTime).toEqual(new Date('2026-08-01T18:00:00Z'))
+      expect(conversation!.properties!.zoomMeetingUrl).toBe('https://zoom.us/j/123456789')
+      expect(conversation!.presenters).toEqual([expect.objectContaining({ name: 'Jane Doe' })])
+      expect(conversation!.moderators).toEqual([expect.objectContaining({ name: 'Mod Person' })])
+      expect(conversation!.description).toBe('Weekly sync')
+      expect(conversation!.sourceInviteUid).toBe('UID-DEFAULT')
+
+      const persisted = await Conversation.findById(conversation!._id)
+      expect(persisted).not.toBeNull()
+    })
+
+    /* Leaving features unspecified resolves to an empty array (see resolver.ts's resolveFeatures),
+       which means zero feature agents, not "each feature's own default." A manually-created event
+       gets moderatorSupport, qaAssistant, etc. because the create form sends an explicit features
+       array; an invite-created event must build that same array itself or it silently ships with
+       every feature off. */
+    it('enables each feature at its own type-declared default, matching manual event creation', async () => {
+      await insertUsers([newUser(`org@${allowedDomain}`)])
+
+      const conversation = await createConversationFromInvite(buildInvite({}, `org@${allowedDomain}`))
+
+      expect(conversation!.features).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'moderatorSupport', enabled: true }),
+          expect.objectContaining({ name: 'seriesHistory', enabled: false })
+        ])
+      )
+    })
+
+    it('returns null and creates nothing when the sender cannot be resolved to an organizer', async () => {
+      const conversation = await createConversationFromInvite(buildInvite({}, `stranger@${OUTSIDE_DOMAIN}`))
+
+      expect(conversation).toBeNull()
+      expect(await Conversation.countDocuments()).toBe(0)
+      expect(planConversationFromInviteSpy).not.toHaveBeenCalled()
+    })
+
+    it('creates the conversation with a blank topic when nothing matches', async () => {
+      await insertUsers([newUser(`org@${allowedDomain}`)])
+
+      const conversation = await createConversationFromInvite(
+        buildInvite({ summary: 'Nothing Matches: here' }, `org@${allowedDomain}`)
+      )
+
+      expect(conversation).not.toBeNull()
+      expect(conversation!.topic).toBeFalsy()
+    })
+
+    it('returns the existing conversation instead of creating a duplicate when the invite UID was already processed', async () => {
+      await insertUsers([newUser(`org@${allowedDomain}`)])
+      const invite = buildInvite({ uid: 'UID-RETRY' }, `org@${allowedDomain}`)
+
+      const first = await createConversationFromInvite(invite)
+      const second = await createConversationFromInvite(invite)
+
+      expect(second!._id.toString()).toBe(first!._id.toString())
+      expect(await Conversation.countDocuments()).toBe(1)
+      // Proves the dedup check short-circuits before re-running resolution and extraction on a retry.
+      expect(planConversationFromInviteSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('creates the conversation without deduping when the invite has no UID, and logs a warning', async () => {
+      await insertUsers([newUser(`org@${allowedDomain}`)])
+
+      const conversation = await createConversationFromInvite(buildInvite({ uid: undefined }, `org@${allowedDomain}`))
+
+      expect(conversation).not.toBeNull()
+      expect(conversation!.sourceInviteUid).toBeUndefined()
+      expect(loggerWarnSpy).toHaveBeenCalledWith(expect.stringContaining('no UID'))
+    })
+
+    it('falls back to a placeholder name when the invite has no title', async () => {
+      await insertUsers([newUser(`org@${allowedDomain}`)])
+
+      const conversation = await createConversationFromInvite(buildInvite({ summary: undefined }, `org@${allowedDomain}`))
+
+      expect(conversation).not.toBeNull()
+      expect(conversation!.name).toBe('Untitled event')
     })
   })
 })

--- a/tests/unit/services/eventSetup/emailSetup.service.test.ts
+++ b/tests/unit/services/eventSetup/emailSetup.service.test.ts
@@ -348,7 +348,33 @@ describe('emailSetup.service', () => {
 
       const conversation = await createConversationFromInvite(buildInvite({}, `org@${allowedDomain}`))
 
-      expect(sendEventCreatedSpy).toHaveBeenCalledWith(organizer.email, expect.objectContaining({ _id: conversation!._id }))
+      expect(sendEventCreatedSpy).toHaveBeenCalledWith(
+        organizer.email,
+        expect.objectContaining({ _id: conversation!._id }),
+        expect.anything()
+      )
+    })
+
+    it('tells the organizer which required fields are missing, when the invite had no zoom link and matched no series', async () => {
+      const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])
+
+      await createConversationFromInvite(buildInvite({}, `org@${allowedDomain}`))
+
+      expect(sendEventCreatedSpy).toHaveBeenCalledWith(
+        organizer.email,
+        expect.anything(),
+        expect.arrayContaining(['Zoom Meeting URL', 'a series'])
+      )
+    })
+
+    it('reports nothing missing when the invite matched a series and had a zoom link', async () => {
+      const [organizer] = await insertUsers([newUser(`org@${allowedDomain}`)])
+      await insertTopic({ name: 'BKCircle', owner: organizer._id, private: false })
+      planConversationFromInviteSpy.mockResolvedValue({ zoomLink: 'https://zoom.us/j/123456789' })
+
+      await createConversationFromInvite(buildInvite({ summary: 'BKCircle: Jane Presents' }, `org@${allowedDomain}`))
+
+      expect(sendEventCreatedSpy).toHaveBeenCalledWith(organizer.email, expect.anything(), [])
     })
 
     it('sends no confirmation email on a deduped retry, only on the original creation', async () => {

--- a/tests/unit/services/eventSetup/planner.service.test.ts
+++ b/tests/unit/services/eventSetup/planner.service.test.ts
@@ -1,0 +1,161 @@
+import { jest } from '@jest/globals'
+import { ParsedInvite } from '../../../../src/types/index.types.js'
+
+/* The model call is the only external dependency here, so it is the only thing mocked.
+   getModelChat is mocked too, purely so constructing the chat client never needs real
+   credentials; its return value is never inspected since getChatPromptResponse is mocked. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetChatPromptResponse = jest.fn<(...args: any[]) => Promise<any>>()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetModelChat = jest.fn<(...args: any[]) => Promise<any>>()
+
+jest.unstable_mockModule('../src/agents/helpers/llmChain.js', () => ({
+  getChatPromptResponse: mockGetChatPromptResponse
+}))
+jest.unstable_mockModule('../src/agents/helpers/getModelChat.js', () => ({
+  getModelChat: mockGetModelChat
+}))
+
+const { planEventFromInvite } = await import('../../../../src/services/eventSetup/planner.service.js')
+const { ExtractedFieldsSchema } = await import('../../../../src/services/eventSetup/eventFieldsSchema.js')
+const { default: logger } = await import('../../../../src/config/logger.js')
+
+function invite(overrides: Partial<ParsedInvite> = {}): ParsedInvite {
+  return {
+    uid: 'UID-1',
+    summary: 'Team Sync: standup',
+    description: 'Weekly team sync, join via Zoom',
+    location: 'https://zoom.us/j/123456789',
+    ...overrides
+  }
+}
+
+describe('planEventFromInvite', () => {
+  beforeEach(() => {
+    mockGetChatPromptResponse.mockReset()
+    mockGetModelChat.mockReset()
+    mockGetModelChat.mockResolvedValue({ fake: true })
+    jest.spyOn(logger, 'error').mockReturnValue(undefined as never)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('returns the fuzzy fields the model extracted', async () => {
+    mockGetChatPromptResponse.mockResolvedValue({
+      zoomLink: 'https://zoom.us/j/123456789',
+      speakers: [{ name: 'Jane Doe', bio: '' }],
+      description: 'Weekly team sync'
+    })
+
+    const result = await planEventFromInvite({ invite: invite() })
+
+    expect(result).toEqual({
+      zoomLink: 'https://zoom.us/j/123456789',
+      speakers: [{ name: 'Jane Doe', bio: '' }],
+      description: 'Weekly team sync'
+    })
+  })
+
+  /* The prompt restricts zoomLink to Zoom URLs only (see the "Ignore all other video platforms"
+     rule), so a Teams (or other non-Zoom) link is exactly the case where a well-behaved model
+     omits zoomLink. This confirms the pipeline preserves that absence rather than inventing a
+     fallback value; a missing zoomLink is fine downstream since drafts tolerate it (see
+     resolver.ts's allowDraft check and isConversationDraft treating a missing zoomMeetingUrl as
+     draft, not an error). */
+  it('returns no zoomLink when the invite links to a non-Zoom platform like Teams', async () => {
+    mockGetChatPromptResponse.mockResolvedValue({
+      description: 'Weekly team sync'
+    })
+
+    const result = await planEventFromInvite({
+      invite: invite({ location: 'https://teams.microsoft.com/l/meetup-join/abc123' })
+    })
+
+    expect(result.zoomLink).toBeUndefined()
+  })
+
+  it('returns no zoomLink when the invite has no meeting link at all', async () => {
+    mockGetChatPromptResponse.mockResolvedValue({
+      description: 'Weekly team sync'
+    })
+
+    const result = await planEventFromInvite({ invite: invite({ location: undefined }) })
+
+    expect(result.zoomLink).toBeUndefined()
+  })
+
+  it('sends the invite title, body, and location to the model, validated against the shared ExtractedFieldsSchema', async () => {
+    mockGetChatPromptResponse.mockResolvedValue({})
+
+    await planEventFromInvite({
+      invite: invite({ summary: 'BKCircle: Jane Presents', description: 'A talk on AI', location: 'Room 101' })
+    })
+
+    expect(mockGetChatPromptResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.any(String),
+      { summary: 'BKCircle: Jane Presents', description: 'A talk on AI', location: 'Room 101' },
+      [],
+      ExtractedFieldsSchema
+    )
+  })
+
+  it('substitutes a placeholder when the invite has no description or location', async () => {
+    mockGetChatPromptResponse.mockResolvedValue({})
+
+    await planEventFromInvite({ invite: invite({ description: undefined, location: undefined }) })
+
+    expect(mockGetChatPromptResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.any(String),
+      { summary: 'Team Sync: standup', description: '(none)', location: '(none)' },
+      [],
+      ExtractedFieldsSchema
+    )
+  })
+
+  /* Topic matching is deliberately never LLM-driven (see the plan's "Topic matching never uses
+     the LLM"), and dateTime/duration are already known exactly from the .ics DTSTART/DTEND. If the
+     model returns them anyway, despite the prompt telling it not to, they must not leak through:
+     a future caller reading extracted.topicName would silently reintroduce the thing this design
+     avoids. */
+  it('drops dateTime, duration, topicName, eventName, and timeZone even if the model returns them', async () => {
+    mockGetChatPromptResponse.mockResolvedValue({
+      eventName: 'Team Sync',
+      dateTime: '2026-08-01T17:00:00Z',
+      duration: 60,
+      topicName: 'Team Sync',
+      timeZone: 'America/New_York',
+      zoomLink: 'https://zoom.us/j/123456789',
+      description: 'Weekly sync'
+    })
+
+    const result = await planEventFromInvite({ invite: invite() })
+
+    expect(result).toEqual({
+      zoomLink: 'https://zoom.us/j/123456789',
+      description: 'Weekly sync'
+    })
+  })
+
+  it('falls back to an empty result and logs when the model call throws', async () => {
+    mockGetChatPromptResponse.mockRejectedValue(new Error('rate limited'))
+
+    const result = await planEventFromInvite({ invite: invite() })
+
+    expect(result).toEqual({})
+    expect(logger.error).toHaveBeenCalled()
+  })
+
+  it('falls back to an empty result when the model returns nothing', async () => {
+    mockGetChatPromptResponse.mockResolvedValue(undefined)
+
+    const result = await planEventFromInvite({ invite: invite() })
+
+    expect(result).toEqual({})
+  })
+})

--- a/tests/unit/services/eventSetup/planner.service.test.ts
+++ b/tests/unit/services/eventSetup/planner.service.test.ts
@@ -16,7 +16,7 @@ jest.unstable_mockModule('../src/agents/helpers/getModelChat.js', () => ({
   getModelChat: mockGetModelChat
 }))
 
-const { planEventFromInvite } = await import('../../../../src/services/eventSetup/planner.service.js')
+const { planConversationFromInvite } = await import('../../../../src/services/eventSetup/planner.service.js')
 const { ExtractedFieldsSchema } = await import('../../../../src/services/eventSetup/eventFieldsSchema.js')
 const { default: logger } = await import('../../../../src/config/logger.js')
 
@@ -30,7 +30,7 @@ function invite(overrides: Partial<ParsedInvite> = {}): ParsedInvite {
   }
 }
 
-describe('planEventFromInvite', () => {
+describe('planConversationFromInvite', () => {
   beforeEach(() => {
     mockGetChatPromptResponse.mockReset()
     mockGetModelChat.mockReset()
@@ -49,7 +49,7 @@ describe('planEventFromInvite', () => {
       description: 'Weekly team sync'
     })
 
-    const result = await planEventFromInvite({ invite: invite() })
+    const result = await planConversationFromInvite({ invite: invite() })
 
     expect(result).toEqual({
       zoomLink: 'https://zoom.us/j/123456789',
@@ -69,7 +69,7 @@ describe('planEventFromInvite', () => {
       description: 'Weekly team sync'
     })
 
-    const result = await planEventFromInvite({
+    const result = await planConversationFromInvite({
       invite: invite({ location: 'https://teams.microsoft.com/l/meetup-join/abc123' })
     })
 
@@ -81,7 +81,7 @@ describe('planEventFromInvite', () => {
       description: 'Weekly team sync'
     })
 
-    const result = await planEventFromInvite({ invite: invite({ location: undefined }) })
+    const result = await planConversationFromInvite({ invite: invite({ location: undefined }) })
 
     expect(result.zoomLink).toBeUndefined()
   })
@@ -89,7 +89,7 @@ describe('planEventFromInvite', () => {
   it('sends the invite title, body, and location to the model, validated against the shared ExtractedFieldsSchema', async () => {
     mockGetChatPromptResponse.mockResolvedValue({})
 
-    await planEventFromInvite({
+    await planConversationFromInvite({
       invite: invite({ summary: 'BKCircle: Jane Presents', description: 'A talk on AI', location: 'Room 101' })
     })
 
@@ -106,7 +106,7 @@ describe('planEventFromInvite', () => {
   it('substitutes a placeholder when the invite has no description or location', async () => {
     mockGetChatPromptResponse.mockResolvedValue({})
 
-    await planEventFromInvite({ invite: invite({ description: undefined, location: undefined }) })
+    await planConversationFromInvite({ invite: invite({ description: undefined, location: undefined }) })
 
     expect(mockGetChatPromptResponse).toHaveBeenCalledWith(
       expect.anything(),
@@ -134,7 +134,7 @@ describe('planEventFromInvite', () => {
       description: 'Weekly sync'
     })
 
-    const result = await planEventFromInvite({ invite: invite() })
+    const result = await planConversationFromInvite({ invite: invite() })
 
     expect(result).toEqual({
       zoomLink: 'https://zoom.us/j/123456789',
@@ -145,7 +145,7 @@ describe('planEventFromInvite', () => {
   it('falls back to an empty result and logs when the model call throws', async () => {
     mockGetChatPromptResponse.mockRejectedValue(new Error('rate limited'))
 
-    const result = await planEventFromInvite({ invite: invite() })
+    const result = await planConversationFromInvite({ invite: invite() })
 
     expect(result).toEqual({})
     expect(logger.error).toHaveBeenCalled()
@@ -154,7 +154,7 @@ describe('planEventFromInvite', () => {
   it('falls back to an empty result when the model returns nothing', async () => {
     mockGetChatPromptResponse.mockResolvedValue(undefined)
 
-    const result = await planEventFromInvite({ invite: invite() })
+    const result = await planConversationFromInvite({ invite: invite() })
 
     expect(result).toEqual({})
   })


### PR DESCRIPTION
## What is in this PR?

- Forwarded calendar invites now create a draft event automatically, no manual setup needed.
- Matches the invite to an existing Topic by title prefix; unmatched invites still create a topicless draft, and senders without an account get a signup email first.
- LLM extraction fills in Zoom link, speakers, moderators, and description from the invite text; date, time, and title come straight from the .ics file.
- Organizer gets an email once the event's created or failed, linking to the event page to confirm and edit.
- Duplicate deliveries from Postmark retries dedup by the invite's UID.
- Admins can now update any conversation, not just ones they own.

## Changes in the codebase

- Forwarding an invite creates a draft event instead of requiring manual setup.
- Senders outside the allowlisted domain get a signup email instead of a silently dropped invite.
- An adapter (e.g. Zoom) is created as soon as its own settings are valid, not gated on the whole event leaving draft.
- Editing an event's topic or properties backfills any adapter that was deferred at creation.
- The event-created email links to the event's detail page.
- Fixed the Zoom-link uniqueness check incorrectly matching unrelated events for adapter types that don't declare a uniqueness rule.
- Admins can edit any conversation, not just ones they own or whose Topic they own.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

This feature is triggered by an inbound email, not a button in the app, so there's no UI flow to click through to test it. Postmark's inbound webhook is already pointed at production, so sending a real email would land there instead of on your local branch. Test it instead by sending the same request Postmark would send directly to your own local server.

**Setup:**

- In Hoppscotch, open **Collections > Conversations > Event Assistant > "Create conversation via email webhook."**
- Point the request at your local server instead of prod.
- Swap `From`/`ORGANIZER` for an address you actually control before running these: if your local SMTP env vars are configured in .env, these steps really do send email to whatever address you use. See Chelsea for Postmark SMTP details.
- Under the request's Basic Auth, enter your own username and password. These aren't shared credentials, they just need to match `POSTMARK_WEBHOOK_AUTH_USER` and `POSTMARK_WEBHOOK_AUTH_SECRET` in your local `.env`. If you don't have those set yet, add them yourself, any values work as long as the request and your `.env` agree.
- For each scenario below, paste the whole JSON block into the request body and send. It always responds `200 ok` right away (that's intentional, it's how Postmark expects an inbound webhook to behave), the event is created a moment later in the background, so check the app rather than the response body.
- Each scenario below uses its own unique `.ics` UID. Reusing a UID you've already sent will just dedup against the event it already created (see Scenario D), so if you need to rerun a scenario from scratch, edit the UID in its JSON first.

---

### Scenario A: full match, ready to run

```json
{
  "From": "<your_email>",
  "Subject": "AI Policy Series: Governing Frontier Models",
  "Attachments": [{
    "Name": "invite.ics",
    "ContentType": "text/calendar; method=REQUEST",
    "ContentLength": 750,
    "Content": "QkVHSU46VkNBTEVOREFSClZFUlNJT046Mi4wClBST0RJRDotLy9UZXN0Ly9UZXN0IENhbGVuZGFyLy9FTgpCRUdJTjpWRVZFTlQKVUlEOnByMjE5LXNjZW5hcmlvLWFAZXhhbXBsZS5jb20KRFRTVEFNUDoyMDI2MDcyM1QxMjAwMDBaCkRUU1RBUlQ6MjAyNjA3MzBUMTYwMDAwWgpEVEVORDoyMDI2MDczMFQxNzAwMDBaClNVTU1BUlk6QUkgUG9saWN5IFNlcmllczogR292ZXJuaW5nIEZyb250aWVyIE1vZGVscwpMT0NBVElPTjpodHRwczovL3pvb20udXMvai85ODc2NTQzMjEwMT9wd2Q9YWJjWFlaMTIzCk9SR0FOSVpFUjptYWlsdG86b3JnYW5pemVyQGN5YmVyLmhhcnZhcmQuZWR1CkRFU0NSSVBUSU9OOkpvaW4gdXMgZm9yIGEgZGlzY3Vzc2lvbiBvbiBob3cgZ292ZXJubWVudHMgYXJlIGFwcHJvYWNoaW5nIGZyb250aWVyIEFJIHJlZ3VsYXRpb24uIFNwZWFrZXJzOiBEci4gTWFyaWEgQ2hlbiAoYWxzbyBnb2VzIGJ5IE1pYSkgd2lsbCBwcmVzZW50IHJlY2VudCBFVSBBSSBBY3QgZW5mb3JjZW1lbnQgZGF0YVwsIGFuZCBKYW1lcyBPa29ua3dvIHdpbGwgY292ZXIgY29tcGFyYWJsZSBVUyBzdGF0ZS1sZXZlbCBwcm9wb3NhbHMuIFRoaXMgc2Vzc2lvbiB3aWxsIGJlIG1vZGVyYXRlZCBieSBQcml5YSBSYW1hblwsIHdobyB3aWxsIG9wZW4gd2l0aCBmcmFtaW5nIHF1ZXN0aW9ucyBiZWZvcmUgdHVybmluZyBpdCBvdmVyIHRvIHRoZSBmbG9vciBmb3IgYXVkaWVuY2UgUSZBLgpFTkQ6VkVWRU5UCkVORDpWQ0FMRU5EQVIK"
  }]
}
```

**Expected result:** a new event, **not Draft**, assigned to a Topic named `AI Policy Series` (create that Topic first if you don't have one, or you'll land in Scenario C's outcome instead). The Zoom adapter is created immediately, since a valid Zoom link, end time, and Topic are all already present. The organizer receives the event-created email.

- [x] Ran and confirmed

---

### Scenario B: missing the one required property (Zoom link)

```json
{
  "From": "<your_email>",
  "Subject": "AI Policy Series: Data Governance Roundtable",
  "Attachments": [{
    "Name": "invite.ics",
    "ContentType": "text/calendar; method=REQUEST",
    "ContentLength": 490,
    "Content": "QkVHSU46VkNBTEVOREFSClZFUlNJT046Mi4wClBST0RJRDotLy9UZXN0Ly9UZXN0IENhbGVuZGFyLy9FTgpCRUdJTjpWRVZFTlQKVUlEOnByMjE5LXNjZW5hcmlvLWJAZXhhbXBsZS5jb20KRFRTVEFNUDoyMDI2MDcyM1QxMjAwMDBaCkRUU1RBUlQ6MjAyNjA3MzFUMTYwMDAwWgpEVEVORDoyMDI2MDczMVQxNzAwMDBaClNVTU1BUlk6QUkgUG9saWN5IFNlcmllczogRGF0YSBHb3Zlcm5hbmNlIFJvdW5kdGFibGUKTE9DQVRJT046Um9vbSAyMTRcLCBCZXJrbWFuIEtsZWluIENlbnRlcgpPUkdBTklaRVI6bWFpbHRvOm9yZ2FuaXplckBjeWJlci5oYXJ2YXJkLmVkdQpERVNDUklQVElPTjpJbmZvcm1hbCByb3VuZHRhYmxlIG9uIGNyb3NzLWJvcmRlciBkYXRhIGdvdmVybmFuY2UgZnJhbWV3b3Jrcy4gQnJpbmcgeW91ciBxdWVzdGlvbnMuIE5vIHZpZGVvIGxpbmsgeWV0XCwgd2lsbCBmb2xsb3cgdXAgc2VwYXJhdGVseS4KRU5EOlZFVkVOVApFTkQ6VkNBTEVOREFSCg=="
  }]
}
```

**Expected result:** this is the scenario that exercises the core fix in this PR. The event is still assigned to the `AI Policy Series` Topic (the topic gate doesn't care about Zoom), but it comes in **Draft** because `zoomMeetingUrl` is a required property with no value. No Zoom adapter exists yet. The organizer still gets the event-created email even though it's a Draft, that's expected, the email is about giving them a place to finish setup, not a signal that setup is done. Edit the event afterward to add a Zoom link and confirm the adapter gets created then and the event leaves Draft.

- [x] Ran and confirmed

---

### Scenario C: no matching Topic

```json
{
  "From": "<your_email>",
  "Subject": "Quantum Computing 101",
  "Attachments": [{
    "Name": "invite.ics",
    "ContentType": "text/calendar; method=REQUEST",
    "ContentLength": 409,
    "Content": "QkVHSU46VkNBTEVOREFSClZFUlNJT046Mi4wClBST0RJRDotLy9UZXN0Ly9UZXN0IENhbGVuZGFyLy9FTgpCRUdJTjpWRVZFTlQKVUlEOnByMjE5LXNjZW5hcmlvLWNAZXhhbXBsZS5jb20KRFRTVEFNUDoyMDI2MDcyM1QxMjAwMDBaCkRUU1RBUlQ6MjAyNjA4MDFUMTUwMDAwWgpEVEVORDoyMDI2MDgwMVQxNjAwMDBaClNVTU1BUlk6UXVhbnR1bSBDb21wdXRpbmcgMTAxCkxPQ0FUSU9OOmh0dHBzOi8vem9vbS51cy9qLzU1NTY2Njc3Nzg4Ck9SR0FOSVpFUjptYWlsdG86b3JnYW5pemVyQGN5YmVyLmhhcnZhcmQuZWR1CkRFU0NSSVBUSU9OOkludHJvIHNlc3Npb24gb24gcXVhbnR1bSBjb21wdXRpbmcgZnVuZGFtZW50YWxzLiBQcmVzZW50ZWQgYnkgQWxleCBGZXJyZWlyYS4KRU5EOlZFVkVOVApFTkQ6VkNBTEVOREFSCg=="
  }]
}
```

**Expected result:** the title has no `<Topic>:` prefix matching any existing Topic, so the event is created with **no Topic assigned**, and comes in **Draft** for that reason alone (the topic gate is independent of everything else). Since the Zoom link and end time are both valid, the Zoom adapter is still created immediately, this is the other half of the fix: an unrelated missing field (topic) no longer blocks an adapter whose own settings are already fine.

- [x] Ran and confirmed

---

### Scenario D: duplicate delivery

Resend Scenario A's exact JSON body a second time, unchanged.

**Expected result:** no second event is created. Postmark retries the same message on any non-200 response, so this is deliberate, the invite's UID is checked against `sourceInviteUid` before anything else runs. Confirm only one event exists for that UID.

- [x] Ran and confirmed

---

### Scenario E: sender outside the allowlisted domains

```json
{
  "From": "<your_g.harvard_email>",
  "Subject": "AI Policy Series: Outside Sender Test",
  "Attachments": [{
    "Name": "invite.ics",
    "ContentType": "text/calendar; method=REQUEST",
    "ContentLength": 410,
    "Content": "QkVHSU46VkNBTEVOREFSClZFUlNJT046Mi4wClBST0RJRDotLy9UZXN0Ly9UZXN0IENhbGVuZGFyLy9FTgpCRUdJTjpWRVZFTlQKVUlEOnByMjE5LXNjZW5hcmlvLWVAZXhhbXBsZS5jb20KRFRTVEFNUDoyMDI2MDcyM1QxMjAwMDBaCkRUU1RBUlQ6MjAyNjA4MDJUMTYwMDAwWgpEVEVORDoyMDI2MDgwMlQxNzAwMDBaClNVTU1BUlk6QUkgUG9saWN5IFNlcmllczogT3V0c2lkZSBTZW5kZXIgVGVzdApMT0NBVElPTjpodHRwczovL3pvb20udXMvai85OTk4ODg3Nzc2NgpPUkdBTklaRVI6bWFpbHRvOnNvbWVvbmVAZ21haWwuY29tCkRFU0NSSVBUSU9OOlRlc3RpbmcgdGhlIHJlamVjdGlvbiBwYXRoIGZvciBhIHNlbmRlciBvdXRzaWRlIHRoZSBhbGxvd2xpc3RlZCBkb21haW4uCkVORDpWRVZFTlQKRU5EOlZDQUxFTkRBUgo="
  }]
}
```

**Expected result:** nothing is created, and no email is sent at all, this domain never reaches the "do they have an account" check. Confirm via the server log: `sender ... is outside the allowlisted domains; rejecting, no event created`.

- [x] Ran and confirmed

---

### Admin update permission fix

This part of the PR is unrelated to the invite feature above, it fixes who's allowed to save changes to a conversation.
- Log into Nextspace as an Admin account (use a separate account from the ones you used above to create the event).
- Open a conversation you don't own and whose Topic you don't own either (any event created by Scenario A above works, as long as you sent it `From` a different account).
- Edit the conversation and save.

**Expected result:** the save succeeds. Before this fix, an admin without ownership would get a 403 with "Only conversation or topic owner can update."

- [ ] Ran and confirmed

## Additional information

Builds directly on the organizer and Topic resolution work in #214 and the inbound webhook infrastructure from #207. A companion Nextspace fix that makes the Edit-event permission check admin-aware on the frontend too is landing in a separate PR.