### PR TITLE
feat: let goals grant LLM tools via resolveTools()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,3 +40,8 @@ yarn lint && yarn prettier && yarn build   # eslint / prettier --check / tsc typ
 
 `yarn build` and tests are not enforced by any hook — run them yourself. Pushing runs
 no hooks: `git push`.
+
+## Pull requests
+
+Always fill out [.github/pull_request_template.md](.github/pull_request_template.md)
+when opening a PR (`gh pr create --body-file ...`) — don't drop or skip its sections.

--- a/goals/schema.json
+++ b/goals/schema.json
@@ -137,6 +137,20 @@
       },
       "minItems": 1,
       "description": "Concrete example outputs demonstrating this pattern in practice."
+    },
+    "tools": {
+      "type": "array",
+      "description": "Optional LLM tools this pattern grants when active, merged with the agent's already-configured tools.",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "description": "Tool name as registered in the tool registry, e.g. \"web_search\"." },
+          "config": { "type": "object", "description": "Optional per-goal config overrides passed to the tool's factory, e.g. { \"maxResults\": 3 }." },
+          "usageNotes": { "type": "string", "description": "Optional goal-specific guidance on when/how to use this tool, appended to its default usage guidance." }
+        }
+      }
     }
   }
 }

--- a/src/agents/eventAssistant/buildEventAssistantToolSystemPrompt.ts
+++ b/src/agents/eventAssistant/buildEventAssistantToolSystemPrompt.ts
@@ -1,25 +1,12 @@
 import { buildEventHistoryToolsPrompt } from '../tools/eventHistory.js'
+import { WEB_SEARCH_USAGE_GUIDANCE } from '../tools/webSearch.js'
 
 /**
  * System instructions for the event assistant when tools (e.g. web_search) are enabled.
- * Exported as a constant so unit tests can lock the decision rule without calling an LLM.
+ * Re-exported under this name so existing tests locking the wording keep working; the
+ * canonical text now lives with the tool it describes, in webSearch.ts.
  */
