### PR TITLE
feat: add goal priority system for steering agent interventions

### DIFF
--- a/src/agents/helpers/interventionHandler.ts
+++ b/src/agents/helpers/interventionHandler.ts
@@ -5,7 +5,7 @@ import transcript from './transcript.js'
 import { getChatPromptResponse } from './llmChain.js'
 
 import logger from '../../config/logger.js'
-import { getConfidenceThreshold, getMinContributionMs } from './promptComposer.js'
+import { getConfidenceThreshold, getEffectiveMinConfidence, getMinContributionMs } from './promptComposer.js'
 
 /**
  * Analysis result from intervention detection — shared across proactiveGroupAgent and checkinHandler.
@@ -117,7 +117,8 @@ export async function runInterventionAnalysis(
   extraTemplateVars?: Record<string, string>,
   activeGoals?: ConversationGoal[],
   behaviorPolicy?: BehaviorPolicy,
-  channelType: 'dm' | 'groupChat' = 'groupChat'
+  channelType: 'dm' | 'groupChat' = 'groupChat',
+  goalPriorities?: Record<string, number>
 ): Promise<InterventionAnalysis | null> {
   // Format conversation histories
   const sharedChatMessages = formatMultiUserConversationHistory(sharedChatHistory)
@@ -175,7 +176,7 @@ export async function runInterventionAnalysis(
   const channelPolicy = channelType === 'dm' ? behaviorPolicy?.channels?.dm?.proactivePolicy : behaviorPolicy?.channels?.groupChat?.proactivePolicy
   const policyThreshold = getConfidenceThreshold(channelPolicy)
   const matchedGoal = activeGoals?.find((g) => g.id === analysis.goalId)
-  const patternFloor = matchedGoal?.triggers.minConfidence ?? 0
+  const patternFloor = matchedGoal ? getEffectiveMinConfidence(matchedGoal, goalPriorities) : 0
   const effectiveThreshold = Math.max(policyThreshold, patternFloor)
 
   logger.debug(`[interventionHandler] goalId=${analysis.goalId} confidence=${analysis.confidenceScore} threshold=${effectiveThreshold} (policy=${policyThreshold}, patternFloor=${patternFloor})`)
@@ -212,7 +213,8 @@ export async function detectPrivateInterventionOpportunity(
   userTemplate?: string,
   extraTemplateVars?: Record<string, string>,
   activeGoals?: ConversationGoal[],
-  behaviorPolicy?: BehaviorPolicy
+  behaviorPolicy?: BehaviorPolicy,
+  goalPriorities?: Record<string, number>
 ): Promise<InterventionAnalysis | null> {
   const now = sharedChatHistory.end ? sharedChatHistory.end.getTime() : Date.now()
   const dmProactivePolicy = behaviorPolicy?.channels?.dm?.proactivePolicy
@@ -241,6 +243,7 @@ export async function detectPrivateInterventionOpportunity(
     extraTemplateVars,
     activeGoals,
     behaviorPolicy,
-    'dm'
+    'dm',
+    goalPriorities
   )
 }

--- a/src/agents/helpers/promptComposer.ts
+++ b/src/agents/helpers/promptComposer.ts
@@ -48,6 +48,42 @@ const QA_SCOPE_LINES: Record<string, string> = {
 }
 
 /**
+ * Maps a 0–100 priority to a prompt label for that goal, or null for normal priority (34–66).
+ */
+function getGoalTierLabel(priority: number): string | null {
+  if (priority >= 67) return '**Preferred pattern — prioritize this when applicable.**'
+  if (priority <= 33) return '**Use sparingly — only when the signal is especially clear.**'
+  return null
+}
+
+/**
+ * Returns the effective minConfidence threshold for a goal after applying a priority-based modifier.
+ * High priority (>50) lowers the threshold; low priority (<50) raises it.
+ * The modifier scales linearly from −15 at priority 100 to +15 at priority 0.
+ * Goals with priority 0 are disabled and should be excluded before this is called.
+ */
+function getEffectiveMinConfidence(goal: ConversationGoal, goalPriorities?: Record<string, number>): number {
+  if (!goalPriorities) return goal.triggers.minConfidence
+  const priority = goalPriorities[goal.id] ?? 50
+  const modifier = Math.round((15 * (50 - priority)) / 50)
+  return Math.max(0, Math.min(100, goal.triggers.minConfidence + modifier))
+}
+
+/**
+ * Removes disabled goals (priority === 0) and sorts the remainder by priority descending.
+ * Goals not listed in goalPriorities default to priority 50.
+ * Returns the original array unchanged when goalPriorities is absent.
+ */
+function filterAndSortGoalsByPriority(
+  goals: ConversationGoal[],
+  goalPriorities?: Record<string, number>
+): ConversationGoal[] {
+  if (!goalPriorities) return goals
+  const active = goals.filter((g) => (goalPriorities[g.id] ?? 50) > 0)
+  return active.sort((a, b) => (goalPriorities[b.id] ?? 50) - (goalPriorities[a.id] ?? 50))
+}
+
+/**
  * Returns goals from the goals list that are eligible given channel and hard constraints.
  * pollPolicy.allowed: false removes poll_reveal regardless of goals.
  */
