### PR TITLE
Fix: Backfill agent triggers on load so existing agents respond to messages

### DIFF
--- a/src/agents/helpers/agentEvaluationService.ts
+++ b/src/agents/helpers/agentEvaluationService.ts
@@ -4,9 +4,13 @@ import { IChannel } from '../../types/index.types.js'
 export default class AgentEvaluationService {
   static async evaluateMessage(agent, userMessage, messageCount) {
     // Disallow processing messages from agents (including self) unless explicitly opted in
-    if (userMessage.fromAgent && !agent.triggers?.perMessage?.allowMessagesFromAgents) return false
+    if (userMessage.fromAgent && !agent.triggers?.perMessage?.allowMessagesFromAgents) {
+      logger.debug(`evaluateMessage: skipping message from agent for ${agent.agentType} ${agent._id}`)
+      return false
+    }
 
     if (userMessage && !agent.triggers?.perMessage) {
+      logger.debug(`evaluateMessage: no perMessage trigger for ${agent.agentType} ${agent._id}`)
       return false
     }
 
@@ -24,6 +28,7 @@ export default class AgentEvaluationService {
 
       // Either no matching channels in channel trigger or no supported DM channels
       if (matchingChannels.length === 0 && directChannels.length === 0) {
+        logger.debug(`evaluateMessage: no matching channels for ${agent.agentType} ${agent._id}`)
         return false
       }
     }

--- a/src/models/user.model/agent.model/index.ts
+++ b/src/models/user.model/agent.model/index.ts
@@ -495,7 +495,7 @@ agentSchema.pre('validate', function () {
     ...instanceConfig,
     ...(typeConfig.goalPriorities !== undefined || instanceConfig.goalPriorities !== undefined
       ? { goalPriorities: { ...(typeConfig.goalPriorities ?? {}), ...(instanceConfig.goalPriorities ?? {}) } }
-      : {}),
+      : {})
   }
   // ensure a botName exists
   if (!this.agentConfig!.botName) this.agentConfig!.botName = config.conversationBotName
@@ -528,6 +528,11 @@ agentSchema.post('init', function () {
   }
   if (this.description === undefined) {
     this.description = agentTypes[this.agentType]?.description || 'N/A'
+  }
+  // Backfills agents saved before their type defined triggers, mirroring pre('validate') so the
+  // perMessage gate still fires. Optional chaining survives retired agentTypes.
+  if (this.triggers === undefined) {
+    this.triggers = agentTypes[this.agentType]?.defaultTriggers
   }
 })
 

--- a/tests/models/agent.model.test.ts
+++ b/tests/models/agent.model.test.ts
@@ -222,6 +222,20 @@ describe('agent tests', () => {
     expect(agent.conversationHistorySettings).toBe(testAgentTypes.perMessageWithMin.defaultConversationHistorySettings)
   })
 
+  test('should backfill triggers from agent type when loading a doc saved without them', async () => {
+    // An agent saved before its type defined defaultTriggers has no triggers field. Loading must
+    // restore the default, or evaluateMessage's perMessage gate silently rejects every message.
+    const agent = new Agent({ agentType: 'perMessageWithMin', conversation })
+    await agent.save()
+
+    // Strip triggers directly through the driver to bypass the model's save hooks,
+    // leaving the legacy on-disk shape a fresh load has to cope with.
+    await Agent.collection.updateOne({ _id: agent._id }, { $unset: { triggers: '' } })
+
+    const reloaded = await Agent.findById(agent._id)
+    expect(reloaded!.triggers).toEqual(testAgentTypes.perMessageWithMin.defaultTriggers)
+  })
+
   test('should introduce itself on a specified channel', async () => {
     const agent = new Agent({
       agentType: 'perMessageWithMin',


### PR DESCRIPTION
## What is in this PR?

Every agent in this repo (the chatbot, the Event Historian, the Vibes Analyst, and the rest) carries a list of triggers on its stored record, which is what says when that agent is allowed to act: on every message, at the start of an event, on a schedule. When a message comes in, the evaluation path reads that stored list to decide whether the agent even looks at the message, so an agent whose record has no triggers silently ignores everything. Until now the defaults for an agent type were only filled in when a record was saved, never when one was loaded, so any agent created before its type declared defaults has been sitting in that dead state. This fills them in on load as well, which brings those agents back without anyone editing the database. It also adds debug logging at each point where the evaluation path can drop a message, which is the part that made this hard to track down.

## Changes in the codebase

- An agent record now picks up its type's default triggers when it loads without any, matching what already happened on save. The fix runs in memory each time a record is read, so nothing in the database changes and no migration is needed.
- An agent type with no declared defaults, or one that has since been retired from the registry, is left alone rather than throwing.
- The message evaluation path logs each of its early returns at debug level, so a message that gets dropped leaves a trace instead of vanishing.

## Documentation and automated testing

Did you:
- [x] document any breaking changes in your commit messages? (none: this restores intended behavior)
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [x] update team documentation of any new or changed environment variables? (none added)

## Testing this PR

You need an agent whose stored record has no `triggers` field, which is the broken state this fixes. The quickest way to get one is to install any agent, then unset that field on its record directly in the database.

- [ ] On `main`, send a message in that agent's channel that should provoke a response. It stays silent.
- [ ] On this branch, restart the server and send the same message. The agent responds.
- [ ] Confirm an agent that already had triggers stored behaves exactly as before.

## Additional information
The new log lines are `logger.debug`, and the logger defaults to `info` outside development, so they only show up with `LOG_LEVEL=debug`. That is for watching the fix work, not for enabling it.

Merge this before the Vibes Analyst enrichment PR ([#245](https://github.com/berkmancenter/llm_engine/pull/245)). That PR's behavior sits behind this same trigger check, so shipping it first against an agent record in the broken state would make it look like nothing changed.