-export const EVENT_ASSISTANT_TOOL_USAGE_RULES = `**Tools (web search):**
-You have access to \`web_search\` for the public web.
-
-**Default — search first when not certain:** If you cannot **state with certainty** that **every substantive factual claim** in your answer is **directly supported** by the **Context** (recent transcript + retrieved chunks) and the **conversation history** you were given—**not** from training-time memory, knowledge after your cutoff, or guesswork—**you MUST call \`web_search\` at least once before replying**. When you are **uncertain**, **prefer running \`web_search\` over answering without it**; a redundant search is acceptable; **confident guessing or filling gaps from memory is not**.
-
-**Call \`web_search\` when** (non-exhaustive): facts that may have changed after your training cutoff or need "latest" confirmation; statistics, dates, regulations, product or version facts; verifiable claims about the **wider world** the discussion depends on; **incomplete** lists, rosters, or details **mentioned** in the event when the user asks for more than the Context literally contains; anything you would otherwise **infer** without a cited source in Context.
-
-**Do NOT call \`web_search\`** only when you will answer **solely** by summarizing, explaining, or closely paraphrasing what is **explicitly or unambiguously** already in Context + chat, with **no** material reliance on unchecked external facts. **Background Reading chunks in the Context are authoritative sources — treat them the same as transcript context; do not search for information already covered there.**
-
-**IMPORTANT — use tools instead of suggesting sources:** Do NOT tell the user to "check" or "look at" external sites or reports without having called \`web_search\` yourself in this turn—run the search and synthesize what you find.
-
-**If you use \`web_search\`:** Keep queries tightly scoped to the missing or uncertain facts. If results are empty or useless, say so briefly, then answer from Context and clearly-labeled general knowledge.
-
-**Citing web search results (mandatory):** When your response uses information from \`web_search\` results, you MUST attribute it — include the source title and URL inline (e.g. "According to [Title](URL), ...") or as a numbered reference at the end. Never state a fact drawn from search results without citing its source.
-
-**Never narrate your tool decisions in your response.** Do not explain why you did or did not search, or comment on what the context contains. Just answer the question.`
+export const EVENT_ASSISTANT_TOOL_USAGE_RULES = WEB_SEARCH_USAGE_GUIDANCE
 
 /** Prepended to the user message on the Event Assistant tool path (see eventQuestionHandler). */
 export const EVENT_ASSISTANT_TOOL_USER_MANDATE = `**Tool policy (mandatory):** Unless every substantive factual claim in your reply will be **directly and fully** supported by the Context and recent conversation in this thread—not from training-time memory alone—you **must** call \`web_search\` at least once before answering. If you are **uncertain**, **search first**; prefer a redundant web search over guessing. Background Reading in the Context counts as a fully supported source — do not search for what it already covers. Do not narrate your tool decisions in your reply.
@@ -81,7 +68,10 @@ export function buildEventAssistantToolSystemPrompt(
   options: EventAssistantToolPromptOptions = {}
 ) {
   const { hasWebSearch = true, series, today = new Date().toISOString().slice(0, 10) } = options
-  const ruleBlocks = [hasWebSearch ? EVENT_ASSISTANT_TOOL_USAGE_RULES : '', series ? buildSeriesHistoryRules(series.name, today) : '']
+  const ruleBlocks = [
+    hasWebSearch ? EVENT_ASSISTANT_TOOL_USAGE_RULES : '',
+    series ? buildSeriesHistoryRules(series.name, today) : ''
+  ]
     .filter(Boolean)
     .join('\n\n')
 

--- a/src/agents/eventAssistant/checkinHandler.ts
+++ b/src/agents/eventAssistant/checkinHandler.ts
@@ -18,6 +18,7 @@ import { getChatPromptResponse } from '../helpers/llmChain.js'
 import { getDmGoals } from '../../goals/loader.js'
 import { getEligibleGoals, composeSystemPrompt, getMinContributionMs } from '../helpers/promptComposer.js'
 import config from '../../config/config.js'
+import { resolveTools } from '../tools/resolver.js'
 
 interface AgentLike {
   agentConfig?: { minInterval?: number; [key: string]: unknown }
@@ -263,9 +264,15 @@ async function processParticipant(
       ? formatDmHistoryByChannel(participantDmHistory.messages, [channel])
       : 'No messages yet from this participant.'
 
+  const { tools, promptGuidance } = resolveTools({
+    configuredTools: this.agentConfig?.tools as string[] | undefined,
+    goals: goalsToPursue
+  })
+
   const { behaviorPolicy, conversationContext } = this.conversation
   const personalityName = (this.agentConfig?.personality as string | null | undefined) ?? (config.enableAgentPersonality ? 'sarcastic-expert' : null)
-  const systemPrompt = buildCheckinSystemPrompt(goalsToPursue, behaviorPolicy, conversationContext, personalityName)
+  const baseSystemPrompt = buildCheckinSystemPrompt(goalsToPursue, behaviorPolicy, conversationContext, personalityName)
+  const systemPrompt = promptGuidance ? `${baseSystemPrompt}\n\n${promptGuidance}` : baseSystemPrompt
   const schema = getCheckinDmAnalysisSchema(goalsToPursue)
 
   const analysis = (await detectPrivateInterventionOpportunity.call(
@@ -279,7 +286,8 @@ async function processParticipant(
     { participantPseudonym, thisParticipantHistory, eventSignals },
     goalsToPursue,
     behaviorPolicy,
-    recentTranscript
+    recentTranscript,
+    tools
   )) as unknown as InterventionAnalysis | null
 
   if (!analysis?.directMessage) {

--- a/src/agents/eventAssistant/checkinHandler.ts
+++ b/src/agents/eventAssistant/checkinHandler.ts
@@ -265,7 +265,6 @@ async function processParticipant(
       : 'No messages yet from this participant.'
 
   const { tools, promptGuidance } = resolveTools({
-    configuredTools: this.agentConfig?.tools as string[] | undefined,
     goals: goalsToPursue
   })
 

--- a/src/agents/eventAssistant/eventQuestionHandler.ts
+++ b/src/agents/eventAssistant/eventQuestionHandler.ts
@@ -9,7 +9,7 @@ import config from '../../config/config.js'
 
 import { getModelChat, classificationLLMPlatform, classificationLLMModel } from '../helpers/getModelChat.js'
 import { composeSystemPrompt } from '../helpers/promptComposer.js'
-import { getTools } from '../tools/registry.js'
+import { resolveTools } from '../tools/resolver.js'
 import { TopicRef } from '../tools/eventHistory.js'
 import Topic from '../../models/topic.model.js'
 import {
@@ -408,8 +408,11 @@ export async function answerQuestion(userMessage, conversationHistory, options?)
     }
   }
 
-  const toolNames = series ? [...configuredToolNames, 'event_history'] : configuredToolNames
-  const tools = toolNames.length > 0 ? getTools(toolNames, toolContext) : []
+  const { tools, toolNames } = resolveTools({
+    configuredTools: configuredToolNames,
+    extraTools: series ? ['event_history'] : [],
+    toolContext
+  })
   const hasWebSearch = toolNames.includes('web_search')
 
   const channelType = userMessage?.channels?.includes('chat') ? 'groupChat' : 'dm'

--- a/src/agents/helpers/interventionHandler.ts
+++ b/src/agents/helpers/interventionHandler.ts
@@ -163,7 +163,7 @@ export async function runInterventionAnalysis(
   const renderedUserPrompt = Object.entries(templateVars).reduce(
     (prompt, [key, value]) =>
       // eslint-disable-next-line security/detect-non-literal-regexp
-      prompt.replace(new RegExp(`\\{${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\}`, 'g'), value ?? ''),
+      prompt.replace(new RegExp(`\\{${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\}`, 'g'), () => value ?? ''),
     resolvedUserTemplate
   )
 

--- a/src/agents/helpers/interventionHandler.ts
+++ b/src/agents/helpers/interventionHandler.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod'
+import type { StructuredToolInterface } from '@langchain/core/tools'
 import { BehaviorPolicy, ConversationHistory, ConversationGoal, IChannel } from '../../types/index.types.js'
 import { formatMultiUserConversationHistory, formatDmHistoryByChannel } from './llmInputFormatters.js'
 import transcript from './transcript.js'
-import { getChatPromptResponse } from './llmChain.js'
+import { getChatPromptResponse, getAgentStructuredResponse } from './llmChain.js'
 
 import logger from '../../config/logger.js'
 import { getConfidenceThreshold, getMinContributionMs } from './promptComposer.js'
@@ -118,7 +119,8 @@ export async function runInterventionAnalysis(
   activeGoals?: ConversationGoal[],
   behaviorPolicy?: BehaviorPolicy,
   channelType: 'dm' | 'groupChat' = 'groupChat',
-  recentTranscript?: string
+  recentTranscript?: string,
+  tools?: StructuredToolInterface[]
 ): Promise<InterventionAnalysis | null> {
   // Format conversation histories
   const sharedChatMessages = formatMultiUserConversationHistory(sharedChatHistory)
@@ -158,15 +160,26 @@ export async function runInterventionAnalysis(
     ...extraTemplateVars
   }
 
+  const renderedUserPrompt = Object.entries(templateVars).reduce(
+    (prompt, [key, value]) =>
+      // eslint-disable-next-line security/detect-non-literal-regexp
+      prompt.replace(new RegExp(`\\{${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\}`, 'g'), value ?? ''),
+    resolvedUserTemplate
+  )
+
   const llm = await this.getLLM()
-  const analysis = (await getChatPromptResponse(
-    llm,
-    baseSystemPrompt,
-    resolvedUserTemplate,
-    templateVars,
-    [], // No chat history - we provide full context in the prompt
-    schema
-  )) as z.infer<typeof schema>
+  const analysis = (
+    tools && tools.length > 0
+      ? await getAgentStructuredResponse(llm, tools, baseSystemPrompt, renderedUserPrompt, schema)
+      : await getChatPromptResponse(
+          llm,
+          baseSystemPrompt,
+          resolvedUserTemplate,
+          templateVars,
+          [], // No chat history - we provide full context in the prompt
+          schema
+        )
+  ) as z.infer<typeof schema>
 
   logger.debug(`Intervention opportunity analysis: ${JSON.stringify(analysis, null, 2)}`)
 
@@ -184,13 +197,6 @@ export async function runInterventionAnalysis(
   if (!analysis.shouldIntervene || analysis.confidenceScore < effectiveThreshold) {
     return null
   }
-
-  const renderedUserPrompt = Object.entries(templateVars).reduce(
-    (prompt, [key, value]) =>
-      // eslint-disable-next-line security/detect-non-literal-regexp
-      prompt.replace(new RegExp(`\\{${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\}`, 'g'), value ?? ''),
-    resolvedUserTemplate
-  )
 
   const result = analysis as InterventionAnalysis
   result.context = renderedUserPrompt
@@ -214,7 +220,8 @@ export async function detectPrivateInterventionOpportunity(
   extraTemplateVars?: Record<string, string>,
   activeGoals?: ConversationGoal[],
   behaviorPolicy?: BehaviorPolicy,
-  recentTranscript?: string
+  recentTranscript?: string,
+  tools?: StructuredToolInterface[]
 ): Promise<InterventionAnalysis | null> {
   const now = sharedChatHistory.end ? sharedChatHistory.end.getTime() : Date.now()
   const dmProactivePolicy = behaviorPolicy?.channels?.dm?.proactivePolicy
@@ -244,6 +251,7 @@ export async function detectPrivateInterventionOpportunity(
     activeGoals,
     behaviorPolicy,
     'dm',
-    recentTranscript
+    recentTranscript,
+    tools
   )
 }

--- a/src/agents/proactiveGroupAgent/proactiveGroupAgent.ts
+++ b/src/agents/proactiveGroupAgent/proactiveGroupAgent.ts
@@ -23,6 +23,7 @@ import { getEligibleGoals, getMinContributionMs, composeSystemPrompt } from '../
 import { getGroupChatGoals } from '../../goals/loader.js'
 import validateProfessionalism from '../helpers/professionalismValidator.js'
 import transcript from '../helpers/transcript.js'
+import { resolveTools } from '../tools/resolver.js'
 
 function getProactiveSchema(goals: ConversationGoal[]) {
   const goalIdOptions = [...goals.map((g) => g.id), 'none'] as unknown as [string, ...string[]]
@@ -170,14 +171,20 @@ export default verify({
       return []
     }
 
+    const { tools, promptGuidance } = resolveTools({
+      configuredTools: this.agentConfig?.tools as string[] | undefined,
+      goals: groupChatGoals
+    })
+
     const personalityName = this.agentConfig?.personality ?? null
-    const systemPrompt = composeSystemPrompt(getProactiveGroupSystemPrompt(groupChatGoals), {
+    const baseSystemPrompt = composeSystemPrompt(getProactiveGroupSystemPrompt(groupChatGoals), {
       conversationContext: this.conversation.conversationContext,
       behaviorPolicy: this.conversation.behaviorPolicy,
       goals: groupChatGoals,
       channelType: 'groupChat',
       personalityName
     })
+    const systemPrompt = promptGuidance ? `${baseSystemPrompt}\n\n${promptGuidance}` : baseSystemPrompt
 
     const sharedChatHistory = getConversationHistory(this.conversation.messages, {
       count: 100,
@@ -224,7 +231,8 @@ export default verify({
       groupChatGoals,
       this.conversation.behaviorPolicy,
       'groupChat',
-      recentTranscript
+      recentTranscript,
+      tools
     )) as unknown as InterventionAnalysis | null
 
     if (!analysis) {

--- a/src/agents/tools/registry.ts
+++ b/src/agents/tools/registry.ts
@@ -1,6 +1,6 @@
 import type { StructuredToolInterface } from '@langchain/core/tools'
 import logger from '../../config/logger.js'
-import { webSearchTool } from './webSearch.js'
+import { createWebSearchTool, WEB_SEARCH_USAGE_GUIDANCE } from './webSearch.js'
 import { searchSemanticScholarTool, getSemanticScholarRecommendationsTool } from './semanticScholar.js'
 import createEventHistoryTools from './eventHistory.js'
 
@@ -69,8 +69,12 @@ export function listRegisteredTools(): string[] {
 // Built-in registrations
 // ---------------------------------------------------------------------------
 
-registerTool('tavily_search', () => webSearchTool)
-registerTool('web_search', () => webSearchTool)
+registerTool('tavily_search', (context) => createWebSearchTool(context?.toolConfig?.tavily_search), {
+  promptGuidance: WEB_SEARCH_USAGE_GUIDANCE
+})
+registerTool('web_search', (context) => createWebSearchTool(context?.toolConfig?.web_search), {
+  promptGuidance: WEB_SEARCH_USAGE_GUIDANCE
+})
 registerTool('search_semantic_scholar', () => searchSemanticScholarTool)
 registerTool('get_semantic_scholar_recommendations', () => getSemanticScholarRecommendationsTool)
 

--- a/src/agents/tools/registry.ts
+++ b/src/agents/tools/registry.ts
@@ -12,14 +12,19 @@ import createEventHistoryTools from './eventHistory.js'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ToolFactory = (context?: Record<string, any>) => StructuredToolInterface[] | StructuredToolInterface
 
-const factories = new Map<string, ToolFactory>()
+interface ToolRegistration {
+  factory: ToolFactory
+  promptGuidance?: string
+}
+
+const registrations = new Map<string, ToolRegistration>()
 
 /**
- * Register a tool factory under a given name.
+ * Register a tool factory under a given name, with optional static prompt guidance.
  * Call at module init time — idempotent (last-write wins).
  */
-export function registerTool(name: string, factory: ToolFactory): void {
-  factories.set(name, factory)
+export function registerTool(name: string, factory: ToolFactory, meta?: { promptGuidance?: string }): void {
+  registrations.set(name, { factory, promptGuidance: meta?.promptGuidance })
 }
 
 /**
@@ -30,12 +35,12 @@ export function registerTool(name: string, factory: ToolFactory): void {
 export function getTools(names: string[], context?: Record<string, any>): StructuredToolInterface[] {
   const tools: StructuredToolInterface[] = []
   for (const name of names) {
-    const factory = factories.get(name)
-    if (!factory) {
+    const registration = registrations.get(name)
+    if (!registration) {
       logger.warn(`Tool registry: unknown tool "${name}" — skipping`)
       continue
     }
-    const result = factory(context)
+    const result = registration.factory(context)
     if (Array.isArray(result)) {
       tools.push(...result)
     } else {
@@ -46,10 +51,18 @@ export function getTools(names: string[], context?: Record<string, any>): Struct
 }
 
 /**
+ * Returns a tool's registered static prompt guidance, or '' if none was registered
+ * (or the name is unknown).
+ */
+export function getToolPromptGuidance(name: string): string {
+  return registrations.get(name)?.promptGuidance ?? ''
+}
+
+/**
  * List all registered tool names (useful for diagnostics).
  */
 export function listRegisteredTools(): string[] {
-  return Array.from(factories.keys())
+  return Array.from(registrations.keys())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agents/tools/resolver.ts
+++ b/src/agents/tools/resolver.ts
@@ -1,0 +1,64 @@
+import type { StructuredToolInterface } from '@langchain/core/tools'
+import type { ConversationGoal } from '../../types/index.types.js'
+import { getTools, getToolPromptGuidance } from './registry.js'
+
+export interface ResolveToolsOptions {
+  /** Agent-type-level default tool names, computed by the caller (e.g. from Tavily config). */
+  defaultTools?: string[]
+  /** The agent instance's explicitly configured tools — today's `agentConfig.tools`. */
+  configuredTools?: string[]
+  /** Goals eligible for this turn; each goal's `tools` entries are merged in. */
+  goals?: ConversationGoal[]
+  /** One-off, caller-computed runtime-conditional tool names (e.g. `series ? ['event_history'] : []`). */
+  extraTools?: string[]
+  /** Passed through to tool factories verbatim, alongside the derived `toolConfig` map. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  toolContext?: Record<string, any>
+}
+
+export interface ResolvedTools {
+  tools: StructuredToolInterface[]
+  toolNames: string[]
+  promptGuidance: string
+}
+
+/**
+ * Merges an agent's tool sources into a final tool list, instantiated tools, and combined
+ * prompt guidance. Merge order is default -> configured -> goal-derived -> extra; the first
+ * goal (in `goals` order) to reference a given tool wins on conflicting `config`. Every goal
+ * that references a tool contributes its `usageNotes` (if any), concatenated in goal order.
+ */
+export function resolveTools(options: ResolveToolsOptions): ResolvedTools {
+  const { defaultTools = [], configuredTools = [], goals = [], extraTools = [], toolContext } = options
+
+  const toolConfig: Record<string, Record<string, unknown>> = {}
+  const usageNotesByTool: Record<string, string[]> = {}
+  const goalToolNames: string[] = []
+
+  for (const goal of goals) {
+    for (const ref of goal.tools ?? []) {
+      goalToolNames.push(ref.name)
+      if (ref.config && !(ref.name in toolConfig)) {
+        toolConfig[ref.name] = ref.config
+      }
+      if (ref.usageNotes) {
+        usageNotesByTool[ref.name] = [...(usageNotesByTool[ref.name] ?? []), ref.usageNotes]
+      }
+    }
+  }
+
+  const toolNames = Array.from(new Set([...defaultTools, ...configuredTools, ...goalToolNames, ...extraTools]))
+
+  const tools = toolNames.length > 0 ? getTools(toolNames, { ...toolContext, toolConfig }) : []
+
+  const promptGuidance = toolNames
+    .map((name) => {
+      const staticGuidance = getToolPromptGuidance(name)
+      const notes = usageNotesByTool[name]?.join('\n') ?? ''
+      return [staticGuidance, notes].filter(Boolean).join('\n\n')
+    })
+    .filter(Boolean)
+    .join('\n\n')
+
+  return { tools, toolNames, promptGuidance }
+}

--- a/src/agents/tools/resolver.ts
+++ b/src/agents/tools/resolver.ts
@@ -27,6 +27,13 @@ export interface ResolvedTools {
  * prompt guidance. Merge order is default -> configured -> goal-derived -> extra; the first
  * goal (in `goals` order) to reference a given tool wins on conflicting `config`. Every goal
  * that references a tool contributes its `usageNotes` (if any), concatenated in goal order.
+ *
+ * NOTE: a tool's registered promptGuidance (see registry.ts's registerTool meta param) is
+ * written for whatever agent output-shape first registered it — e.g. web_search's guidance
+ * assumes a free-text Q&A reply. If a goal grants a tool to an agent with a different output
+ * shape (e.g. a structured decision or a private DM), check that the registered guidance
+ * still fits; use a goal's tools[].usageNotes to add or override context-specific instructions
+ * rather than relying on the static guidance alone.
  */
 export function resolveTools(options: ResolveToolsOptions): ResolvedTools {
   const { defaultTools = [], configuredTools = [], goals = [], extraTools = [], toolContext } = options

--- a/src/agents/tools/webSearch.ts
+++ b/src/agents/tools/webSearch.ts
@@ -71,39 +71,69 @@ registerWebSearchProvider(
 // LangChain tool — provider-agnostic
 // ---------------------------------------------------------------------------
 
-export const webSearchTool = tool(
-  async ({ query, maxResults, includeDomains, excludeDomains }) => {
-    const results = await searchWeb({ query, maxResults, includeDomains, excludeDomains })
-    if (results.length === 0) return 'No results found.'
-    return results
-      .map((r, i) => `[${i + 1}] ${r.title}\nURL: ${r.url}\n${r.content}`)
-      .join('\n\n')
-  },
-  {
-    name: 'web_search',
-    description:
-      'Search the public web for facts that are missing, uncertain, time-sensitive, or need verification beyond the event transcript and chat supplied in this request. ' +
-      'Use when the user needs post-knowledge-cutoff updates, verifiable third-party details, or anything you would otherwise infer from memory instead of from cited context. ' +
-      'Returns titled, numbered results with URLs and snippets. **Default:** if unsure whether context alone suffices, call this tool rather than guessing. ' +
-      '**Omit only** when your entire reply will restate or tightly paraphrase information explicitly present in that supplied context and chat, with no material external factual claims. ' +
-      '**When using results:** cite the source title and URL in your response.',
-    schema: z.object({
-      query: z.string().describe('The search query to look up on the web.'),
-      maxResults: z
-        .number()
-        .int()
-        .min(1)
-        .max(20)
-        .default(5)
-        .describe('Maximum number of results to return (default 5, max 20).'),
-      includeDomains: z
-        .array(z.string())
-        .optional()
-        .describe('Optional list of domains to restrict search to, e.g. ["arxiv.org", "nature.com"].'),
-      excludeDomains: z
-        .array(z.string())
-        .optional()
-        .describe('Optional list of domains to exclude from search results.')
-    })
-  }
-)
+export interface WebSearchToolConfig {
+  maxResults?: number
+}
+
+/**
+ * Static, tool-intrinsic guidance on when/how to use web_search — registered on the tool
+ * so any agent that ends up with web_search active gets it automatically (see registry.ts).
+ * Kept under its original exported name via a re-export in buildEventAssistantToolSystemPrompt.ts
+ * so existing tests locking the wording don't need to change.
+ */
+export const WEB_SEARCH_USAGE_GUIDANCE = `**Tools (web search):**
+You have access to \`web_search\` for the public web.
+
+**Default — search first when not certain:** If you cannot **state with certainty** that **every substantive factual claim** in your answer is **directly supported** by the **Context** (recent transcript + retrieved chunks) and the **conversation history** you were given—**not** from training-time memory, knowledge after your cutoff, or guesswork—**you MUST call \`web_search\` at least once before replying**. When you are **uncertain**, **prefer running \`web_search\` over answering without it**; a redundant search is acceptable; **confident guessing or filling gaps from memory is not**.
+
+**Call \`web_search\` when** (non-exhaustive): facts that may have changed after your training cutoff or need "latest" confirmation; statistics, dates, regulations, product or version facts; verifiable claims about the **wider world** the discussion depends on; **incomplete** lists, rosters, or details **mentioned** in the event when the user asks for more than the Context literally contains; anything you would otherwise **infer** without a cited source in Context.
+
+**Do NOT call \`web_search\`** only when you will answer **solely** by summarizing, explaining, or closely paraphrasing what is **explicitly or unambiguously** already in Context + chat, with **no** material reliance on unchecked external facts. **Background Reading chunks in the Context are authoritative sources — treat them the same as transcript context; do not search for information already covered there.**
+
+**IMPORTANT — use tools instead of suggesting sources:** Do NOT tell the user to "check" or "look at" external sites or reports without having called \`web_search\` yourself in this turn—run the search and synthesize what you find.
+
+**If you use \`web_search\`:** Keep queries tightly scoped to the missing or uncertain facts. If results are empty or useless, say so briefly, then answer from Context and clearly-labeled general knowledge.
+
+**Citing web search results (mandatory):** When your response uses information from \`web_search\` results, you MUST attribute it — include the source title and URL inline (e.g. "According to [Title](URL), ...") or as a numbered reference at the end. Never state a fact drawn from search results without citing its source.
+
+**Never narrate your tool decisions in your response.** Do not explain why you did or did not search, or comment on what the context contains. Just answer the question.`
+
+/**
+ * Builds the web_search LangChain tool. `config.maxResults`, when given, becomes the schema's
+ * default maxResults (the LLM can still pass a different value per call).
+ */
+export function createWebSearchTool(toolConfig: WebSearchToolConfig = {}) {
+  return tool(
+    async ({ query, maxResults, includeDomains, excludeDomains }) => {
+      const results = await searchWeb({ query, maxResults, includeDomains, excludeDomains })
+      if (results.length === 0) return 'No results found.'
+      return results.map((r, i) => `[${i + 1}] ${r.title}\nURL: ${r.url}\n${r.content}`).join('\n\n')
+    },
+    {
+      name: 'web_search',
+      description:
+        'Search the public web for facts that are missing, uncertain, time-sensitive, or need verification beyond the event transcript and chat supplied in this request. ' +
+        'Use when the user needs post-knowledge-cutoff updates, verifiable third-party details, or anything you would otherwise infer from memory instead of from cited context. ' +
+        'Returns titled, numbered results with URLs and snippets. **Default:** if unsure whether context alone suffices, call this tool rather than guessing. ' +
+        '**Omit only** when your entire reply will restate or tightly paraphrase information explicitly present in that supplied context and chat, with no material external factual claims. ' +
+        '**When using results:** cite the source title and URL in your response.',
+      schema: z.object({
+        query: z.string().describe('The search query to look up on the web.'),
+        maxResults: z
+          .number()
+          .int()
+          .min(1)
+          .max(20)
+          .default(toolConfig.maxResults ?? 5)
+          .describe(`Maximum number of results to return (default ${toolConfig.maxResults ?? 5}, max 20).`),
+        includeDomains: z
+          .array(z.string())
+          .optional()
+          .describe('Optional list of domains to restrict search to, e.g. ["arxiv.org", "nature.com"].'),
+        excludeDomains: z.array(z.string()).optional().describe('Optional list of domains to exclude from search results.')
+      })
+    }
+  )
+}
+
+export const webSearchTool = createWebSearchTool()

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -357,6 +357,15 @@ export interface TriggerCondition {
   condition: string
 }
 
+export interface GoalToolRef {
+  /** Tool name as registered in the tool registry, e.g. "web_search". */
+  name: string
+  /** Optional per-goal config overrides passed to the tool's factory, e.g. { maxResults: 3 }. */
+  config?: Record<string, unknown>
+  /** Optional goal-specific usage guidance, appended to the tool's default usage guidance. */
+  usageNotes?: string
+}
+
 export interface ConversationGoal {
   id: string
   label: string
@@ -374,6 +383,7 @@ export interface ConversationGoal {
     pollInstructions?: string
   }
   examples: string[]
+  tools?: GoalToolRef[]
 }
 
 export interface ConversationContext {

--- a/tests/agents/helpers/interventionHandler.test.ts
+++ b/tests/agents/helpers/interventionHandler.test.ts
@@ -470,5 +470,37 @@ describe('interventionHandler', () => {
       const callArgs = mockGetAgentStructuredResponse.mock.calls[0]
       expect(callArgs[1]).toEqual([fakeTool])
     })
+
+    it('passes the tools param through detectPrivateInterventionOpportunity to the LLM call', async () => {
+      const fakeTool = { name: 'fake_tool' } as unknown as StructuredToolInterface
+      mockGetAgentStructuredResponse.mockResolvedValue({
+        shouldIntervene: true,
+        reasoning: 'test reasoning',
+        confidenceScore: 90,
+        goalId: 'some_goal'
+      })
+
+      // conversation.startTime is 20 minutes ago (well outside the 2 min default rate
+      // limit) and participantDmHistory has no prior agent messages, so this proceeds
+      // past the rate limiter and reaches runInterventionAnalysis's LLM call.
+      await detectPrivateInterventionOpportunity.call(
+        makeContext(),
+        sharedChatHistory,
+        'system',
+        schema,
+        null,
+        { end: new Date(), messages: [] },
+        'user template {topic}',
+        undefined, // extraTemplateVars
+        undefined, // activeGoals
+        undefined, // behaviorPolicy
+        undefined, // recentTranscript
+        [fakeTool]
+      )
+
+      expect(mockGetAgentStructuredResponse).toHaveBeenCalled()
+      const callArgs = mockGetAgentStructuredResponse.mock.calls[0]
+      expect(callArgs[1]).toEqual([fakeTool])
+    })
   })
 })

--- a/tests/agents/helpers/interventionHandler.test.ts
+++ b/tests/agents/helpers/interventionHandler.test.ts
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals'
+import type { StructuredToolInterface } from '@langchain/core/tools'
 import setupIntTest from '../../utils/setupIntTest.js'
 import type { ConversationGoal } from '../../../src/types/index.types.js'
 
@@ -6,10 +7,13 @@ import type { ConversationGoal } from '../../../src/types/index.types.js'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockGetChatPromptResponse = jest.fn<(...args: any[]) => Promise<any>>()
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetAgentStructuredResponse = jest.fn<(...args: any[]) => Promise<any>>()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockGetTranscript = jest.fn<(...args: any[]) => string>().mockReturnValue('transcript text')
 
 jest.unstable_mockModule('../src/agents/helpers/llmChain.js', () => ({
-  getChatPromptResponse: mockGetChatPromptResponse
+  getChatPromptResponse: mockGetChatPromptResponse,
+  getAgentStructuredResponse: mockGetAgentStructuredResponse
 }))
 
 jest.unstable_mockModule('../src/agents/helpers/transcript.js', () => ({
@@ -405,6 +409,66 @@ describe('interventionHandler', () => {
 
       expect(result).not.toBeNull()
       expect(result!.confidenceScore).toBe(80)
+    })
+  })
+
+  describe('runInterventionAnalysis tools param', () => {
+    function makeContext() {
+      return {
+        name: 'Test Agent',
+        agentType: 'proactiveGroupAgent',
+        _id: 'test-agent-id',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        getLLM: jest.fn<(...args: any[]) => Promise<any>>().mockResolvedValue({}),
+        llmTemplates: { user: undefined },
+        conversation: {
+          name: 'Test Conversation',
+          startTime: new Date(Date.now() - 20 * 60 * 1000),
+          channels: []
+        }
+      }
+    }
+
+    const sharedChatHistory = { end: new Date(), messages: [] }
+    const schema = { parse: jest.fn() } as unknown as import('zod').ZodSchema
+    const analysis = { shouldIntervene: false, reasoning: 'no', confidenceScore: 0 }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('calls getChatPromptResponse, not getAgentStructuredResponse, when no tools are given', async () => {
+      mockGetChatPromptResponse.mockResolvedValue(analysis)
+
+      await runInterventionAnalysis.call(makeContext(), sharedChatHistory, 'system', schema, null, 'user template')
+
+      expect(mockGetChatPromptResponse).toHaveBeenCalled()
+      expect(mockGetAgentStructuredResponse).not.toHaveBeenCalled()
+    })
+
+    it('calls getAgentStructuredResponse, not getChatPromptResponse, when tools are given', async () => {
+      mockGetAgentStructuredResponse.mockResolvedValue(analysis)
+      const fakeTool = { name: 'fake_tool' } as unknown as StructuredToolInterface
+
+      await runInterventionAnalysis.call(
+        makeContext(),
+        sharedChatHistory,
+        'system',
+        schema,
+        null,
+        'user template {topic}',
+        undefined, // extraTemplateVars
+        undefined, // activeGoals
+        undefined, // behaviorPolicy
+        'groupChat',
+        undefined, // recentTranscript
+        [fakeTool]
+      )
+
+      expect(mockGetAgentStructuredResponse).toHaveBeenCalled()
+      expect(mockGetChatPromptResponse).not.toHaveBeenCalled()
+      const callArgs = mockGetAgentStructuredResponse.mock.calls[0]
+      expect(callArgs[1]).toEqual([fakeTool])
     })
   })
 })