@@ -180,18 +216,43 @@ function buildBehaviorPolicySection(behaviorPolicy: BehaviorPolicy | undefined, 
 /**
  * Generates the active goal instructions section of a system prompt.
  * Each goal contributes its description, trigger conditions, guardrails, and examples.
+ * When goalPriorities is provided, goals are sorted by priority and a ranked preference
+ * list is prepended so the LLM knows which patterns to prefer.
  */
-function buildGoalInstructions(goals: ConversationGoal[], channelType: 'dm' | 'groupChat'): string {
-  const channelGoals = channelType === 'groupChat' ? getGroupChatGoals(goals) : getDmGoals(goals)
-  if (channelGoals.length === 0) return ''
+function buildGoalInstructions(
+  goals: ConversationGoal[],
+  channelType: 'dm' | 'groupChat',
+  goalPriorities?: Record<string, number>
+): string {
+  const allChannelGoals = channelType === 'groupChat' ? getGroupChatGoals(goals) : getDmGoals(goals)
+  if (allChannelGoals.length === 0) return ''
+
+  const channelGoals = goalPriorities
+    ? [...allChannelGoals].sort((a, b) => (goalPriorities[b.id] ?? 50) - (goalPriorities[a.id] ?? 50))
+    : allChannelGoals
 
   const lines: string[] = ['## Active Behavioral Patterns']
+
+  const hasPriorityVariation =
+    goalPriorities && channelGoals.length > 1 && channelGoals.some((g) => (goalPriorities[g.id] ?? 50) !== 50)
+  if (hasPriorityVariation) {
+    lines.push('When multiple patterns apply simultaneously, prefer them in this order:')
+    channelGoals.forEach((g, i) => lines.push(`${i + 1}. ${g.label}`))
+    lines.push('')
+  }
+
   lines.push(
     'The following patterns define when and how you should act. Choose the most appropriate pattern when conditions are met. When in doubt, remain silent.\n'
   )
 
   for (const goal of channelGoals) {
     lines.push(`### ${goal.label}`)
+
+    if (goalPriorities) {
+      const tierLabel = getGoalTierLabel(goalPriorities[goal.id] ?? 50)
+      if (tierLabel) lines.push(tierLabel)
+    }
+
     lines.push(goal.description)
 
     if (goal.triggers.conditions.length > 0) {
@@ -232,9 +293,10 @@ function composeSystemPrompt(
     goals?: ConversationGoal[]
     channelType?: 'dm' | 'groupChat'
     personalityName?: string | null
+    goalPriorities?: Record<string, number>
   } = {}
 ): string {
-  const { conversationContext, behaviorPolicy, goals, channelType, personalityName } = options
+  const { conversationContext, behaviorPolicy, goals, channelType, personalityName, goalPriorities } = options
   const parts: string[] = [basePrompt]
 
   const contextSection = buildConversationContextSection(conversationContext)
@@ -244,7 +306,8 @@ function composeSystemPrompt(
   if (policySection) parts.push(policySection)
 
   if (goals && goals.length > 0 && channelType) {
-    const goalSection = buildGoalInstructions(goals, channelType)
+    const prioritizedGoals = filterAndSortGoalsByPriority(goals, goalPriorities)
+    const goalSection = buildGoalInstructions(prioritizedGoals, channelType, goalPriorities)
     if (goalSection) parts.push(goalSection)
   }
 
@@ -260,6 +323,8 @@ export {
   getEligibleGoals,
   getConfidenceThreshold,
   getMinContributionMs,
+  getEffectiveMinConfidence,
+  filterAndSortGoalsByPriority,
   buildConversationContextSection,
   buildBehaviorPolicySection,
   buildGoalInstructions,

--- a/src/models/user.model/agent.model/index.ts
+++ b/src/models/user.model/agent.model/index.ts
@@ -488,7 +488,15 @@ agentSchema.pre('validate', function () {
   if (this.triggers === undefined) {
     this.triggers = agentTypes[this.agentType].defaultTriggers
   }
-  this.agentConfig = { ...(agentTypes[this.agentType].agentConfig || {}), ...(this.agentConfig || {}) }
+  const typeConfig = agentTypes[this.agentType].agentConfig ?? {}
+  const instanceConfig = this.agentConfig ?? {}
+  this.agentConfig = {
+    ...typeConfig,
+    ...instanceConfig,
+    ...(typeConfig.goalPriorities !== undefined || instanceConfig.goalPriorities !== undefined
+      ? { goalPriorities: { ...(typeConfig.goalPriorities ?? {}), ...(instanceConfig.goalPriorities ?? {}) } }
+      : {}),
+  }
   // ensure a botName exists
   if (!this.agentConfig!.botName) this.agentConfig!.botName = config.conversationBotName
   if (this.conversationHistorySettings === undefined && agentTypes[this.agentType].defaultConversationHistorySettings) {

--- a/tests/agents/helpers/promptComposer.test.ts
+++ b/tests/agents/helpers/promptComposer.test.ts
@@ -2,6 +2,8 @@ import {
   getEligibleGoals,
   getConfidenceThreshold,
   getMinContributionMs,
+  getEffectiveMinConfidence,
+  filterAndSortGoalsByPriority,
   buildConversationContextSection,
   buildBehaviorPolicySection,
   buildGoalInstructions,
@@ -506,6 +508,176 @@ describe('buildGoalInstructions', () => {
     const result = buildGoalInstructions([FIXTURE_GROUP_GOAL, FIXTURE_BRIDGE_GOAL], 'groupChat')
     expect(result).toContain('### Provoke participation')
     expect(result).toContain('### Bridge topics')
+  })
+})
+
+const FIXTURE_SYNTHESIZE_GOAL: ConversationGoal = {
+  id: 'synthesize_discussion',
+  label: 'Synthesize discussion',
+  description: 'Draws together threads from across the conversation.',
+  channel: 'groupChat',
+  triggers: { conditions: [{ scope: 'participant', condition: 'multiple threads are active' }], minConfidence: 60 },
+  guardrails: [],
+  outputContract: { format: 'text' },
+  examples: []
+}
+
+describe('getEffectiveMinConfidence', () => {
+  test('returns goal minConfidence unchanged when goalPriorities is absent', () => {
+    expect(getEffectiveMinConfidence(FIXTURE_GROUP_GOAL, undefined)).toBe(65)
+  })
+
+  test('returns goal minConfidence unchanged when goal not listed in priorities', () => {
+    expect(getEffectiveMinConfidence(FIXTURE_GROUP_GOAL, {})).toBe(65)
+  })
+
+  test('lowers threshold for high-priority goal (priority 100 → −15 modifier)', () => {
+    expect(getEffectiveMinConfidence(FIXTURE_GROUP_GOAL, { provoke_participation: 100 })).toBe(50)
+  })
+
+  test('raises threshold for low-priority goal (priority 0 → +15 modifier)', () => {
+    expect(getEffectiveMinConfidence(FIXTURE_GROUP_GOAL, { provoke_participation: 0 })).toBe(80)
+  })
+
+  test('no modifier at default priority 50', () => {
+    expect(getEffectiveMinConfidence(FIXTURE_GROUP_GOAL, { provoke_participation: 50 })).toBe(65)
+  })
+
+  test('clamps result at 0 when modifier would go below 0', () => {
+    const veryLowBase: ConversationGoal = { ...FIXTURE_GROUP_GOAL, triggers: { ...FIXTURE_GROUP_GOAL.triggers, minConfidence: 5 } }
+    expect(getEffectiveMinConfidence(veryLowBase, { provoke_participation: 100 })).toBe(0)
+  })
+
+  test('clamps result at 100 when modifier would exceed 100', () => {
+    const veryHighBase: ConversationGoal = { ...FIXTURE_GROUP_GOAL, triggers: { ...FIXTURE_GROUP_GOAL.triggers, minConfidence: 95 } }
+    expect(getEffectiveMinConfidence(veryHighBase, { provoke_participation: 0 })).toBe(100)
+  })
+})
+
+describe('filterAndSortGoalsByPriority', () => {
+  test('returns goals unchanged when goalPriorities is absent', () => {
+    const goals = [FIXTURE_GROUP_GOAL, FIXTURE_BRIDGE_GOAL]
+    expect(filterAndSortGoalsByPriority(goals, undefined)).toStrictEqual(goals)
+  })
+
+  test('removes goals with priority 0', () => {
+    const result = filterAndSortGoalsByPriority([FIXTURE_GROUP_GOAL, FIXTURE_BRIDGE_GOAL], {
+      provoke_participation: 0
+    })
+    expect(result.map((g) => g.id)).toEqual(['bridge_topics'])
+  })
+
+  test('sorts goals by priority descending', () => {
+    const result = filterAndSortGoalsByPriority([FIXTURE_GROUP_GOAL, FIXTURE_BRIDGE_GOAL, FIXTURE_SYNTHESIZE_GOAL], {
+      provoke_participation: 20,
+      bridge_topics: 80,
+      synthesize_discussion: 50
+    })
+    expect(result.map((g) => g.id)).toEqual(['bridge_topics', 'synthesize_discussion', 'provoke_participation'])
+  })
+
+  test('unlisted goals default to priority 50 and sort accordingly', () => {
+    const result = filterAndSortGoalsByPriority([FIXTURE_GROUP_GOAL, FIXTURE_BRIDGE_GOAL], {
+      bridge_topics: 70
+    })
+    expect(result[0].id).toBe('bridge_topics')
+    expect(result[1].id).toBe('provoke_participation')
+  })
+
+  test('all-default priorities preserves relative order', () => {
+    const goals = [FIXTURE_GROUP_GOAL, FIXTURE_BRIDGE_GOAL]
+    const result = filterAndSortGoalsByPriority(goals, {})
+    expect(result.map((g) => g.id)).toEqual(['provoke_participation', 'bridge_topics'])
+  })
+})
+
+describe('buildGoalInstructions with goalPriorities', () => {
+  test('renders ranked preference list when priorities differ from default', () => {
+    const result = buildGoalInstructions(
+      [FIXTURE_GROUP_GOAL, FIXTURE_BRIDGE_GOAL],
+      'groupChat',
+      { provoke_participation: 80, bridge_topics: 30 }
+    )
+    expect(result).toContain('When multiple patterns apply simultaneously')
+    expect(result).toContain('1. Provoke participation')
+    expect(result).toContain('2. Bridge topics')
+  })
+
+  test('does not render ranked list when only one channel goal', () => {
+    const result = buildGoalInstructions([FIXTURE_GROUP_GOAL], 'groupChat', { provoke_participation: 80 })
+    expect(result).not.toContain('When multiple patterns apply simultaneously')
+  })
+
+  test('does not render ranked list when all priorities are default (50)', () => {
+    const result = buildGoalInstructions(
+      [FIXTURE_GROUP_GOAL, FIXTURE_BRIDGE_GOAL],
+      'groupChat',
+      { provoke_participation: 50, bridge_topics: 50 }
+    )
+    expect(result).not.toContain('When multiple patterns apply simultaneously')
+  })
+
+  test('does not render ranked list when goalPriorities is absent', () => {
+    const result = buildGoalInstructions([FIXTURE_GROUP_GOAL, FIXTURE_BRIDGE_GOAL], 'groupChat')
+    expect(result).not.toContain('When multiple patterns apply simultaneously')
+  })
+
+  test('adds preferred tier label for high-priority goal', () => {
+    const result = buildGoalInstructions([FIXTURE_GROUP_GOAL], 'groupChat', { provoke_participation: 80 })
+    expect(result).toContain('Preferred pattern')
+  })
+
+  test('adds use-sparingly tier label for low-priority goal', () => {
+    const result = buildGoalInstructions([FIXTURE_GROUP_GOAL], 'groupChat', { provoke_participation: 20 })
+    expect(result).toContain('Use sparingly')
+  })
+
+  test('adds no tier label for normal priority goal', () => {
+    const result = buildGoalInstructions([FIXTURE_GROUP_GOAL], 'groupChat', { provoke_participation: 50 })
+    expect(result).not.toContain('Preferred pattern')
+    expect(result).not.toContain('Use sparingly')
+  })
+
+  test('ranked list reflects priority order, not input order', () => {
+    const result = buildGoalInstructions(
+      [FIXTURE_GROUP_GOAL, FIXTURE_BRIDGE_GOAL],
+      'groupChat',
+      { provoke_participation: 30, bridge_topics: 70 }
+    )
+    const bridgePos = result.indexOf('Bridge topics')
+    const provokePos = result.indexOf('Provoke participation')
+    expect(bridgePos).toBeLessThan(provokePos)
+  })
+
+  test('goals with priority 0 filtered out before reaching buildGoalInstructions via composeSystemPrompt', () => {
+    const result = composeSystemPrompt('Base.', {
+      goals: [FIXTURE_GROUP_GOAL, FIXTURE_BRIDGE_GOAL],
+      channelType: 'groupChat',
+      goalPriorities: { provoke_participation: 0, bridge_topics: 70 }
+    })
+    expect(result).not.toContain('Provoke participation')
+    expect(result).toContain('Bridge topics')
+  })
+})
+
+describe('composeSystemPrompt with goalPriorities', () => {
+  test('passes goalPriorities through to goal section', () => {
+    const result = composeSystemPrompt('Base.', {
+      goals: [FIXTURE_GROUP_GOAL, FIXTURE_BRIDGE_GOAL],
+      channelType: 'groupChat',
+      goalPriorities: { provoke_participation: 80, bridge_topics: 30 }
+    })
+    expect(result).toContain('When multiple patterns apply simultaneously')
+    expect(result).toContain('Preferred pattern')
+  })
+
+  test('goal section is unchanged when goalPriorities is absent', () => {
+    const withPriorities = composeSystemPrompt('Base.', {
+      goals: [FIXTURE_GROUP_GOAL],
+      channelType: 'groupChat'
+    })
+    expect(withPriorities).not.toContain('When multiple patterns apply simultaneously')
+    expect(withPriorities).not.toContain('Preferred pattern')
   })
 })
 

--- a/tests/models/agent.model.test.ts
+++ b/tests/models/agent.model.test.ts
@@ -131,6 +131,29 @@ const testAgentTypes = {
       translatedMsg.body = `**${msg.body.insights.join('\n')}**`
       return translatedMsg
     }
+  },
+  withGoalPriorities: {
+    respond: mockRespond,
+    evaluate: mockEvaluate,
+    start: mockStart,
+    stop: mockStop,
+    name: 'Test Agent With Goal Priorities',
+    description: 'An agent type with goalPriorities in agentConfig',
+    maxTokens: 2000,
+    defaultTriggers: { perMessage: {} },
+    priority: 50,
+    llmTemplateVars: {},
+    llmTemplates: {},
+    defaultLLMPlatform,
+    defaultLLMModel,
+    agentConfig: {
+      minInterval: 5,
+      goalPriorities: {
+        synthesize_discussion: 80,
+        bridge_topics: 50,
+        provoke_participation: 20
+      }
+    }
   }
 }
 
@@ -2523,6 +2546,82 @@ describe('agent tests', () => {
       const bodies = conversationHistory.messages.map((m) => m.body)
       expect(bodies).toContain('Parent message')
       expect(bodies).toContain('Existing reply')
+    })
+  })
+
+  describe('goalPriorities agentConfig merge', () => {
+    // agentConfig is Mixed so we cast goalPriorities to its runtime shape for assertions
+    const priorities = (agent) => agent.agentConfig!.goalPriorities as Record<string, number> | undefined
+
+    test('applies type-level goalPriorities when instance has none', async () => {
+      const agent = new Agent({ agentType: 'withGoalPriorities', conversation })
+      await agent.save()
+      expect(priorities(agent)).toEqual({
+        synthesize_discussion: 80,
+        bridge_topics: 50,
+        provoke_participation: 20
+      })
+    })
+
+    test('instance goalPriorities override individual keys while preserving type defaults', async () => {
+      const agent = new Agent({
+        agentType: 'withGoalPriorities',
+        conversation,
+        agentConfig: { goalPriorities: { bridge_topics: 90 } }
+      })
+      await agent.save()
+      expect(priorities(agent)).toEqual({
+        synthesize_discussion: 80,
+        bridge_topics: 90,
+        provoke_participation: 20
+      })
+    })
+
+    test('instance can add a new goal key not present in type defaults', async () => {
+      const agent = new Agent({
+        agentType: 'withGoalPriorities',
+        conversation,
+        agentConfig: { goalPriorities: { challenge_consensus: 70 } }
+      })
+      await agent.save()
+      expect(priorities(agent)).toMatchObject({
+        synthesize_discussion: 80,
+        bridge_topics: 50,
+        provoke_participation: 20,
+        challenge_consensus: 70
+      })
+    })
+
+    test('instance can disable a goal by setting priority 0', async () => {
+      const agent = new Agent({
+        agentType: 'withGoalPriorities',
+        conversation,
+        agentConfig: { goalPriorities: { synthesize_discussion: 0 } }
+      })
+      await agent.save()
+      expect(priorities(agent)!.synthesize_discussion).toBe(0)
+      expect(priorities(agent)!.bridge_topics).toBe(50)
+    })
+
+    test('other agentConfig fields are still shallow-merged correctly', async () => {
+      const agent = new Agent({
+        agentType: 'withGoalPriorities',
+        conversation,
+        agentConfig: { minInterval: 10 }
+      })
+      await agent.save()
+      expect(agent.agentConfig!.minInterval).toBe(10)
+      expect(priorities(agent)).toEqual({
+        synthesize_discussion: 80,
+        bridge_topics: 50,
+        provoke_participation: 20
+      })
+    })
+
+    test('no goalPriorities key set when neither type nor instance defines it', async () => {
+      const agent = new Agent({ agentType: 'perMessage', conversation })
+      await agent.save()
+      expect(priorities(agent)).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
## What is in this PR?

Adds a priority system for agent goals so that individual goals can be weighted to be more or less likely to trigger. Priority is configured via `agentConfig.goalPriorities` (a `Record<string, number>`, 0–100) at the agent-type level, with instance-level overrides stored in MongoDB. This lets you steer which interventions an agent favors without changing goal definitions or feature flags.

## Changes in the codebase

- **`src/agents/helpers/promptComposer.ts`**: Added `filterAndSortGoalsByPriority` (removes disabled goals, sorts by priority) and `getEffectiveMinConfidence` (applies a priority-derived ±15 modifier to a goal's `minConfidence` threshold). Extended `buildGoalInstructions` to sort goals by priority, prepend a ranked preference list when priorities are non-uniform, and add per-goal tier labels (`Preferred pattern` / `Use sparingly`). Extended `composeSystemPrompt` to accept and thread `goalPriorities` through.
- **`src/agents/helpers/interventionHandler.ts`**: `runInterventionAnalysis` and `detectPrivateInterventionOpportunity` now accept an optional `goalPriorities` parameter; the post-LLM confidence gate uses `getEffectiveMinConfidence` so high-priority goals have a lower effective threshold and low-priority goals have a higher one.
- **`src/models/user.model/agent.model/index.ts`**: The `agentConfig` init merge now deep-merges `goalPriorities` specifically, so an instance can override individual goal priorities without having to re-specify all type-level defaults. All other `agentConfig` fields retain the existing shallow-merge behavior.

## Documentation and automated testing

Did you:
- [x] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

- [ ] Add `goalPriorities` to an agent type's `agentConfig`, e.g. `{ synthesize_discussion: 80, play_commentary: 20 }`, start a conversation with that agent, and verify the ranked preference list appears in the composed system prompt.
- [ ] Set a goal's priority to `0` and confirm it is excluded from the system prompt entirely.
- [ ] Save an agent instance with a partial `goalPriorities` override (only one key) and confirm the other type-level priorities are preserved on the saved document.

## Additional information

The three steering mechanisms (prompt ordering, ranked list header, confidence threshold modifier) are complementary and mutually reinforcing: ordering and the ranked list work on the LLM's attention during reasoning; the confidence threshold modifier is a deterministic post-processing gate that applies regardless of how the LLM interprets the prompt. This makes the system more robust than relying on any single mechanism alone.


## Additional information


