### PR TITLE
ensure proactiveGroupAgent contributes more when policy set to highlyProactive

### DIFF
--- a/goals/missing_perspective.json
+++ b/goals/missing_perspective.json
@@ -7,19 +7,19 @@
     "conditions": [
       {
         "scope": "participant",
-        "condition": "the transcript contains enough substantive discussion to reasonably infer each distinct speaker's position on the topic — look for speaker attribution inside the transcript text itself (names, self-introductions, turn-taking, diarization-style labels), since an in-person event is usually captured through a single transcription participant carrying every human speaker's turns; do not assume one participant equals one speaker, and do not assume the reverse either — a virtual event may have one participant per panelist"
+        "condition": "enough speakers have spoken in the transcript to give a reasonable picture of the range of views being represented in the room — look for speaker attribution inside the transcript text itself (names, self-introductions, turn-taking, diarization-style labels), since an in-person event is usually captured through a single transcription participant carrying every human speaker's turns; do not assume one participant equals one speaker, and do not assume the reverse either — a virtual event may have one participant per panelist"
       },
       {
         "scope": "participant",
-        "condition": "a genuinely substantive view, counterargument, or framing relevant to the topic is identifiably absent from every speaker's position so far — not a minor nuance, and not something already raised and dropped"
-      },
-      "the room has heard enough from its speakers to make this assessment responsibly — if speaker positions are still forming or too thin to characterize, this is not yet true"
+        "condition": "a genuinely substantive view, counterargument, or framing relevant to the topic is identifiably absent from what speakers have actually said so far — not a minor nuance, and not something already raised and dropped"
+      }
     ],
     "minConfidence": 75
   },
   "guardrails": [
     "base this judgment on the transcript (what speakers have actually said), not the shared chat — chat is peripheral commentary, not the panelists' positions",
     "identify speakers from cues in the transcript content itself first; only fall back to participant/message metadata when the transcript gives no attribution cues",
+    "base the absence judgment on what speakers have actually said in the transcript — do not treat a speaker's known or expected position as already having been stated; only intervene on views that are absent from what has been said, not from what might be said",
     "never claim or imply you are one of the panelists or a real attendee — always frame the contribution as a perspective being deliberately brought into the room from outside it",
     "make clear this is a perspective being deliberately introduced from outside the room — participants should immediately understand it isn't a live attendee speaking; the framing can vary as long as that intent is unambiguous",
     "synthesize into exactly one unified voice — if multiple angles are missing, pick the single most substantive one rather than listing several",

--- a/goals/provoke_participation.json
+++ b/goals/provoke_participation.json
@@ -9,10 +9,10 @@
       "participants are not exchanging messages with each other right now",
       "there is no active back-and-forth among participants at this moment"
     ],
