### PR TITLE
feat: add BKC Archive Wiki tools to eventHistorian

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -185,6 +185,11 @@ DEFAULT_OPENAI_API_KEY=
 # Which web search provider to use (defaults to 'tavily')
 # WEB_SEARCH_PROVIDER=tavily
 
+
+# (Optional) For BKC archive wiki search tool (used by Event Historian)
+# BKC_ARCHIVE_API_URL=http://localhost:4000
+# BKC_ARCHIVE_API_TOKEN=
+
 # (Optional) Configure which platform and model to use for automated tests
 # TEST_LLM_PLATFORM=
 # TEST_LLM_MODEL=

--- a/src/agents/eventHistorian/eventHistorian.ts
+++ b/src/agents/eventHistorian/eventHistorian.ts
@@ -1,3 +1,4 @@
+import type { StructuredToolInterface } from '@langchain/core/tools'
 import { getAgentStructuredResponse } from '../helpers/llmChain.js'
 import verify from '../helpers/verify.js'
 import { AgentMessageActions, ConversationHistory } from '../../types/index.types.js'
@@ -6,6 +7,7 @@ import { composeSystemPrompt } from '../helpers/promptComposer.js'
 import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
 import { extractMessageText } from '../helpers/slashCommandParser.js'
 import createEventHistoryTools, { TopicRef, buildEventHistoryToolsPrompt } from '../tools/eventHistory.js'
+import { bkcArchiveWikiTools, buildArchiveWikiToolsPrompt } from '../tools/bkcArchiveWiki.js'
 import Topic from '../../models/topic.model.js'
 import Conversation from '../../models/conversation.model.js'
 import config from '../../config/config.js'
@@ -28,6 +30,9 @@ Your primary specialty is answering questions about past events and their transc
 ${buildEventHistoryToolsPrompt()}
 
 When searching, search across all series unless the question clearly refers to a specific one. Don't require the user to specify a series — use your judgment. Prefer \`search_topic_transcripts\` for broad questions; use \`search_conversation_transcript\` to retrieve specific quotes or details once you know which event to drill into. For questions that are clearly unrelated to past events, respond directly without calling any tools.
+
+You are in a live chat — respond promptly. Gather just enough to answer well: one or two searches usually suffice, and never re-run near-identical queries against the same source. Answer as soon as you have the substance.
+${bkcArchiveWikiTools.length > 0 ? `\n\n${buildArchiveWikiToolsPrompt()}` : ''}
 {topicContext}`
 
 function buildTopicContext(topics: TopicRef[]): string {
@@ -102,15 +107,22 @@ export default verify({
       personalityName = 'sarcastic-expert'
     }
 
+    const archiveEnabled = bkcArchiveWikiTools.length > 0
+
     const systemPromptBase = BASE_SYSTEM_PROMPT.replace('{botName}', this.agentConfig.botName).replace(
       '{topicContext}',
       buildTopicContext(topics)
     )
     const systemPrompt = composeSystemPrompt(systemPromptBase, { personalityName })
 
-    const tools = topics.length > 0 ? createEventHistoryTools(topics) : []
+    const tools: StructuredToolInterface[] = topics.length > 0 ? createEventHistoryTools(topics) : []
+    if (archiveEnabled) {
+      tools.push(...bkcArchiveWikiTools)
+    }
 
     // Build message array: chat history + current question
+    // Recursion limit: each tool round-trip costs 2 graph steps; with both event-history
+    // and archive tool sets the agent may need to consult several before answering.
     const response = await getAgentStructuredResponse(
       llm,
       tools,
@@ -118,7 +130,7 @@ export default verify({
       `## Question:\n${question}`,
       undefined,
       chatHistory,
-      10
+      30
     )
 
     const responseChannels = this.conversation.channels.filter((channel) => channel.name === 'historian')