--- a/tests/agents/tools/registry.test.ts
+++ b/tests/agents/tools/registry.test.ts
@@ -1,5 +1,5 @@
 import type { StructuredToolInterface } from '@langchain/core/tools'
-import { registerTool, getTools, listRegisteredTools } from '../../../src/agents/tools/registry.js'
+import { registerTool, getTools, listRegisteredTools, getToolPromptGuidance } from '../../../src/agents/tools/registry.js'
 
 describe('Tool Registry', () => {
   test('should have built-in tools registered', () => {
@@ -86,5 +86,21 @@ describe('Tool Registry', () => {
       activeConversationId: '507f1f77bcf86cd799439012'
     })
     expect(tools).toHaveLength(3)
+  })
+
+  test('registerTool accepts optional promptGuidance metadata', () => {
+    registerTool('guidance_test_tool', () => ({ name: 'guidance_test_tool' } as unknown as StructuredToolInterface), {
+      promptGuidance: 'Use guidance_test_tool only when the user asks for it directly.'
+    })
+    expect(getToolPromptGuidance('guidance_test_tool')).toBe('Use guidance_test_tool only when the user asks for it directly.')
+  })
+
+  test('getToolPromptGuidance returns empty string when no guidance was registered', () => {
+    registerTool('no_guidance_tool', () => ({ name: 'no_guidance_tool' } as unknown as StructuredToolInterface))
+    expect(getToolPromptGuidance('no_guidance_tool')).toBe('')
+  })
+
+  test('getToolPromptGuidance returns empty string for an unknown tool name', () => {
+    expect(getToolPromptGuidance('totally_unregistered_tool')).toBe('')
   })
 })

