### PR TITLE
feat: refactor experiment agents to support experimenting with a new agent type

### DIFF
--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -933,21 +933,21 @@ components:
           type: string
           format: date-time
 
-    AgentModification:
+    ExperimentAgent:
       type: object
-      required:
-        - agent
       properties:
         agent:
           $ref: '#/components/schemas/Agent'
+          description: Reference to an existing agent on the base conversation. Mutually exclusive with agentType.
+        agentType:
+          type: string
+          description: Agent type to instantiate as a new agent. Mutually exclusive with agent.
         experimentValues:
           type: object
           additionalProperties: true
-          description: Should match properties object of agentType
-        simulatedStartTime:
-          type: string
-          format: date-time
-          description: The Date of the earliest message considered in the periodic interval
+          description: >
+            Spread into the cloned or created agent to override defaults
+            (e.g. llmTemplates, agentConfig, llmModel).
 
     Experiment:
       type: object
@@ -980,10 +980,10 @@ components:
         status:
           type: string
           enum: [running, completed, failed, 'not started']
-        agentModifications:
+        agents:
           type: array
           items:
-            $ref: '#/components/schemas/AgentModification'
+            $ref: '#/components/schemas/ExperimentAgent'
         resultConversation:
           oneOf:
             - type: string

--- a/src/models/experiment.model/experiment.ts
+++ b/src/models/experiment.model/experiment.ts
@@ -2,7 +2,7 @@ import mongoose from 'mongoose'
 
 import { toJSON, paginate } from '../plugins/index.js'
 import { IExperiment } from '../../types/index.types.js'