--- a/src/agents/tools/bkcArchiveWiki.ts
+++ b/src/agents/tools/bkcArchiveWiki.ts
@@ -1,0 +1,212 @@
+import { tool } from '@langchain/core/tools'
+import { z } from 'zod'
+import logger from '../../config/logger.js'
+import config from '../../config/config.js'
+
+/**
+ * Tools that connect an agent to the BKC archive wiki API:
+ *:
+ *  - search_archive                 keyword search via GET /v1/search
+ *  - list_archive_wiki_pages        GET /v1/pages
+ *  - read_archive_wiki_page         GET /v1/pages/:section/:slug
+ *  - get_archive_item               GET /v1/items/:id
+ *
+ */
+
+const API_TIMEOUT_MS = 15000
+const API_MAX_RETRIES = 2
+const API_RETRY_BASE_DELAY_MS = 500
+const API_SECTIONS = ['topics', 'people', 'orgs', 'events', 'timeline'] as const
+const API_UNAVAILABLE = 'The archive is not reachable right now. Answer from other sources or try again later.'
+
+export interface ArchiveToolsSource {
+  apiUrl: string
+  apiToken?: string
+}
+
+/** Fetch-with-timeout-and-retry for the archive-wiki API, mirroring tavilySearch.ts's
+ * resilience against transient 429/5xx — one retry on a server error, backoff on rate limit. */
+async function archiveApiRequest(
+  apiUrl: string,
+  apiToken: string | undefined,
+  endpoint: string,
+  init?: { method?: string; body?: unknown }
+): Promise<{ status: number; data } | null> {
+  for (let attempt = 0; attempt <= API_MAX_RETRIES; attempt++) {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
+    try {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (apiToken) headers.Authorization = `Bearer ${apiToken}`
+      const response = await fetch(`${apiUrl.replace(/\/+$/, '')}${endpoint}`, {
+        method: init?.method || 'GET',
+        headers,
+        body: init?.body ? JSON.stringify(init.body) : undefined,
+        signal: controller.signal
+      })
+      if ((response.status === 429 || response.status >= 500) && attempt < API_MAX_RETRIES) {
+        const retryAfter = response.headers.get('Retry-After')
+        const delay = retryAfter ? parseInt(retryAfter, 10) * 1000 : API_RETRY_BASE_DELAY_MS * 2 ** attempt
+        logger.warn(`Archive API ${response.status} (${endpoint}); retrying in ${delay}ms`)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+        continue
+      }
+      const data = await response.json().catch(() => null)
+      return { status: response.status, data }
+    } catch (error) {
+      logger.warn(`Archive API request failed (${endpoint}): ${error.message}`)
+      return null
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+  return null
+}
+
+function apiErrorText(result: { status: number; data }): string | null {
+  if (result.status === 401) return 'The archive API rejected the configured credentials (check ARCHIVE_API_TOKEN).'
+  if (result.status >= 400) return result.data?.message || `Archive API error (HTTP ${result.status}).`
+  return null
+}
+
+function createArchiveApiTools(apiUrl: string, apiToken?: string) {
+  const searchArchiveTool = tool(
+    async ({ query, section }) => {
+      const params = new URLSearchParams({ q: query, limit: '10' })
+      if (section) params.set('section', section)
+      const result = await archiveApiRequest(apiUrl, apiToken, `/v1/search?${params}`)
+      if (!result) return API_UNAVAILABLE
+      const error = apiErrorText(result)
+      if (error) return error
+      const results = result.data?.results || []
+      if (results.length === 0) return 'No relevant archive content found.'
+      return results
+        .map((r) => {
+          const ref = r.id ? `item ${r.id}` : `${r.section}/${r.slug}`
+          return `- [${ref}] "${r.title}"\n  ${r.snippet}`
+        })
+        .join('\n')
+    },
+    {
+      name: 'search_archive',
+      description:
+        'Keyword search across the BKC archive wiki: curated topic/people/org/event/timeline pages and all archive ' +
+        'item stubs. Use this for content questions about what the archive holds. Results reference either an item id ' +
+        '(drill in with get_archive_item) or a wiki page as section/slug (open with read_archive_wiki_page). ' +
+        'This is exact-term matching, not semantic search — prefer concrete names and terms over paraphrases.',
+      schema: z.object({
+        query: z.string().describe('The search query, e.g. "content moderation", "Zittrain Polymarket"'),
+        section: z
+          .enum([...API_SECTIONS, 'items'])
+          .optional()
+          .describe('Limit results to one section, or "items" for archive item stubs. Omit to search everything.')
+      })
+    }
+  )
+
+  const listWikiPagesTool = tool(
+    async ({ section }) => {
+      const result = await archiveApiRequest(apiUrl, apiToken, `/v1/pages${section ? `?section=${section}` : ''}`)
+      if (!result) return API_UNAVAILABLE
+      const error = apiErrorText(result)
+      if (error) return error
+      const pages = result.data?.pages || []
+      if (pages.length === 0) return 'No wiki pages found.'
+      return pages
+        .map((p) => {
+          const extras = [
+            p.meta?.item_count ? `${p.meta.item_count} items` : null,
+            p.meta?.related ? `related: ${p.meta.related}` : null,
+            p.meta?.related_topics ? `topics: ${p.meta.related_topics}` : null,
+            p.meta?.affiliations ? `affiliations: ${p.meta.affiliations}` : null
+          ]
+            .filter(Boolean)
+            .join(' | ')
+          return `- [${p.section}] ${p.slug} — "${p.title}"${extras ? ` (${extras})` : ''}`
+        })
+        .join('\n')
+    },
+    {
+      name: 'list_archive_wiki_pages',
+      description:
+        'List the curated archive-wiki pages: thematic topic pages, people, organizations, events, and per-year ' +
+        'timeline narratives. Use this first to route a question about a theme, person, org, or era to the right ' +
+        'page, then call read_archive_wiki_page with the slug.',
+      schema: z.object({
+        section: z
+          .enum([...API_SECTIONS])
+          .optional()
+          .describe('Limit to one section: topics, people, orgs, events, or timeline. Omit to list all.')
+      })
+    }
+  )
+
+  const readWikiPageTool = tool(
+    async ({ slug, section }) => {
+      const endpoint = section ? `/v1/pages/${section}/${encodeURIComponent(slug)}` : `/v1/pages/${encodeURIComponent(slug)}`
+      const result = await archiveApiRequest(apiUrl, apiToken, endpoint)
+      if (!result) return API_UNAVAILABLE
+      if (result.status === 404) {
+        return `No wiki page found for slug "${slug}". Use list_archive_wiki_pages to see valid slugs.`
+      }
+      const error = apiErrorText(result)
+      if (error) return error
+      return result.data?.markdown || 'The page is empty.'
+    },
+    {
+      name: 'read_archive_wiki_page',
+      description:
+        'Read one curated archive-wiki page by slug (from list_archive_wiki_pages or search_archive). Pages link to ' +
+        'archive items as wiki-links like [[<itemId>-<slug>|Title]] — pass that leading itemId (e.g. "17120704" or ' +
+        '"yt_BSt010su3rU") to get_archive_item to retrieve the underlying source material.',
+      schema: z.object({
+        slug: z.string().describe('The page slug, e.g. "ai-governance-and-regulation" or "jonathan-zittrain"'),
+        section: z
+          .enum([...API_SECTIONS])
+          .optional()
+          .describe('Which section the slug is in, if known. Omit to search all sections.')
+      })
+    }
+  )
+
+  const getArchiveItemTool = tool(
+    async ({ id }) => {
+      const result = await archiveApiRequest(apiUrl, apiToken, `/v1/items/${encodeURIComponent(id)}`)
+      if (!result) return API_UNAVAILABLE
+      if (result.status === 404) {
+        return `No archive item found with id "${id}". Ids come from wiki-links ([[<id>-<slug>|...]]) or search_archive results.`
+      }
+      const error = apiErrorText(result)
+      if (error) return error
+      return result.data?.markdown || 'The item is empty.'
+    },
+    {
+      name: 'get_archive_item',
+      description:
+        'Retrieve one archive item by id: its stub metadata plus the full source material when available ' +
+        '(YouTube transcript for "yt_..." ids, article/newsletter full text for numeric ids). Use ids surfaced ' +
+        'by read_archive_wiki_page wiki-links or search_archive results.',
+      schema: z.object({
+        id: z.string().describe('The archive item id, e.g. "17120704" or "yt_BSt010su3rU". Not the title.')
+      })
+    }
+  )
+
+  return [searchArchiveTool, listWikiPagesTool, readWikiPageTool, getArchiveItemTool]
+}
+
+export const bkcArchiveWikiTools = config.bkcArchive.apiUrl
+  ? createArchiveApiTools(config.bkcArchive.apiUrl, config.bkcArchive.apiToken)
+  : []
+
+export function buildArchiveWikiToolsPrompt(): string {
+  return `**Archive tools:**
+You also have access to the BKC archive — a curated collection of video transcripts, articles, newsletters, and bookmarked items, organized by a wiki of topic, people, org, and timeline pages.
+
+- \`search_archive\`: keyword search across all archive content — use for questions about what the archive holds (talks, writings, coverage of a subject); prefer concrete names and terms over paraphrases
+- \`list_archive_wiki_pages\`: list the curated wiki pages — use to route a thematic question (a topic, person, organization, or era) to the right page
+- \`read_archive_wiki_page\`: read one wiki page; its wiki-links carry archive item ids
+- \`get_archive_item\`: fetch one item's metadata plus full source material (transcript or article text) by id
+
+For direct content questions, go straight to \`search_archive\`. For thematic or survey questions ("what does the archive have on X", questions about a person/org/era), route through the wiki: \`list_archive_wiki_pages\` → \`read_archive_wiki_page\` → \`get_archive_item\` for the sources you need. Cite items by title, date, and URL. Event transcripts (the tools above) and the archive are different bodies of material — talks, videos, interviews, articles, and newsletters usually live in the archive. Budget your tool calls: if an event-history search returns nothing relevant, switch to \`search_archive\` instead of retrying variations of the same search.`
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -127,6 +127,8 @@ const envVarsSchema = Joi.object()
     WEB_SEARCH_PROVIDER: Joi.string()
       .default('tavily')
       .description('Web search provider to use (e.g. tavily, brave, serpapi)'),
+    BKC_ARCHIVE_API_URL: Joi.string().description('Base URL of the BKC archive-wiki API (e.g. http://localhost:4000).'),
+    BKC_ARCHIVE_API_TOKEN: Joi.string().description('Bearer token for the BKC archive-wiki API'),
     CONVERSATION_AUTO_START_LEAD_TIME_MINUTES: Joi.number()
       .default(5)
       .description('Minutes before scheduledTime to auto-start a conversation'),
@@ -281,6 +283,10 @@ const config = {
   },
   tavily: {
     apiKey: envVars.TAVILY_API_KEY
+  },
+  bkcArchive: {
+    apiUrl: envVars.BKC_ARCHIVE_API_URL,
+    apiToken: envVars.BKC_ARCHIVE_API_TOKEN
   },
   webSearchProvider: envVars.WEB_SEARCH_PROVIDER,
   conversation: {

--- a/src/handlers/helpers/findSlackAdapter.ts
+++ b/src/handlers/helpers/findSlackAdapter.ts
@@ -47,10 +47,18 @@ export default async function findSlackAdapter({
   const event = payload?.event
   if (!event?.team) return null
 
+  // Only route to the active adapter. Failed/old conversations can leave inactive
+  // adapter docs for the same channel+workspace; without this filter findOne may
+  // return a stale inactive one (insertion order) and the message is silently dropped.
   if (event.channel_type === 'im') {
-    return Adapter.findOne({ type: 'slack', 'config.channel': 'direct', 'config.workspace': event.team })
+    return Adapter.findOne({ type: 'slack', 'config.channel': 'direct', 'config.workspace': event.team, active: true })
   }
 
   if (!event.channel) return null
-  return Adapter.findOne({ type: 'slack', 'config.channel': event.channel, 'config.workspace': event.team })
+  return Adapter.findOne({
+    type: 'slack',
+    'config.channel': event.channel,
+    'config.workspace': event.team,
+    active: true
+  })
 }

--- a/src/handlers/slackInteraction.ts
+++ b/src/handlers/slackInteraction.ts
@@ -89,8 +89,8 @@ async function receiveInteraction(rawPayload: unknown): Promise<void> {
 
   const slackAdapter = await Adapter.findOne(
     isIM
-      ? { type: 'slack', 'config.channel': 'direct', 'config.workspace': payload.team.id }
-      : { type: 'slack', 'config.channel': resolvedChannelId, 'config.workspace': payload.team.id }
+      ? { type: 'slack', 'config.channel': 'direct', 'config.workspace': payload.team.id, active: true }
+      : { type: 'slack', 'config.channel': resolvedChannelId, 'config.workspace': payload.team.id, active: true }
   )
 
   if (!slackAdapter) {

--- a/tests/agents/tools/bkcArchiveWiki.test.ts
+++ b/tests/agents/tools/bkcArchiveWiki.test.ts
@@ -1,0 +1,112 @@
+/* eslint-disable no-console */
+import { bkcArchiveWikiTools } from '../../../src/agents/tools/bkcArchiveWiki.js'
+
+jest.setTimeout(20000)
+
+describe('BKC Archive Wiki Tools Integration', () => {
+  const hasApiUrl = !!process.env.BKC_ARCHIVE_API_URL
+
+  ;(hasApiUrl ? describe : describe.skip)('archive tools (requires BKC_ARCHIVE_API_URL)', () => {
+    let searchTool
+    let listPagesTool
+    let readPageTool
+    let getItemTool
+
+    beforeAll(() => {
+      expect(bkcArchiveWikiTools).toHaveLength(4)
+      ;[searchTool, listPagesTool, readPageTool, getItemTool] = bkcArchiveWikiTools
+    })
+
+    describe('search_archive', () => {
+      test('returns results for a basic query', async () => {
+        const result = await searchTool.invoke({ query: 'internet governance' })
+        console.log('search_archive (internet governance):', result)
+
+        expect(typeof result).toBe('string')
+        expect(result).not.toBe('The archive is not reachable right now. Answer from other sources or try again later.')
+        expect(result).not.toBe('No relevant archive content found.')
+      })
+
+      test('returns a no-results message for a nonsense query', async () => {
+        const result = await searchTool.invoke({ query: 'xyzzy123nonsense987qwerty' })
+        console.log('search_archive (nonsense query):', result)
+
+        expect(typeof result).toBe('string')
+        expect(result).toBe('No relevant archive content found.')
+      })
+
+      test('accepts an optional section filter', async () => {
+        const result = await searchTool.invoke({ query: 'privacy', section: 'topics' })
+        console.log('search_archive (privacy, topics):', result)
+
+        expect(typeof result).toBe('string')
+      })
+
+      test('throws on invalid section filter', async () => {
+        await expect(searchTool.invoke({ query: 'privacy', section: 'sandwiches' })).rejects.toThrow()
+      })
+    })
+
+    describe('list_archive_wiki_pages', () => {
+      test('lists pages without a section filter', async () => {
+        const result = await listPagesTool.invoke({})
+        console.log('list_archive_wiki_pages (all):', result)
+
+        expect(typeof result).toBe('string')
+        expect(result).not.toBe('The archive is not reachable right now. Answer from other sources or try again later.')
+        expect(result).not.toBe('No wiki pages found.')
+      })
+
+      test('lists pages for a specific section', async () => {
+        const result = await listPagesTool.invoke({ section: 'topics' })
+        console.log('list_archive_wiki_pages (topics):', result)
+
+        expect(typeof result).toBe('string')
+        expect(result).not.toBe('No wiki pages found.')
+      })
+
+      test('throws on invalid section filter', async () => {
+        await expect(listPagesTool.invoke({ section: 'sandwiches' })).rejects.toThrow()
+      })
+    })
+
+    describe('read_archive_wiki_page', () => {
+      test('returns a not-found message for an unknown slug', async () => {
+        const result = await readPageTool.invoke({ slug: 'this-slug-does-not-exist-xyzzy' })
+        console.log('read_archive_wiki_page (unknown slug):', result)
+
+        expect(typeof result).toBe('string')
+        expect(result).toContain('No wiki page found')
+      })
+      test('returns a wiki page with a known slug', async () => {
+        const result = await readPageTool.invoke({ slug: 'jonathan-zittrain' })
+        console.log('read_archive_wiki_page (known slug):', result)
+
+        expect(typeof result).toBe('string')
+        expect(result).not.toContain('No wiki page found')
+      })
+    })
+
+    describe('get_archive_item', () => {
+      test('returns a not-found message for an unknown id', async () => {
+        const result = await getItemTool.invoke({ id: 'nonexistent-item-id-xyzzy' })
+        console.log('get_archive_item (unknown id):', result)
+
+        expect(typeof result).toBe('string')
+        expect(result).toContain('No archive item found')
+      })
+      test('returns a result for known id', async () => {
+        const result = await getItemTool.invoke({ id: '2461702' })
+        console.log('get_archive_item (known id):', result)
+
+        expect(typeof result).toBe('string')
+        expect(result).not.toContain('No archive item found')
+      })
+    })
+  })
+  ;(!hasApiUrl ? describe : describe.skip)('archive tools (no BKC_ARCHIVE_API_URL)', () => {
+    test('bkcArchiveWikiTools is an empty array', () => {
+      expect(bkcArchiveWikiTools).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## What is in this PR?

<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->

Two independent fixes:                                                                                            
                                                                                                                    
  1. BKC Archive Wiki tools for Event Historian — the Event Historian agent can now search and read from the BKC    
  archive wiki API when configured, giving it access to curated topic, people, org, and timeline pages alongside its
   existing event transcript tools.                                                                                 
  2. Slack adapter scoping fix — Slack events and interactions are now routed only to adapters that are active on   
  the current conversation, preventing stale or unrelated adapters from handling messages.

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

 src/agents/tools/bkcArchiveWiki.ts (new file)
  Four LangChain tools wrapping the archive wiki API: search_archive, list_archive_wiki_pages,                      
  read_archive_wiki_page, and get_archive_item. Tools are instantiated once at module load from config.bkcArchive 
  (following the same pattern as webSearchTool) and exported as bkcArchiveWikiTools. A buildArchiveWikiToolsPrompt()
   export provides the system prompt section describing the tools, mirroring buildEventHistoryToolsPrompt in
  eventHistory.ts. Includes timeout, retry, and rate-limit backoff logic.                                           
   
  src/agents/eventHistorian/eventHistorian.ts                                                                       
  Adds the archive tools to the historian's tool list and injects the archive prompt section when                 
  BKC_ARCHIVE_API_URL is configured.                                                     
   
  src/config/config.ts / .env.example                                                                               
  Added BKC_ARCHIVE_API_URL and BKC_ARCHIVE_API_TOKEN env vars.                                                   
                                                                                                                    
  src/handlers/helpers/findSlackAdapter.ts / src/handlers/slackInteraction.ts                                     
  Scoped adapter lookup to only active adapters on the relevant conversation, fixing a bug where Slack events could
  be routed to adapters from older test conversations.                                                                   
                                         

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [x] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Run the BKC Archive Wiki process locally
- [ ] Update .env to set BKC_ARCHIVE_API_URL=[url]
- [ ] Run llm_engine and create a test Slack eventHistorian convo using Hoppscotch, pointing to a test Slack channel
- [ ] Ask questions of both the archive and any NS events
- [ ] Shut down the local BKC Archive Wiki process
- [ ] Ask a question in Slack - verify error is logged but response is still received and can still query NS events
- [ ] Comment out BKC_ARCHIVE_API_URL and restart. Ensure Slack channel still works to ask about NS events and no errors logged



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