-    "minConfidence": 65
+    "minConfidence": 60
   },
   "guardrails": [
-    "only use when participants are not posting RIGHT NOW — what must be absent is participant-to-participant chat, not speaker content; a speaker actively presenting to a passive audience fully satisfies this trigger",
+    "only use when participants are not posting RIGHT NOW — what must be absent is participant-to-participant chat, not speaker content; a speaker actively presenting to a passive audience fully satisfies this trigger, including during opening introductions or the early minutes of an event before substantive topic discussion has begun",
     "if participants are actively exchanging messages with each other, stay silent — even if the exchange could go deeper, even if a question was just asked that hasn't been answered yet",
     "don't introduce provocation into an already heated exchange",
     "frame as genuine question, not attack",

--- a/src/agents/helpers/promptComposer.ts
+++ b/src/agents/helpers/promptComposer.ts
@@ -35,9 +35,10 @@ const JARGON_LINES: Record<string, string> = {
 }
 
 const INITIATIVE_LINES: Record<string, string> = {
-  lightlyProactive: '- Intervene sparingly — only when the signal is clear',
-  moderatelyProactive: '- Intervene regularly when you see an opportunity',
-  highlyProactive: '- Participate actively and frequently'
+  lightlyProactive: '- Intervene sparingly — only when the trigger is unambiguous and the moment is clearly right',
+  moderatelyProactive: '- Intervene regularly when you see a clear opportunity',
+  highlyProactive:
+    '- Participate actively and frequently. A recent post is not a reason to stay silent — post again whenever there is something genuinely worth saying. Do not wait for participants to respond to a previous post before contributing again; in panel settings people are often listening without typing.'
 }
 
 const QA_SCOPE_LINES: Record<string, string> = {

--- a/src/agents/proactiveGroupAgent/PROACTIVE_GROUP_AGENT.md
+++ b/src/agents/proactiveGroupAgent/PROACTIVE_GROUP_AGENT.md
@@ -37,7 +37,7 @@ A `behaviorPolicy` on the conversation controls how the agent operates:
 
 - **Initiative level** — `passive` (agent stays silent), `lightlyProactive`, `moderatelyProactive`, `highlyProactive`. Passive skips the agent entirely.
 - **Social sensitivity** — `standard` (confidence threshold 60) or `high` (threshold raised to 75 before the agent will post).
-- **Min contribution interval** — How many minutes must pass between the agent's own posts. Defaults to 2. A 20-second grace buffer on the rate limit compensates for LLM execution time between the rate check and message persistence.
+- **Min contribution interval** — How many minutes must pass between the agent's own posts. Defaults to 2. A grace buffer equal to the periodic timer period is subtracted from the rate limit check, so a post from the previous cycle never blocks the next one when `minContributionMinutes` matches the timer period.
 - **Safety posture** — `standard` or `strict`. When strict, proposed messages are passed through a professionalism validator before being sent.
 
 The effective confidence threshold is `max(policyThreshold, max(goal.triggers.minConfidence))` — the most conservative floor across both layers wins.

--- a/src/agents/proactiveGroupAgent/proactiveGroupAgent.ts
+++ b/src/agents/proactiveGroupAgent/proactiveGroupAgent.ts
@@ -65,11 +65,8 @@ JUDGMENT:
 - Intervene only when a trigger condition is clearly and currently true — not potentially true, not soon-to-be-true. "This discussion might stall" is not a trigger. "Participation is currently low with no back-and-forth" is a trigger.
 - If participants are actively exchanging substantive messages with each other, stay quiet. This applies even if you could add something useful — adding to a working discussion is not your role.
 - A speaker actively presenting is not the same as participants being active. If the transcript shows a speaker talking but there are few or no participant messages in chat, that is a passive room — treat it as low participation regardless of how much content the speaker is delivering.
-- Silence is a valid output. Most cycles should produce no intervention.
 - Prioritize the present moment. History is context; act on what just happened.
-- Before posting, check: Have I already said this? Did it land? How recently did I post?
-- Never repeat a theme unless it has meaningfully evolved.
-- Build on posts that got engagement. Drop topics that fell flat.
+- Don't re-raise a theme that has already run its course or that you've made recently without meaningful development since.
 - Vary the goals you apply. Don't overuse any single one.
 
 ## Output Format

--- a/src/agents/proactiveGroupAgent/proactiveGroupAgent.ts
+++ b/src/agents/proactiveGroupAgent/proactiveGroupAgent.ts
@@ -64,7 +64,8 @@ PRIVACY:
 JUDGMENT:
 - Intervene only when a trigger condition is clearly and currently true — not potentially true, not soon-to-be-true. "This discussion might stall" is not a trigger. "Participation is currently low with no back-and-forth" is a trigger.
 - If participants are actively exchanging substantive messages with each other, stay quiet. This applies even if you could add something useful — adding to a working discussion is not your role.
-- A speaker actively presenting is not the same as participants being active. If the transcript shows a speaker talking but there are few or no participant messages in chat, that is a passive room — treat it as low participation regardless of how much content the speaker is delivering.
+- A speaker actively presenting is not the same as participants being active. If the transcript shows a speaker talking but there are few or no participant messages in chat, that is a passive room — consider whether a goal applies rather than waiting for participants to engage first.
+- Do not treat the opening phase of an event as a reason to withhold. A silent room during introductions is a valid state to act on — you do not need to wait for substantive topic discussion to begin before checking whether a goal applies.
 - Prioritize the present moment. History is context; act on what just happened.
 - Don't re-raise a theme that has already run its course or that you've made recently without meaningful development since.
 - Vary the goals you apply. Don't overuse any single one.

--- a/src/agents/proactiveGroupAgent/proactiveGroupAgent.ts
+++ b/src/agents/proactiveGroupAgent/proactiveGroupAgent.ts
@@ -201,9 +201,11 @@ export default verify({
       ? lastGroupIntervention.createdAt!.getTime()
       : new Date(this.conversation.startTime).getTime()
     // Grace buffer accounts for LLM execution time between the rate-limit check and message creation.
-    // Without it, messages created 10-30s after the check causes the next periodic tick to be
-    // slightly under the interval and rate-limit every other invocation.
-    const RATE_LIMIT_GRACE_MS = 20 * 1000
+    // When minInterval equals the timer period, dissolve the check entirely (grace = minInterval)
+    // so every cycle is eligible. When minInterval exceeds the timer period, use a small fixed
+    // buffer for LLM latency only — preserving the intent of the longer minimum.
+    const timerPeriodMs = (this.triggers?.periodic?.timerPeriod ?? 120) * 1000
+    const RATE_LIMIT_GRACE_MS = minInterval <= timerPeriodMs ? minInterval : 30 * 1000
     if (now - baseline < minInterval - RATE_LIMIT_GRACE_MS) {
       logger.debug(
         `${this.name}: Rate limited — last intervention ${Math.round((now - baseline) / 1000)}s ago (min ${

--- a/tests/unit/agents/proactiveGroupAgent/proactiveGroupAgent.respond.test.ts
+++ b/tests/unit/agents/proactiveGroupAgent/proactiveGroupAgent.respond.test.ts
@@ -70,7 +70,7 @@ function makeAgent(
   } = {}
 ) {
   const startTime = overrides.startTime ?? new Date(Date.now() - 20 * 60 * 1000) // 20 min ago
-  const minContributionMinutes = overrides.minContributionMinutes ?? 2
+  const minContributionMinutes = overrides.minContributionMinutes ?? 3 // > timerPeriod (2 min) so grace buffer doesn't dissolve the check
 
   return {
     name: AGENT_NAME,


### PR DESCRIPTION
## What is in this PR?

<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->

This PR improves the responsiveness of the Proactive Group Agent throughout a conversation — making it more willing to act  during quiet moments, passive audiences, and the opening phase of events. Two main problems observed in practice: (1) the  agent over-suppressing itself due to recency bias in its system prompt, holding back even when a clear trigger was present;  and (2) the agent skipping a full cycle after posting because the message timestamp fell just inside the rate limit window due to LLM execution time.   

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->
- Rate limit grace buffer (proactiveGroupAgent.ts): Replaced the fixed 20-second grace buffer with a dynamic one. When minContributionMinutes equals the periodic timer period (both default to 2 min), the grace equals the full interval —    effectively dissolving the rate check so every cycle is eligible. When minContributionMinutes exceeds the timer period, a conservative 30-second buffer applies instead, preserving the intent of the longer minimum.                                   
- System prompt JUDGMENT section (proactiveGroupAgent.ts): Removed instructions that biased the model toward silence throughout the conversation — "Most cycles should produce no intervention," "Before posting, check how recently did I post,"  and "Build on posts that got engagement." Replaced with lighter-touch guidance that treats any quiet or passive moment as a valid state to evaluate, including during introductions and early in the event.                                               
- highlyProactive initiative line (promptComposer.ts): Expanded to explicitly tell the model that a recent post is not a  reason to stay silent and that in panel settings, lack of participant responses does not mean the post fell flat.             
- provoke_participation goal (provoke_participation.json): Lowered minConfidence from 65 → 60. Extended the primary guardrail to explicitly cover opening introductions and early-event minutes, since the model was treating those as a reason to hold  back.                                                                                                                       
- missing_perspective goal (missing_perspective.json): Loosened trigger condition 1 from requiring a fully characterized  position per speaker to "enough speakers to give a reasonable picture of the range of views." Removed a redundant third  condition. Added a guardrail preventing the model from treating a speaker's known or expected position as already stated — only what's in the transcript counts.                     

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ]



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