-import agentModificationsSchema from './agentModifications.schema.js'
+import experimentAgentSchema from './experimentAgent.schema.js'
 
 const experimentSchema = new mongoose.Schema<IExperiment>(
   {
@@ -21,8 +21,8 @@ const experimentSchema = new mongoose.Schema<IExperiment>(
       required: true,
       default: 'not started'
     },
-    agentModifications: {
-      type: [agentModificationsSchema],
+    agents: {
+      type: [experimentAgentSchema],
       default: undefined
     },
     executedAt: {

--- a/src/models/experiment.model/experimentAgent.schema.ts
+++ b/src/models/experiment.model/experimentAgent.schema.ts
@@ -1,0 +1,19 @@
+import mongoose from 'mongoose'
+
+const experimentAgentSchema = new mongoose.Schema({
+  // Reference to an existing agent on the base conversation
+  agent: {
+    type: mongoose.SchemaTypes.ObjectId,
+    ref: 'Agent'
+  },
+  // Instantiate a new agent type instead of referencing an existing one
+  agentType: {
+    type: String
+  },
+  // Spread into the cloned/created agent to override defaults
+  experimentValues: {
+    type: mongoose.SchemaTypes.Mixed
+  }
+})
+
+export default experimentAgentSchema

--- a/src/routes/v1/experiments.route.ts
+++ b/src/routes/v1/experiments.route.ts
@@ -45,15 +45,15 @@ const router = express.Router()
  *                 type: string
  *                 description: ID of the base conversation to use for the experiment
  *                 example: "6123456789abcdef0123456b"
- *               agentModifications:
+ *               agents:
  *                 type: array
- *                 description: Array of agent modifications for the experiment
+ *                 description: Agents to run in the experiment (modify, add, or remove)
  *                 items:
- *                   $ref: '#/components/schemas/AgentModification'
+ *                   $ref: '#/components/schemas/ExperimentAgent'
  *               executedAt:
  *                 type: string
  *                 format: date-time
- *                 description: If provided, marks this as a past experiment (cannot be used with agentModifications)
+ *                 description: If provided, marks this as a past experiment (cannot be used with agents)
  *                 example: "2021-11-30T01:51:01.639Z"
  *     responses:
  *       201:

--- a/src/services/experiment.service.ts
+++ b/src/services/experiment.service.ts
@@ -2,6 +2,8 @@ import mongoose from 'mongoose'
 import httpStatus from 'http-status'
 import Experiment from '../models/experiment.model/experiment.js'
 import { Agent, Message, Conversation, Topic } from '../models/index.js'
+import { ConversationDocument } from '../models/conversation.model.js'
+import { AgentDocument } from '../models/user.model/agent.model/index.js'
 import ApiError from '../utils/ApiError.js'
 import logger from '../config/logger.js'
 import transcript from '../agents/helpers/transcript.js'
@@ -23,16 +25,22 @@ async function getAgentResponse(agent, experiment, endTime, msg?) {
   const responses = await agent.respond(msg)
   for (const response of responses) {
     const msgData = agentResponseToMessageData(response, agent)
-    const responseMsg = await Message.create({
+    const simulatedAt = new Date(endTime.getTime() + 1000)
+    const responseMsg = new Message({
       ...msgData,
       channels: msgData.channels?.map((c) => (typeof c === 'string' ? c : c.name)),
-      createdAt: new Date(endTime.getTime() + 1000)
+      createdAt: simulatedAt,
+      updatedAt: simulatedAt
     })
+    await responseMsg.save({ timestamps: false })
     experiment.resultConversation.messages.push(responseMsg)
+  }
+  if (responses.length > 0) {
+    await experiment.resultConversation.save()
   }
 }
 
-async function runPeriodicExperiment(agent, experiment, simulatedStartTime?) {
+async function runPeriodicExperiment(agent, experiment) {
   // Seed RAG for the result conversation so transcript search works against its collection.
   // The result conversation has a different _id than the base, so we must re-embed here.
   await transcript.loadEventMetadataIntoVectorStore(experiment.resultConversation)
@@ -43,12 +51,24 @@ async function runPeriodicExperiment(agent, experiment, simulatedStartTime?) {
     await transcript.loadTranscriptIntoVectorStore(transcriptMsgs, experiment.resultConversation._id)
   }
 
-  const msgStartTime = new Date(Math.min(...experiment.resultConversation.messages.map((msg) => msg.createdAt.getTime())))
-  const msgEndTime = new Date(Math.max(...experiment.resultConversation.messages.map((msg) => msg.createdAt.getTime())))
+  // Use only original (non-agent) messages to calculate the window. Agent responses added
+  // during simulation of earlier agents must not stretch the window for later agents.
+  const baseMsgs = experiment.resultConversation.messages.filter((msg) => !msg.fromAgent)
+  const msgStartTime = new Date(Math.min(...baseMsgs.map((msg) => msg.createdAt.getTime())))
+  const msgEndTime = new Date(Math.max(...baseMsgs.map((msg) => msg.createdAt.getTime())))
+
+  // Align the conversation's startTime with the earliest message so agents that use
+  // conversation.startTime as a rate-limit baseline (e.g. proactiveGroupAgent) behave
+  // correctly even when the conversation was restarted after the original messages.
+  const resultConv = experiment.resultConversation as ConversationDocument
+  if (!resultConv.startTime || resultConv.startTime > msgStartTime) {
+    resultConv.startTime = msgStartTime
+    await resultConv.save()
+  }
 
   const timeInterval = agent.triggers.periodic.timerPeriod
   const endTime = new Date(msgEndTime.getTime() + timeInterval * 1000)
-  const startTime = simulatedStartTime ?? msgStartTime
+  const startTime = msgStartTime
   let currentTime = new Date(startTime.getTime() + timeInterval * 1000)
 
   // simulate running agent at normal periodic interval, ensuring first and last messages are captured
@@ -104,33 +124,31 @@ const runExperiment = async (experimentId) => {
     throw new ApiError(httpStatus.BAD_REQUEST, 'Experiment does not have a result conversation')
   }
 
+  await (experiment.resultConversation as ConversationDocument).populate('agents')
+
   experiment.executedAt = new Date(Date.now())
   experiment.status = 'running'
   await experiment.save()
   try {
-    if (experiment.agentModifications) {
-      for (const agentMod of experiment.agentModifications) {
-        const agent = await Agent.findOne({ _id: agentMod.agent._id })
-        if (!agent) {
-          logger.warn(`Could not find agent ${agentMod.agent._id}. Skipping experiment for this agent.`)
-          continue
-        }
-        agent.conversation = experiment.resultConversation
-        if (agentMod.experimentValues) {
-          // temp modify the agent by deep patching without saving
-          agent.deepPatch(agentMod.experimentValues)
-        }
-        if (agent.triggers?.periodic) {
-          await runPeriodicExperiment(agent, experiment, agentMod.simulatedStartTime)
-        } else if (agent.triggers?.perMessage) {
-          await runPerMessageExperiment(agent, experiment)
-        } else {
-          logger.error('Experiments with manual agents are not currently supported')
-          continue
-        }
-        if (!agent.active) {
-          await agent.start()
-        }
+    const resultConv = experiment.resultConversation as ConversationDocument
+    for (const agentDoc of resultConv.agents ?? []) {
+      const agent = await Agent.findOne({ _id: agentDoc._id ?? agentDoc })
+      if (!agent) {
+        logger.warn(`Could not find agent ${agentDoc._id ?? agentDoc}. Skipping.`)
+        continue
+      }
+      if (!agent.active) {
+        // Set active in-memory only — do not save, so the periodic job scheduler
+        // never picks this experimental agent up for real-world scheduling on server restart.
+        agent.active = true
+      }
+      if (agent.triggers?.periodic) {
+        await runPeriodicExperiment(agent, experiment)
+      } else if (agent.triggers?.perMessage) {
+        await runPerMessageExperiment(agent, experiment)
+      } else {
+        logger.error('Experiments with manual agents are not currently supported')
+        continue
       }
     }
     experiment.status = 'completed'
@@ -150,17 +168,20 @@ const createExperiment = async (experimentBody, user) => {
 
   if (!baseConversation) throw new ApiError(httpStatus.BAD_REQUEST, 'Base conversation not found')
 
-  // Make sure all agents involved in the experiment are valid
-  for (const agentMod of experimentBody.agentModifications || []) {
-    const agent = baseConversation.agents.find((a) => a._id!.toString() === agentMod.agent)
-    if (!agent) {
-      throw new ApiError(httpStatus.BAD_REQUEST, `Agent ${agentMod.agent} not found in base conversation`)
+  // Resolve agent references for entries that reference existing agents
+  const agentOps = experimentBody.agents ?? []
+  for (const op of agentOps) {
+    if (op.agent) {
+      const agent = baseConversation.agents.find((a) => a._id!.toString() === op.agent.toString())
+      if (!agent) {
+        throw new ApiError(httpStatus.BAD_REQUEST, `Agent ${op.agent} not found in base conversation`)
+      }
+      op.agent = agent
     }
-    agentMod.agent = agent
   }
 
   let resultConversation
-  if (experimentBody.agentModifications) {
+  if (!experimentBody.executedAt) {
     // clone base conversation into a new conversation that can be used for simulation
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { _id, createdAt, updatedAt, ...resultConversationData } = baseConversation.toObject()
@@ -174,9 +195,42 @@ const createExperiment = async (experimentBody, user) => {
 
     // refresh messages - delete and re-duplicate
     await Message.deleteMany({ conversation: resultConversation._id })
-    // TODO only remove the messages from agents we are experimenting with?
     await duplicateConversationMessages(baseConversation._id, resultConversation._id, { fromAgent: false })
     await resultConversation.populate('messages')
+
+    // Determine which base agents to clone:
+    // if agents array is provided, only clone those referenced; otherwise clone all.
+    const existingAgentOps = agentOps.filter((op) => op.agent)
+    const opsByAgentId = new Map(existingAgentOps.map((op) => [op.agent._id.toString(), op]))
+    const agentsToClone =
+      agentOps.length > 0
+        ? (baseConversation.agents as unknown as AgentDocument[]).filter((a) => opsByAgentId.has(a._id!.toString()))
+        : (baseConversation.agents as unknown as AgentDocument[])
+
+    resultConversation.agents = []
+    for (const baseAgent of agentsToClone) {
+      const agentObj = baseAgent.toObject() as unknown as Record<string, unknown>
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { _id: __, createdAt: ___, updatedAt: ____, conversation: _____, active: ______, ...agentFields } = agentObj
+      const op = opsByAgentId.get(baseAgent._id!.toString()) as { experimentValues?: Record<string, unknown> } | undefined
+      const clone = await Agent.create({
+        ...agentFields,
+        conversation: resultConversation._id,
+        ...(op?.experimentValues ?? {})
+      })
+      resultConversation.agents.push(clone._id)
+    }
+
+    // Create new agents for entries that specify an agentType
+    for (const op of agentOps.filter((o) => o.agentType)) {
+      const newAgent = await Agent.create({
+        agentType: op.agentType,
+        conversation: resultConversation._id,
+        ...(op.experimentValues ?? {})
+      })
+      resultConversation.agents.push(newAgent._id)
+    }
+
     await resultConversation.save()
   }
 
@@ -185,7 +239,7 @@ const createExperiment = async (experimentBody, user) => {
     description: experimentBody.description,
     baseConversation,
     createdBy: user,
-    ...(resultConversation !== undefined && { resultConversation, agentModifications: experimentBody.agentModifications }),
+    ...(resultConversation !== undefined && { resultConversation, agents: agentOps }),
     ...(experimentBody.executedAt !== undefined && {
       executedAt: experimentBody.executedAt,
       status: 'completed',

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -199,6 +199,10 @@ export interface IAdapter {
   dmChannels?: AdapterChannelConfig[]
 }
 
+export type ExperimentAgent =
+  | { agent: IAgent; agentType?: never; experimentValues?: Record<string, unknown> }
+  | { agentType: string; agent?: IAgent; experimentValues?: Record<string, unknown> }
+
 export interface IExperiment {
   name: string
   description?: string
@@ -206,11 +210,7 @@ export interface IExperiment {
   createdBy: IUser
   createdAt: Date
   status: 'running' | 'completed' | 'failed' | 'not started'
-  agentModifications?: {
-    agent: IAgent
-    experimentValues?: Record<string, unknown> // should match properties object of agentType passed in on Conversation creation
-    simulatedStartTime?: Date // The Date of the earliest message considered in the periodic interval
-  }[]
+  agents?: ExperimentAgent[]
   resultConversation?: IConversation
   executedAt?: Date
 }

--- a/src/validations/experiment.validation.ts
+++ b/src/validations/experiment.validation.ts
@@ -1,18 +1,26 @@
 import Joi from 'joi'
 
-const agentModifications = {
-  agent: Joi.any().required(),
-  experimentValues: Joi.object(),
-  simulatedStartTime: Joi.date()
-}
-const createExperiment = {
-  body: Joi.object().keys({
-    name: Joi.string().required(),
-    baseConversation: Joi.any().required(),
-    description: Joi.string(),
-    agentModifications: Joi.array().items(Joi.object(agentModifications)),
-    executedAt: Joi.date()
+const agents = Joi.alternatives().try(
+  Joi.object({
+    agent: Joi.any().required(),
+    experimentValues: Joi.object()
+  }),
+  Joi.object({
+    agentType: Joi.string().required(),
+    experimentValues: Joi.object()
   })
+)
+
+const createExperiment = {
+  body: Joi.object()
+    .keys({
+      name: Joi.string().required(),
+      baseConversation: Joi.any().required(),
+      description: Joi.string(),
+      agents: Joi.array().items(agents),
+      executedAt: Joi.date()
+    })
+    .nand('agents', 'executedAt')
 }
 
 const getExperimentResults = {

--- a/tests/integration/experiment.test.ts
+++ b/tests/integration/experiment.test.ts
@@ -204,7 +204,7 @@ const experimentCreateRequest = {
   name: 'Test Experiment',
   description: 'A test experiment to validate functionality',
   baseConversation: baseConversationId.toString(),
-  agentModifications: [
+  agents: [
     {
       agent: agentId,
       experimentValues: {
@@ -290,7 +290,7 @@ describe('Experiment routes', () => {
 
       const invalidAgentRequest = {
         ...experimentCreateRequest,
-        agentModifications: [
+        agents: [
           {
             agent: new mongoose.Types.ObjectId(),
             experimentValues: { conversationHistorySettings: { timeWindow: 1800 } }
@@ -325,7 +325,7 @@ describe('Experiment routes', () => {
 
       const incompleteRequest = {
         ...experimentCreateRequest,
-        agentModifications: [
+        agents: [
           {
             agent: new mongoose.Types.ObjectId()
           }
@@ -353,15 +353,12 @@ describe('Experiment routes', () => {
 
       const multiAgentRequest = {
         ...experimentCreateRequest,
-        agentModifications: [
+        agents: [
           {
             agent: agentId,
             experimentValues: { conversationHistorySettings: { timeWindow: 1800 } }
           },
-          {
-            agent: agentId2,
-            experimentValues: { conversationHistorySettings: { timeWindow: 900 } }
-          }
+          { agent: agentId2, experimentValues: { conversationHistorySettings: { timeWindow: 900 } } }
         ]
       }
 
@@ -371,8 +368,8 @@ describe('Experiment routes', () => {
         .send(multiAgentRequest)
         .expect(httpStatus.CREATED)
 
-      expect(response.body).toHaveProperty('agentModifications')
-      expect(response.body.agentModifications).toHaveLength(2)
+      expect(response.body).toHaveProperty('agents')
+      expect(response.body.agents).toHaveLength(2)
     })
 
     test('should handle recording past experiments', async () => {
@@ -396,7 +393,7 @@ describe('Experiment routes', () => {
       expect(response.body).toHaveProperty('description', experimentCreateRequest.description)
       expect(response.body).toHaveProperty('baseConversation')
       expect(response.body).toHaveProperty('executedAt')
-      expect(response.body).not.toHaveProperty('agentModifications')
+      expect(response.body).not.toHaveProperty('agents')
 
       // Verify experiment was created in database
       const experiment = await Experiment.findById(response.body.id)
@@ -406,7 +403,21 @@ describe('Experiment routes', () => {
       expect(experiment!.executedAt).toEqual(experimentBody.executedAt)
       expect(experiment!.status).toEqual('completed')
     })
-    test('should return 400 if agentModifications and executedAt are specified', async () => {
+    test('should return 400 when agent entry has neither agent nor agentType', async () => {
+      await insertUsers([registeredUser])
+      await insertTestConversation()
+
+      await request(app)
+        .post('/v1/experiments')
+        .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+        .send({
+          ...experimentCreateRequest,
+          agents: [{ experimentValues: { llmModel: 'x' } }]
+        })
+        .expect(httpStatus.BAD_REQUEST)
+    })
+
+    test('should return 400 if agents and executedAt are specified', async () => {
       await insertUsers([registeredUser])
       await insertTestConversation()
       const executedAt = new Date(Date.now() - 60 * 60 * 1000)
@@ -480,44 +491,9 @@ describe('Experiment routes', () => {
       expect(experiment!.executedAt).toBeDefined()
     })
 
-    test('should return 200 and run experiment simulation with a simulated start time', async () => {
-      const startTimeExp = await Experiment.findOne({ _id: new mongoose.Types.ObjectId(createdExperiment.id) })
-      startTimeExp!.agentModifications = [
-        {
-          agent,
-          experimentValues: {
-            llmTemplates: { contribution: 'Do something bizarre' }
-          },
-          simulatedStartTime: new Date('2024-01-01T10:35:30Z')
-        }
-      ]
-      await startTimeExp!.save()
-
-      await request(app)
-        .post(`/v1/experiments/${createdExperiment.id}/run`)
-        .set('Authorization', `Bearer ${registeredUserAccessToken}`)
-        .expect(httpStatus.OK)
-
-      expect(mockRespond).not.toHaveBeenCalled()
-      const resultConversation = await Conversation.findById(createdExperiment.resultConversation)
-        .populate('messages')
-        .exec()
-      expect(resultConversation).toBeTruthy()
-      // No agent response because starting before any messages were produced
-      expect(resultConversation!.messages).toHaveLength(2)
-      const experiment = await Experiment.findById(createdExperiment.id)
-      expect(experiment).toBeTruthy()
-      expect(experiment!.status).toBe('completed')
-      expect(experiment!.executedAt).toBeDefined()
-    })
-
     test('should return 200 and run experiment with no experimental values', async () => {
       const startTimeExp = await Experiment.findOne({ _id: new mongoose.Types.ObjectId(createdExperiment.id) })
-      startTimeExp!.agentModifications = [
-        {
-          agent
-        }
-      ]
+      startTimeExp!.agents = []
       await startTimeExp!.save()
       const expectedResponse = {
         visible: true,
@@ -570,6 +546,103 @@ describe('Experiment routes', () => {
       expect(experiment).toBeTruthy()
       expect(experiment!.status).toEqual('failed')
     })
+
+    test('runs all agents on the result conversation when no agents ops are specified', async () => {
+      // Create a second agent on the conversation
+      const agent2 = await Agent.create(testAgent2)
+      await agent2.start()
+      conversation.agents.push(agent2)
+      await conversation.save()
+
+      // Create experiment with no agent ops — both agents should run
+      const response = await request(app)
+        .post('/v1/experiments')
+        .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+        .send({
+          name: 'No ops experiment',
+          baseConversation: baseConversationId.toString()
+        })
+        .expect(httpStatus.CREATED)
+
+      const expectedResponse = { visible: true, message: 'A response', pause: 0 }
+      mockRespond.mockResolvedValue([expectedResponse])
+      await request(app)
+        .post(`/v1/experiments/${response.body.id}/run`)
+        .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+        .expect(httpStatus.OK)
+
+      // Both agents should have been called
+      expect(mockRespond.mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+
+    test('creates and runs a new agent type not present on the base conversation', async () => {
+      const response = await request(app)
+        .post('/v1/experiments')
+        .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+        .send({
+          name: 'Add agent experiment',
+          baseConversation: baseConversationId.toString(),
+          agents: [
+            {
+              agent: agentId,
+              experimentValues: { llmTemplates: { contribution: 'Do something bizarre' } }
+            },
+            {
+              agentType: 'generic',
+              experimentValues: { llmTemplates: { main: 'Custom template' } }
+            }
+          ]
+        })
+        .expect(httpStatus.CREATED)
+
+      const resultConversation = await Conversation.findById(response.body.resultConversation).populate('agents').exec()
+      const agentTypes = resultConversation!.agents.map((a) => a.agentType)
+      expect(agentTypes).toContain('test')
+      expect(agentTypes).toContain('generic')
+      expect(resultConversation!.agents).toHaveLength(2)
+
+      const expectedResponse = { visible: true, message: 'A response', pause: 0 }
+      mockRespond.mockResolvedValue([expectedResponse])
+      await request(app)
+        .post(`/v1/experiments/${response.body.id}/run`)
+        .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+        .expect(httpStatus.OK)
+
+      expect(mockRespond.mock.calls).toHaveLength(2)
+    })
+
+    test('only runs agents specified in the agents array, excluding unspecified base agents', async () => {
+      // Add a second agent to the base conversation
+      const agent2 = await Agent.create(testAgent2)
+      await agent2.start()
+      conversation.agents.push(agent2)
+      await conversation.save()
+
+      // Only include agent2 — agent1 should be excluded from the result conversation
+      const response = await request(app)
+        .post('/v1/experiments')
+        .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+        .send({
+          name: 'Selective agent experiment',
+          baseConversation: baseConversationId.toString(),
+          agents: [{ agent: agentId2 }]
+        })
+        .expect(httpStatus.CREATED)
+
+      const resultConversation = await Conversation.findById(response.body.resultConversation).populate('agents').exec()
+      const resultAgentTypes = resultConversation!.agents.map((a) => a.agentType)
+      expect(resultConversation!.agents).toHaveLength(1)
+      expect(resultAgentTypes).toContain('test')
+
+      const expectedResponse = { visible: true, message: 'A response', pause: 0 }
+      mockRespond.mockResolvedValue([expectedResponse])
+      await request(app)
+        .post(`/v1/experiments/${response.body.id}/run`)
+        .set('Authorization', `Bearer ${registeredUserAccessToken}`)
+        .expect(httpStatus.OK)
+
+      expect(mockRespond.mock.calls).toHaveLength(1)
+    })
   })
   describe('GET /v1/experiments/:id', () => {
     test('should return 200 and experiment details', async () => {
@@ -599,7 +672,7 @@ describe('Experiment routes', () => {
       expect(getResponse.body).toHaveProperty('resultConversation')
       expect(getResponse.body).toHaveProperty('status', 'not started')
       expect(getResponse.body.createdBy).toEqual(registeredUser._id.toString())
-      expect(getResponse.body).toHaveProperty('agentModifications')
+      expect(getResponse.body).toHaveProperty('agents')
     })
 
     test('should return 404 for non-existent experiment', async () => {
@@ -641,7 +714,10 @@ describe('Experiment routes', () => {
       const createResponse = await request(app)
         .post('/v1/experiments')
         .set('Authorization', `Bearer ${registeredUserAccessToken}`)
-        .send(experimentCreateRequest)
+        .send({
+          ...experimentCreateRequest,
+          agents: [{ agent: agentId }, { agent: agentTextId }]
+        })
         .expect(httpStatus.CREATED)
 
       // Set up completed experiment with result conversation
@@ -2111,7 +2187,7 @@ ${formatTime(msg7Time)}  DMTestAgent2: Hello! How can I help?
         name: 'Weather Forecast Experiment',
         description: 'Testing generic agent with custom weather prompt',
         baseConversation: conversation._id.toString(),
-        agentModifications: [
+        agents: [
           {
             agent: genericAgentId,
             experimentValues: {
@@ -2180,7 +2256,7 @@ ${formatTime(msg7Time)}  DMTestAgent2: Hello! How can I help?
         name: 'Restaurant Recommendation Experiment',
         description: 'Testing generic agent with structured output',
         baseConversation: conversation._id.toString(),
-        agentModifications: [
+        agents: [
           {
             agent: genericAgentId,
             experimentValues: {
@@ -2261,7 +2337,7 @@ ${formatTime(msg7Time)}  DMTestAgent2: Hello! How can I help?
         name: 'Silent Monitor Experiment',
         description: 'Testing generic agent with invisible responses',
         baseConversation: conversation._id.toString(),
-        agentModifications: [
+        agents: [
           {
             agent: genericAgentId,
 
@@ -2325,7 +2401,7 @@ ${formatTime(msg7Time)}  DMTestAgent2: Hello! How can I help?
         name: 'Channel Specific Experiment',
         description: 'Testing generic agent with custom channel output',
         baseConversation: conversation._id.toString(),
-        agentModifications: [
+        agents: [
           {
             agent: genericAgentId,
             experimentValues: {
@@ -2492,7 +2568,7 @@ ${formatTime(msg7Time)}  DMTestAgent2: Hello! How can I help?
         name: 'Per Message Experiment',
         description: 'Testing perMessage agent responses',
         baseConversation: conversation._id.toString(),
-        agentModifications: [
+        agents: [
           {
             agent: perMessageAgentId,
             experimentValues: {}
@@ -2581,7 +2657,7 @@ ${formatTime(msg7Time)}  DMTestAgent2: Hello! How can I help?
         name: 'Direct Message Experiment',
         description: 'Testing perMessage agent with direct messages only',
         baseConversation: conversation._id.toString(),
-        agentModifications: [
+        agents: [
           {
             agent: perMessageAgentId,
             experimentValues: {}
@@ -2656,7 +2732,7 @@ ${formatTime(msg7Time)}  DMTestAgent2: Hello! How can I help?
         name: 'Channel Specific Experiment',
         description: 'Testing perMessage agent with specific channels',
         baseConversation: conversation._id.toString(),
-        agentModifications: [
+        agents: [
           {
             agent: perMessageAgentId,
             experimentValues: {
@@ -2720,7 +2796,7 @@ ${formatTime(msg7Time)}  DMTestAgent2: Hello! How can I help?
         name: 'Transcript RAG Experiment',
         description: 'Testing perMessage agent with transcript RAG collection',
         baseConversation: conversation._id.toString(),
-        agentModifications: [
+        agents: [
           {
             agent: perMessageAgentId,
             experimentValues: {}
@@ -2817,7 +2893,7 @@ ${formatTime(msg7Time)}  DMTestAgent2: Hello! How can I help?
         name: 'Mixed Channel Experiment',
         description: 'Testing perMessage agent with mixed channel configuration',
         baseConversation: conversation._id.toString(),
-        agentModifications: [
+        agents: [
           {
             agent: perMessageAgentId,
             experimentValues: {
@@ -2886,7 +2962,7 @@ ${formatTime(msg7Time)}  DMTestAgent2: Hello! How can I help?
         name: 'No Match Experiment',
         description: 'Testing perMessage agent with no matching messages',
         baseConversation: conversation._id.toString(),
-        agentModifications: [
+        agents: [
           {
             agent: perMessageAgentId,
             experimentValues: {


### PR DESCRIPTION
## What is in this PR?

<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->

The experiment service previously only supported modifying existing agents on a conversation. This PR extends it to also support adding entirely new agent types to an experiment, and simplifies the data model by replacing the agentModifications array with a unified agents array. Agents are now cloned into the result conversation at creation time rather than pointing at base agents, preventing experiment runs from corrupting base conversation agents. 
     
## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

 - experimentAgent.schema.ts (new file): Replaces agentOperations.schema.ts with a schema containing agent (ref),   
  agentType (string), and experimentValues — no operation field.
  - experiment.model: Renames agentModifications → agents using the new schema.                                      
  - experiment.service:                                                                                              
    - createExperiment now clones agents into the result conversation. If agents is specified, only those agents are
  cloned/created; if omitted, all base agents are cloned.                                                            
    - runExperiment sets active = true in-memory only (no save) to prevent the periodic job scheduler from picking up
   experimental agents.                                                                                              
    - runPeriodicExperiment uses only non-agent messages to calculate the simulation window, and aligns            
  resultConversation.startTime to the earliest message to fix rate-limit baseline issues.                            
    - Response messages are saved with simulated timestamps to ensure subsequent ticks see prior agent responses in
  conversation history.   
                                        

## Documentation and automated testing

Did you:
- [x] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x] Use the Hoppscotch endpoints Create Experiment and Run Experiment against a conversation that did not originally contain the proactiveGroupAgent
- [x] Use the Hoppscotch endpoints Create Experiment - Use Existing Agent and Run Experiment to test a conversation that did have a proactiveGroupAgent



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