--- a/tests/agents/tools/registry.test.ts
+++ b/tests/agents/tools/registry.test.ts
@@ -92,7 +92,9 @@ describe('Tool Registry', () => {
     registerTool('guidance_test_tool', () => ({ name: 'guidance_test_tool' } as unknown as StructuredToolInterface), {
       promptGuidance: 'Use guidance_test_tool only when the user asks for it directly.'
     })
-    expect(getToolPromptGuidance('guidance_test_tool')).toBe('Use guidance_test_tool only when the user asks for it directly.')
+    expect(getToolPromptGuidance('guidance_test_tool')).toBe(
+      'Use guidance_test_tool only when the user asks for it directly.'
+    )
   })
 
   test('getToolPromptGuidance returns empty string when no guidance was registered', () => {
@@ -102,5 +104,22 @@ describe('Tool Registry', () => {
 
   test('getToolPromptGuidance returns empty string for an unknown tool name', () => {
     expect(getToolPromptGuidance('totally_unregistered_tool')).toBe('')
+  })
+
+  test('web_search factory applies toolConfig.web_search as the maxResults default', () => {
+    const tools = getTools(['web_search'], { toolConfig: { web_search: { maxResults: 2 } } })
+    expect(tools).toHaveLength(1)
+    const parsed = (tools[0] as unknown as { schema: { parse: (v: unknown) => { maxResults: number } } }).schema.parse({
+      query: 'x'
+    })
+    expect(parsed.maxResults).toBe(2)
+  })
+
+  test('web_search factory defaults to maxResults 5 without toolConfig', () => {
+    const tools = getTools(['web_search'])
+    const parsed = (tools[0] as unknown as { schema: { parse: (v: unknown) => { maxResults: number } } }).schema.parse({
+      query: 'x'
+    })
+    expect(parsed.maxResults).toBe(5)
   })
 })

--- a/tests/agents/tools/resolver.test.ts
+++ b/tests/agents/tools/resolver.test.ts
@@ -1,0 +1,109 @@
+import type { StructuredToolInterface } from '@langchain/core/tools'
+import { resolveTools } from '../../../src/agents/tools/resolver.js'
+import { registerTool } from '../../../src/agents/tools/registry.js'
+import type { ConversationGoal } from '../../../src/types/index.types.js'
+
+function makeGoal(overrides: Partial<ConversationGoal> = {}): ConversationGoal {
+  return {
+    id: 'test_goal',
+    label: 'Test Goal',
+    description: 'A goal for resolver tests.',
+    channel: 'groupChat',
+    triggers: { conditions: [], minConfidence: 60 },
+    guardrails: [],
+    outputContract: { format: 'text' },
+    examples: ['example'],
+    ...overrides
+  }
+}
+
+describe('resolveTools', () => {
+  test('returns no tools when nothing is configured', () => {
+    const result = resolveTools({})
+    expect(result.tools).toEqual([])
+    expect(result.toolNames).toEqual([])
+    expect(result.promptGuidance).toBe('')
+  })
+
+  test('merges default, configured, goal-derived, and extra tool names, deduped', () => {
+    const goal = makeGoal({ tools: [{ name: 'web_search' }] })
+    const result = resolveTools({
+      defaultTools: ['web_search'],
+      configuredTools: ['search_semantic_scholar'],
+      goals: [goal],
+      extraTools: ['search_semantic_scholar']
+    })
+    expect(result.toolNames.sort()).toEqual(['search_semantic_scholar', 'web_search'])
+    expect(result.tools.map((t) => t.name).sort()).toEqual(['search_semantic_scholar', 'web_search'])
+  })
+
+  test('unknown tool names are dropped, matching getTools behavior', () => {
+    const result = resolveTools({ configuredTools: ['not_a_real_tool'] })
+    expect(result.toolNames).toEqual(['not_a_real_tool'])
+    expect(result.tools).toEqual([])
+  })
+
+  test('applies a goal tool config override to a config-aware factory', () => {
+    const goal = makeGoal({ tools: [{ name: 'web_search', config: { maxResults: 3 } }] })
+    const result = resolveTools({ goals: [goal] })
+    const webSearch = result.tools.find((t) => t.name === 'web_search') as unknown as {
+      schema: { parse: (v: unknown) => { maxResults: number } }
+    }
+    expect(webSearch.schema.parse({ query: 'x' }).maxResults).toBe(3)
+  })
+
+  test('first goal to reference a tool wins on conflicting config', () => {
+    const goalA = makeGoal({ id: 'goal_a', tools: [{ name: 'web_search', config: { maxResults: 2 } }] })
+    const goalB = makeGoal({ id: 'goal_b', tools: [{ name: 'web_search', config: { maxResults: 9 } }] })
+    const result = resolveTools({ goals: [goalA, goalB] })
+    const webSearch = result.tools.find((t) => t.name === 'web_search') as unknown as {
+      schema: { parse: (v: unknown) => { maxResults: number } }
+    }
+    expect(webSearch.schema.parse({ query: 'x' }).maxResults).toBe(2)
+  })
+
+  test('promptGuidance includes a tool\'s registered static guidance', () => {
+    const goal = makeGoal({ tools: [{ name: 'web_search' }] })
+    const result = resolveTools({ goals: [goal] })
+    expect(result.promptGuidance).toMatch(/search first when not certain/i)
+  })
+
+  test('promptGuidance appends a goal\'s usageNotes after the tool\'s static guidance', () => {
+    const goal = makeGoal({ tools: [{ name: 'web_search', usageNotes: 'Prefer academic sources for this goal.' }] })
+    const result = resolveTools({ goals: [goal] })
+    expect(result.promptGuidance).toMatch(/search first when not certain/i)
+    expect(result.promptGuidance).toContain('Prefer academic sources for this goal.')
+    expect(result.promptGuidance.indexOf('search first')).toBeLessThan(
+      result.promptGuidance.indexOf('Prefer academic sources for this goal.')
+    )
+  })
+
+  test('promptGuidance concatenates usageNotes from multiple goals referencing the same tool', () => {
+    const goalA = makeGoal({ id: 'goal_a', tools: [{ name: 'web_search', usageNotes: 'Note from goal A.' }] })
+    const goalB = makeGoal({ id: 'goal_b', tools: [{ name: 'web_search', usageNotes: 'Note from goal B.' }] })
+    const result = resolveTools({ goals: [goalA, goalB] })
+    expect(result.promptGuidance).toContain('Note from goal A.')
+    expect(result.promptGuidance).toContain('Note from goal B.')
+  })
+
+  test('promptGuidance omits a tool with no registered guidance and no usageNotes', () => {
+    registerTool('resolver_test_no_guidance_tool', () => ({ name: 'resolver_test_no_guidance_tool' } as unknown as StructuredToolInterface))
+    const goal = makeGoal({ tools: [{ name: 'resolver_test_no_guidance_tool' }] })
+    const result = resolveTools({ goals: [goal] })
+    expect(result.promptGuidance).toBe('')
+  })
+
+  test('passes toolContext through to factories alongside the derived toolConfig', () => {
+    let received: Record<string, unknown> | null = null
+    registerTool('resolver_test_context_tool', (ctx) => {
+      received = ctx ?? null
+      return { name: 'resolver_test_context_tool' } as unknown as StructuredToolInterface
+    })
+    const goal = makeGoal({ tools: [{ name: 'resolver_test_context_tool', config: { foo: 'bar' } }] })
+    resolveTools({ goals: [goal], toolContext: { activeConversationId: 'abc123' } })
+    expect(received).toEqual({
+      activeConversationId: 'abc123',
+      toolConfig: { resolver_test_context_tool: { foo: 'bar' } }
+    })
+  })
+})

--- a/tests/agents/tools/webSearch.test.ts
+++ b/tests/agents/tools/webSearch.test.ts
@@ -1,11 +1,14 @@
-import { searchWeb, registerWebSearchProvider } from '../../../src/agents/tools/webSearch.js'
+import {
+  searchWeb,
+  registerWebSearchProvider,
+  createWebSearchTool,
+  webSearchTool
+} from '../../../src/agents/tools/webSearch.js'
 import type { WebSearchResult, WebSearchParams } from '../../../src/agents/tools/webSearch.js'
 
 describe('Web Search Abstraction', () => {
   test('searchWeb delegates to the configured provider', async () => {
-    const mockResults: WebSearchResult[] = [
-      { title: 'Test', url: 'https://example.com', content: 'snippet', score: 0.9 }
-    ]
+    const mockResults: WebSearchResult[] = [{ title: 'Test', url: 'https://example.com', content: 'snippet', score: 0.9 }]
     const mockProvider = jest.fn<Promise<WebSearchResult[]>, [WebSearchParams]>().mockResolvedValue(mockResults)
 
     registerWebSearchProvider('test_provider', () => mockProvider)
@@ -43,5 +46,31 @@ describe('Web Search Abstraction', () => {
   test('tavily provider is registered by default', async () => {
     const config = (await import('../../../src/config/config.js')).default
     expect(config.webSearchProvider).toBe('tavily')
+  })
+})
+
+describe('createWebSearchTool', () => {
+  test('defaults maxResults to 5 when no config is given', () => {
+    const t = createWebSearchTool()
+    const parsed = t.schema.parse({ query: 'x' })
+    expect(parsed.maxResults).toBe(5)
+  })
+
+  test('applies a config override as the schema default', () => {
+    const t = createWebSearchTool({ maxResults: 3 })
+    const parsed = t.schema.parse({ query: 'x' })
+    expect(parsed.maxResults).toBe(3)
+  })
+
+  test('an explicit per-call maxResults still overrides the config default', () => {
+    const t = createWebSearchTool({ maxResults: 3 })
+    const parsed = t.schema.parse({ query: 'x', maxResults: 12 })
+    expect(parsed.maxResults).toBe(12)
+  })
+
+  test('webSearchTool is the no-config default instance', () => {
+    expect(webSearchTool.name).toBe('web_search')
+    const parsed = webSearchTool.schema.parse({ query: 'x' })
+    expect(parsed.maxResults).toBe(5)
   })
 })

--- a/tests/unit/agents/proactiveGroupAgent/proactiveGroupAgent.respond.test.ts
+++ b/tests/unit/agents/proactiveGroupAgent/proactiveGroupAgent.respond.test.ts
@@ -32,7 +32,10 @@ jest.unstable_mockModule('../src/agents/helpers/transcript.js', () => ({
     searchTranscript: mockFn().mockResolvedValue({ chunks: '' }),
     loadEventMetadataIntoVectorStore: mockFn().mockResolvedValue(undefined),
     deleteTranscript: mockFn().mockResolvedValue(undefined)
-  }
+  },
+  // resolveTools -> registry.js -> eventHistory.js imports this named export statically,
+  // so it must be present even though this test never exercises the event_history tool.
+  TOPIC_TRANSCRIPT_COLLECTION_PREFIX: 'topic-transcript'
 }))
 
 const { default: proactiveGroupAgent } = await import('../../../../src/agents/proactiveGroupAgent/proactiveGroupAgent.js')
@@ -261,7 +264,7 @@ describe('proactiveGroupAgent respond', () => {
         expect.any(Date)
       )
       const callArgs = mockRunInterventionAnalysis.mock.calls[0]
-      const recentTranscript = callArgs[callArgs.length - 1] as string
+      const recentTranscript = callArgs[9] as string
       expect(recentTranscript).toBe('Part-time work is the future.')
     })
 
@@ -275,6 +278,34 @@ describe('proactiveGroupAgent respond', () => {
       await proactiveGroupAgent.respond.call(agent, makeConversationHistory(now))
 
       expect(mockGetTranscript).toHaveBeenCalledWith(agent.conversation, 300, expect.any(Date))
+    })
+  })
+
+  describe('tools', () => {
+    it('passes resolved tools through to runInterventionAnalysis when agentConfig.tools is set', async () => {
+      const now = new Date()
+      const agent = makeAgent({ startTime: new Date(now.getTime() - 10 * 60 * 1000) })
+      agent.agentConfig.tools = ['web_search']
+      mockRunInterventionAnalysis.mockResolvedValue(null)
+
+      await proactiveGroupAgent.respond.call(agent, makeConversationHistory(now))
+
+      expect(mockRunInterventionAnalysis).toHaveBeenCalled()
+      const callArgs = mockRunInterventionAnalysis.mock.calls[0]
+      const toolsArg = callArgs[10] as Array<{ name: string }>
+      expect(Array.isArray(toolsArg)).toBe(true)
+      expect(toolsArg.map((t) => t.name)).toContain('web_search')
+    })
+
+    it('passes an empty tools array through when agentConfig.tools is unset', async () => {
+      const now = new Date()
+      const agent = makeAgent({ startTime: new Date(now.getTime() - 10 * 60 * 1000) })
+      mockRunInterventionAnalysis.mockResolvedValue(null)
+
+      await proactiveGroupAgent.respond.call(agent, makeConversationHistory(now))
+
+      const callArgs = mockRunInterventionAnalysis.mock.calls[0]
+      expect(callArgs[10]).toEqual([])
     })
   })
 


### PR DESCRIPTION
## What is in this PR?

Goals can now grant LLM tools to the agents pursuing them. Previously tool access was
wired per-agent-type in ad-hoc ways; this adds a `tools` field to the goal schema so a
goal author can attach tools (e.g. `web_search`) directly to a goal, and centralizes the
merge of an agent's default/configured tools with its currently-eligible goals' tools
behind one `resolveTools()` helper.

## Changes in the codebase

- Add `resolveTools()` (`src/agents/tools/resolver.ts`), which merges an agent's default
  tools, explicitly configured tools, goal-derived tools, and one-off runtime tools into a
  final tool list, instantiated tools, and combined prompt guidance text.
- Add an optional `tools` array to `ConversationGoal` (`GoalToolRef`: `name`, `config`,
  `usageNotes`) and to `goals/schema.json`.
- Let tool registrations carry static prompt guidance (`registerTool(name, factory, {
  promptGuidance })`), surfaced via `getToolPromptGuidance()` and merged with any
  goal-specific `usageNotes` in `resolveTools()`.
- Make `web_search`/`tavily_search` a config-aware factory (`createWebSearchTool`) instead
  of a fixed instance, so per-goal `config` overrides (e.g. `maxResults`) apply.
- Let `runInterventionAnalysis` / `detectPrivateInterventionOpportunity` accept an optional
  `tools` array and route through `getAgentStructuredResponse` when tools are present,
  instead of always using the tool-less `getChatPromptResponse` path.
- Migrate `eventQuestionHandler`, `checkinHandler`, and `proactiveGroupAgent` onto
  `resolveTools()` for their tool resolution.
- Fix a bug where `renderedUserPrompt` (used for the stored intervention `context`) was
  computed from `templateVars` values without stringifying them, and was being
  interpolated in the wrong order relative to the analysis call; also keep
  `checkinHandler` tool-inert by default (only goal-granted tools flow through).
- Note in `CLAUDE.md` to always fill out the PR template when opening a PR.

## Documentation and automated testing

Did you:
- [x] document any breaking changes in your commit messages? (none — `tools` is optional
  and additive)
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

- [ ] `yarn lint && yarn prettier && yarn build`
- [ ] `yarn test` — in particular
      `tests/agents/tools/resolver.test.ts`,
      `tests/agents/tools/registry.test.ts`,
      `tests/agents/tools/webSearch.test.ts`,
      `tests/agents/helpers/interventionHandler.test.ts`,
      `tests/agents/proactiveGroupAgent/proactiveGroupAgent.respond.test.ts`
- [ ] Add a `tools: [{ name: "web_search" }]` entry to a goal in `goals/` and confirm an
      eligible agent (checkin DM, event question, or proactive group) picks up the tool
      and its usage guidance in its system prompt.

## Additional information

Rebased onto current `main` (was previously 4 commits behind) — no other conflicts
besides an import-list conflict in `eventQuestionHandler.ts`, resolved in place.
`yarn lint && yarn prettier && yarn build` all pass post-rebase.

