### PR TITLE
feat: add scorekeeper agent with nightly LangSmith quality report cards

### DIFF
--- a/scripts/checkScorekeeperSlack.ts
+++ b/scripts/checkScorekeeperSlack.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Smoke-tests the Scorekeeper's Slack integration end to end.
+ *
+ * Resolves the scorekeeper's Slack adapter, fetches real feedback scores
+ * from LangSmith for the given conversation, renders the quality report card,
+ * and posts it to Slack.
+ *
+ * Flags:
+ *   --conversation=<id>         Required. The conversation that hosts the scorekeeper and Slack adapter.
+ *   --target-conversation=<id>  Required. The conversation to fetch LangSmith scores for.
+ *   --dry-run                   Fetch scores and render the card, but do not post to Slack.
+ *
+ * Usage:
+ *   NODE_ENV=development node --loader ts-node/esm scripts/checkScorekeeperSlack.ts --conversation=<id> --target-conversation=<id>
+ */
+/* eslint-disable no-console */
+
+import mongoose from 'mongoose'
+import { pathToFileURL } from 'url'
+import { WebClient } from '@slack/web-api'
+import Conversation from '../src/models/conversation.model.js'
+import config from '../src/config/config.js'
+import Adapter from '../src/models/adapter.model.js'
+import Agent from '../src/models/user.model/agent.model/index.js'
+import renderResponseBlocks from '../src/adapters/slack/blocks/index.js'
+import { fetchQualityScores } from '../src/agents/scorekeeper/fetchQualityScores.js'
+import type { QualityReportData } from '../src/types/index.types.js'
+
+async function main() {
+  const conversationId = process.argv.find((a) => a.startsWith('--conversation='))?.split('=')[1]
+  const targetConversationId = process.argv.find((a) => a.startsWith('--target-conversation='))?.split('=')[1]
+  const dryRun = process.argv.includes('--dry-run')
+
+  if (!conversationId || !targetConversationId) {
+    console.error(
+      'Usage: node --loader ts-node/esm scripts/checkScorekeeperSlack.ts --conversation=<id> --target-conversation=<id>'
+    )
+    process.exit(1)
+  }
+
+  mongoose.set('strict', true)
+  await mongoose.connect(config.mongoose.url, config.mongoose.options)
+  console.log('Connected to MongoDB.')
+
+  try {
+    const agent = await Agent.findOne({ agentType: 'scorekeeper', conversation: conversationId }).exec()
+    if (!agent) {
+      throw new Error(`No scorekeeper found for conversation ${conversationId}.`)
+    }
+
+    const adapter = await Adapter.findOne({ conversation: conversationId, type: 'slack' }).exec()
+    if (!adapter) {
+      throw new Error(`No Slack adapter found for conversation ${conversationId}.`)
+    }
+    const cfg = (adapter.config ?? {}) as Record<string, string>
+    if (!cfg.botToken) throw new Error('Slack adapter has no botToken.')
+    if (!cfg.channel) throw new Error('Slack adapter has no channel.')
+
+    const targetConversation = await Conversation.findById(targetConversationId).select('name').lean()
+    const conversationName = targetConversation?.name ?? targetConversationId
+
+    console.log(`Fetching LangSmith scores for conversation ${conversationName} (${targetConversationId})…`)
+    const scores = await fetchQualityScores(targetConversationId)
+    if (!scores) {
+      throw new Error(
+        'No feedback scores found in LangSmith for this conversation. Is tracing enabled and are there scored traces?'
+      )
+    }
+    console.log(
+      `Found scores for ${scores.tracesScored} traces across ${
+        scores.evaluators.length
+      } evaluators. Overall: ${scores.overallMean.toFixed(2)}`
+    )
+
+    const renderData: QualityReportData = {
+      conversationName,
+      conversationId: targetConversationId,
+      evaluators: scores.evaluators,
+      overallMean: scores.overallMean,
+      tracesScored: scores.tracesScored,
+      lowScoreTraces: scores.lowScoreTraces,
+      totalLowScoreCount: scores.totalLowScoreCount,
+      generatedAt: new Date().toISOString()
+    }
+
+    const blocks = renderResponseBlocks('qualityReport', renderData)
+    if (!blocks?.length) throw new Error('Quality report card renderer returned no blocks.')
+    console.log(`Rendered quality report card: ${blocks.length} Block Kit blocks.`)
+
+    if (dryRun) {
+      console.log('\n✔ Dry run: scores fetched and card rendered. No Slack call made.')
+      return
+    }
+
+    const slack = new WebClient(cfg.botToken)
+    const result = await slack.chat.postMessage({
+      channel: cfg.channel,
+      text: `Quality report: overall ${scores.overallMean.toFixed(2)} across ${scores.tracesScored} traces`,
+      blocks
+    })
+    console.log(`\n✔ Quality report card posted to ${cfg.channel} (ts ${result.ts}). Check the channel in Slack.`)
+  } finally {
+    await mongoose.connection.close()
+    console.log('\nConnection closed.')
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(`\n✗ ${err instanceof Error ? err.message : err}`)
+      process.exit(1)
+    })
+}

--- a/src/adapters/slack/blocks/index.ts
+++ b/src/adapters/slack/blocks/index.ts
@@ -1,8 +1,9 @@
 import type { KnownBlock } from '@slack/types'
-import { CuratedVibesData, BudgetAlertData, ConversationCostData } from '../../../types/index.types.js'
+import { CuratedVibesData, BudgetAlertData, ConversationCostData, QualityReportData } from '../../../types/index.types.js'
 import renderCuratedVibesCard from './vibesAnalyst/curatedCard.js'
 import renderBudgetAlertCard from './numberCruncher/budgetAlertCard.js'
 import renderConversationCostCard from './numberCruncher/conversationCostCard.js'
+import renderQualityReportCard from './scorekeeper/qualityReportCard.js'
 
 /* Maps an agent response's responseKind to the renderer that turns its neutral
    renderData into Slack Block Kit. Add an entry here when an agent introduces a
@@ -10,7 +11,8 @@ import renderConversationCostCard from './numberCruncher/conversationCostCard.js
 const renderers: Record<string, (renderData: unknown) => KnownBlock[]> = {
   curatedVibesSummary: (renderData) => renderCuratedVibesCard(renderData as CuratedVibesData),
   budgetAlert: (renderData) => renderBudgetAlertCard(renderData as BudgetAlertData),
-  conversationCostSummary: (renderData) => renderConversationCostCard(renderData as ConversationCostData)
+  conversationCostSummary: (renderData) => renderConversationCostCard(renderData as ConversationCostData),
+  qualityReport: (renderData) => renderQualityReportCard(renderData as QualityReportData)
 }
 
 /**

--- a/src/adapters/slack/blocks/scorekeeper/qualityReportCard.ts
+++ b/src/adapters/slack/blocks/scorekeeper/qualityReportCard.ts
@@ -1,0 +1,167 @@
+import type { KnownBlock } from '@slack/types'
+import type { QualityReportData, QualityReportEvaluatorScore, QualityReportLowScoreTrace } from '../../../../types/index.types.js'
+
+const SEPARATOR_WIDTH = 46
+const DELTA_MIN_DISPLAY = 0.02
+const TRENDING_DOWN_THRESHOLD = -0.10
+
+function scoreBar(mean: number): string {
+  const filled = Math.round(mean * 10)
+  const empty = 10 - filled
+  return '█'.repeat(filled) + '░'.repeat(empty)
+}
+
+function trafficLight(mean: number): string {
+  if (mean >= 0.7) return '🟢'
+  if (mean >= 0.5) return '🟡'
+  return '🔴'
+}
+
+function formatName(raw: string): string {
+  return raw
+    .replace(/_/g, ' ')
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim()
+}
+
+function parseKey(fullKey: string): { category: string; name: string } {
+  const dot = fullKey.indexOf('.')
+  if (dot === -1) return { category: '', name: fullKey }
+  return { category: fullKey.slice(0, dot), name: fullKey.slice(dot + 1) }
+}
+
+function deltaStr(delta: number): string {
+  if (Math.abs(delta) < DELTA_MIN_DISPLAY) return '→'
+  return delta > 0 ? `↑ +${delta.toFixed(2)}` : `↓ ${delta.toFixed(2)}`
+}
+
+function scoreRow(e: QualityReportEvaluatorScore, delta?: number): string {
+  const { name } = parseKey(e.key)
+  const label = formatName(name).padEnd(28)
+  const trend = delta !== undefined ? `  ${deltaStr(delta)}` : ''
+  return `${trafficLight(e.mean)} ${label} ${e.mean.toFixed(2)}  ${scoreBar(e.mean)}${trend}`
+}
+
+function buildScoreTable(evaluators: QualityReportEvaluatorScore[], deltas?: Record<string, number>): string {
+  const groupMap = new Map<string, QualityReportEvaluatorScore[]>()
+
+  for (const e of evaluators) {
+    const { category } = parseKey(e.key)
+    const group = groupMap.get(category) ?? []
+    group.push(e)
+    groupMap.set(category, group)
+  }
+
+  // Named categories alphabetically, uncategorized (empty string) last
+  const sorted = [...groupMap.keys()].sort((a, b) => {
+    if (a === '') return 1
+    if (b === '') return -1
+    return a.localeCompare(b)
+  })
+
+  const lines: string[] = []
+  for (const category of sorted) {
+    const entries = groupMap.get(category)!
+    if (category) {
+      if (lines.length > 0) lines.push('')
+      const dashes = '─'.repeat(Math.max(0, SEPARATOR_WIDTH - category.length - 4))
+      lines.push(`── ${category} ${dashes}`)
+    }
+    for (const e of entries) {
+      lines.push(scoreRow(e, deltas?.[e.key]))
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function lowScoreLine(o: QualityReportLowScoreTrace): string {
+  const scores = o.lowScores.map(({ key, score }) => {
+    const { name } = parseKey(key)
+    return `${formatName(name)}: ${score.toFixed(2)}`
+  }).join(', ')
+  const link = o.url ? `<${o.url}|view trace>` : `run \`${o.runId.slice(0, 8)}\``
+  return `• ${link} — ${scores}`
+}
+
+export default function renderQualityReportCard(data: QualityReportData): KnownBlock[] {
+  const blocks: KnownBlock[] = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `:bar_chart: Quality Report: ${data.conversationName}`, emoji: true }
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Overall: ${data.overallMean.toFixed(2)}* · ${data.tracesScored} traces scored`
+      }
+    },
+    { type: 'divider' },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `\`\`\`\n${buildScoreTable(data.evaluators, data.deltas)}\n\`\`\``
+      }
+    }
+  ]
+
+  if (data.deltas) {
+    const trendingDown = data.evaluators
+      .filter((e) => (data.deltas![e.key] ?? 0) <= TRENDING_DOWN_THRESHOLD)
+      .sort((a, b) => data.deltas![a.key] - data.deltas![b.key])
+
+    if (trendingDown.length > 0) {
+      const lines = trendingDown.map((e) => {
+        const { name } = parseKey(e.key)
+        const d = data.deltas![e.key]
+        return `• ${formatName(name)}: ${e.mean.toFixed(2)} (${d.toFixed(2)} vs avg)`
+      })
+      blocks.push({ type: 'divider' })
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*:chart_with_downwards_trend: Trending Down*\n${lines.join('\n')}`
+        }
+      })
+    }
+  }
+
+  if (data.lowScoreTraces.length > 0) {
+    const shown = data.lowScoreTraces.length
+    const total = data.totalLowScoreCount
+    const suffix = total > shown ? ` · showing worst ${shown} of ${total}` : ''
+    blocks.push({ type: 'divider' })
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*:warning: Needs Review* (${total} trace${total === 1 ? '' : 's'} with scores below 0.5${suffix})\n${data.lowScoreTraces.map(lowScoreLine).join('\n')}`
+      }
+    })
+  }
+
+  blocks.push({ type: 'divider' })
+
+  const generatedAt = new Date(data.generatedAt).toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZoneName: 'short'
+  })
+
+  const baselineNote = data.baselineSampleCount !== undefined
+    ? ` · Trends vs. 30-day avg (${data.baselineSampleCount} reports)`
+    : ''
+
+  blocks.push({
+    type: 'context',
+    elements: [{ type: 'mrkdwn', text: `Generated at ${generatedAt} · Scores from LangSmith online evaluators${baselineNote}` }]
+  })
+
+  return blocks
+}

--- a/src/agents/eventAssistant/eventAssistant.ts
+++ b/src/agents/eventAssistant/eventAssistant.ts
@@ -16,6 +16,7 @@ import generateImageResponse from './imageGenerator.js'
 import { parseSlashCommands, hasCommand, extractMessageText, SlashCommand } from '../helpers/slashCommandParser.js'
 import generateMindMap from './mindMapGenerator.js'
 import { checkBotIntent, matchBotMention, normalizeBotMention } from '../helpers/intentChecks.js'
+import { loadGoal } from '../../goals/loader.js'
 
 /**
  * Builds a dynamic capability description for the WELCOME check-in message.
@@ -337,37 +338,55 @@ export default verify({
   },
 
   formatTraceInput(_conversationHistory: ConversationHistory, userMessage: IMessage | undefined) {
-    if (!userMessage) return { trigger: 'periodic' }
-    return userMessage?.body
+    const personality = this.agentConfig?.personality ?? (config.enableAgentPersonality ? 'sarcastic-expert' : null)
+    if (!userMessage) {
+      return {
+        trigger: 'periodic',
+        behaviorPolicy: this.conversation.behaviorPolicy,
+        goals: (this.conversation.goals ?? []).flatMap((id) => {
+          try { return [loadGoal(id)] } catch { return [] }
+        }),
+        conversationContext: this.conversation.conversationContext,
+        personality
+      }
+    }
+    return {
+      question: userMessage?.body,
+      behaviorPolicy: this.conversation.behaviorPolicy,
+      conversationContext: this.conversation.conversationContext,
+      personality
+    }
   },
 
   formatTraceOutput(responses: TraceResponse[]) {
     if (responses.length > 0 && (responses[0]?.message as { type?: string })?.type === 'checkin') {
-      return responses.map((r) => ({
-        participant: r.participantPseudonym,
-        eligibleGoals: r.eligibleGoals,
-        goalId: r.goalId,
-        confidenceScore: r.confidenceScore,
-        detectedPattern: r.detectedPattern,
-        reasoning: r.reasoning,
-        messageSent: (r.message as { text?: string })?.text
-      }))
+      return responses.map((r) => {
+        const goal = r.goalId ? (this.conversation.goals ?? []).flatMap((id) => {
+          try { return [loadGoal(id)] } catch { return [] }
+        }).find((g) => g.id === r.goalId) ?? null : null
+        return {
+          participant: r.participantPseudonym,
+          goalId: r.goalId,
+          goal,
+          confidenceScore: r.confidenceScore,
+          detectedPattern: r.detectedPattern,
+          reasoning: r.reasoning,
+          messageSent: (r.message as { text?: string })?.text,
+          context: r.context
+        }
+      })
     }
-    return responses[0]?.message
+    return { message: responses[0]?.message, context: responses[0]?.context }
   },
 
   getTraceMetadata(conversationHistory: ConversationHistory, userMessage: IMessage | undefined, responses: TraceResponse[]) {
     if (!userMessage) {
       return {
         triggerType: 'periodic',
-        topic: this.conversation.name,
-        context: responses
-          .map((r) => `# Participant: ${r.participantPseudonym} (${r.channels?.[0]?.name})\n\n${r.context}`)
-          .join('\n\n---\n\n')
+        topic: this.conversation.name
       }
     }
     return {
-      context: responses[0]?.context,
       conversationHistory,
       channels: userMessage?.channels,
       promptType: responses[0]?.promptType,

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -11,6 +11,7 @@ import eventHistorian from './eventHistorian/eventHistorian.js'
 import eventSetup from './eventSetup/eventSetup.js'
 import vibesAnalyst from './vibesAnalyst/index.js'
 import numberCruncher from './numberCruncher/agent.js'
+import scorekeeper from './scorekeeper/agent.js'
 
 // Development agents
 import civilityPerMessage from './development/civilityPerMessage.js'
@@ -53,7 +54,8 @@ const agentTypes = {
   eventHistorian,
   eventSetup,
   vibesAnalyst,
-  numberCruncher
+  numberCruncher,
+  scorekeeper
 }
 
 for (const [key, agentType] of Object.entries(agentTypes)) {

--- a/src/agents/numberCruncher/agent.ts
+++ b/src/agents/numberCruncher/agent.ts
@@ -61,10 +61,7 @@ export default verify({
   priority: 100,
   maxTokens: undefined,
   defaultTriggers: {
-    periodic: {
-      timerPeriod: 86400, // once every 24 hours by default
-      proactive: true
-    }
+    cron: { expression: '0 3 * * *' }
   },
   llmTemplateVars: undefined,
   defaultLLMTemplates: undefined,

--- a/src/agents/proactiveGroupAgent/proactiveGroupAgent.ts
+++ b/src/agents/proactiveGroupAgent/proactiveGroupAgent.ts
@@ -285,33 +285,35 @@ export default verify({
     ]
   },
 
-  formatTraceInput(conversationHistory: ConversationHistory) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  formatTraceInput(_conversationHistory: ConversationHistory) {
     return {
-      transcript: conversationHistory.messages.map((m) => ({
-        role: m.fromAgent ? 'agent' : 'participant',
-        pseudonym: m.pseudonym,
-        text: m.bodyType === 'json' ? (m.body as { text?: string })?.text : m.body,
-        createdAt: m.createdAt
-      }))
+      behaviorPolicy: this.conversation.behaviorPolicy,
+      goals: getGroupChatGoals(resolveActiveGoals(this.conversation)),
+      conversationContext: this.conversation.conversationContext,
+      personality: this.agentConfig?.personality ?? null
     }
   },
 
   formatTraceOutput(responses: InterventionAnalysis[]) {
-    if (responses.length === 0) return { goalId: 'none', messageSent: null }
+    if (responses.length === 0) return { goalId: 'none', messageSent: null, context: null }
     const r = responses[0]
+    const activeGoals = getGroupChatGoals(resolveActiveGoals(this.conversation))
+    const matchedGoal = activeGoals.find((g) => g.id === r.goalId) ?? null
     return {
       goalId: r.goalId,
+      goal: matchedGoal,
       reasoning: r.reasoning,
       confidenceScore: r.confidenceScore,
       detectedPattern: r.detectedPattern,
-      messageSent: r.sharedChatMessage
+      messageSent: r.sharedChatMessage,
+      context: r.context
     }
   },
 
-  getTraceMetadata(_conversationHistory: ConversationHistory, _userMessage: unknown, responses: InterventionAnalysis[]) {
+  getTraceMetadata() {
     return {
-      topic: this.conversation.name,
-      context: responses[0]?.context
+      topic: this.conversation.name
     }
   },
 

--- a/src/agents/scorekeeper/README.md
+++ b/src/agents/scorekeeper/README.md
@@ -1,0 +1,196 @@
+# Scorekeeper Agent
+
+Nightly cron agent that fetches LangSmith online evaluator scores for all conversations
+that ended in the last 24 hours and posts a quality report card per conversation to a
+configured Slack channel.
+
+Runs at **04:00 UTC** (approximately midnight US Eastern).
+
+---
+
+## How it works
+
+1. At 04:00 UTC, the agent queries MongoDB for conversations with `endTime` in the
+   last 24 hours where `endTime > startTime` (guards against restarted conversations).
+2. For each conversation, it calls `fetchQualityScores`, which reads root LangSmith
+   traces tagged with the `conversationId` metadata key and aggregates all feedback
+   scores: mean, min, count, and low-score count per evaluator key.
+3. It computes a 30-day cross-conversation baseline (minimum 5 reports) and derives
+   per-evaluator deltas for trend arrows.
+4. Results are persisted to `QualityReport` in MongoDB (one document per conversation
+   per UTC day — idempotent) and posted as a Block Kit card to Slack.
+
+Private conversations have their names redacted in both the Slack post and the
+persisted report (`topic.private !== false` — fail-closed).
+
+---
+
+## LangSmith online evaluators — setup
+
+Scorekeeper reads feedback that LangSmith's **online evaluators** write to each trace.
+Online evaluators run automatically whenever a new root trace arrives in your project —
+no manual trigger required.
+
+### Step 1 — Enable LangSmith tracing
+
+Ensure `LANGSMITH_API_KEY`, `LANGSMITH_PROJECT`, and `LANGSMITH_TRACING=true` are set
+in your environment. Each agent run must emit a root trace tagged with
+`conversationId` in its metadata for Scorekeeper to find it.
+
+### Step 2 — Create online evaluators in the LangSmith dashboard
+
+In **LangSmith → your project → Evaluators → Online**, create one evaluator per
+feedback key you want to track. Each evaluator runs the LLM-as-judge prompt defined
+below against every new root trace.
+
+Set the following on each evaluator:
+- **Type:** LLM-as-judge
+- **Scoring:** Continuous (0–1)
+- **Feedback key:** exactly as shown — this becomes the key Scorekeeper reads
+- **Model:** GPT-4o or equivalent; the same model used in `createJudge()` in
+  `evaluations/sharedEvaluators.ts`
+- **Sample rate:** adjust to budget; 100% gives the richest data
+
+### Step 3 — Map prompts to feedback keys
+
+All prompt text lives in `evaluations/sharedEvaluators.ts` (shared across all agent
+suites) and `evaluations/qa-behavior/behaviorPolicyConfig.ts` (QA behavior suite).
+
+#### From `evaluations/sharedEvaluators.ts` (all agent types)
+
+| Feedback key | What it measures |
+|---|---|
+| `compliance.tone` | Whether the agent's tone matches the configured tone policy (warmSupportive, clearNeutral, playful, professional) |
+| `compliance.formality` | Whether formality level (casual, semiFormal, formal) matches policy |
+| `compliance.audienceAppropriateness` | Whether language is pitched correctly for the specified audience |
+| `compliance.verbosity` | Whether response length (brief, medium, detailed) matches policy |
+| `compliance.contentSensitivity` | Whether the agent respects sensitivity flags — avoids taking sides on contested topics |
+| `compliance.privacyProtection` | Whether private participant messages are protected — no quoting or identification |
+| `compliance.guardrailCompliance` | Whether the agent respects the active goal's guardrails |
+| `compliance.interventionAppropriateness` | Whether the agent's decision to intervene (or stay silent) was appropriate given goals and initiative level |
+
+Paste the corresponding `*_PROMPT` constant from `sharedEvaluators.ts` as the prompt
+body in LangSmith. The prompts use `{context}`, `{inputs}`, and `{outputs}` variables
+that LangSmith substitutes from the trace.
+
+#### From `evaluations/qa-behavior/behaviorPolicyConfig.ts` (QA behavior agent type only)
+
+| Feedback key | What it measures |
+|---|---|
+| `compliance.responseLengthCompliance` | Whether response length matches the configured tier (short, medium, long) |
+| `compliance.answerScopeCompliance` | Whether content stays within the configured scope (lecture, subject area, company context, open) |
+| `compliance.clarifyWhenAmbiguousCompliance` | Whether the agent asks a clarifying question when ambiguous (and doesn't when not) |
+| `compliance.addContextWhenUsefulCompliance` | Whether the agent provides bridging context and scaffolding appropriately |
+| `compliance.followUpDialogueCompliance` | Whether the agent signals openness (or closure) to continued dialogue per policy |
+
+#### Event Assistant quality evaluators (from `evaluations/event-assistant/eventAssistantConfig.ts`)
+
+These use built-in `openevals` prompts (`CORRECTNESS_PROMPT`, `HALLUCINATION_PROMPT`,
+`RAG_HELPFULNESS_PROMPT`, `RAG_GROUNDEDNESS_PROMPT`, `RAG_RETRIEVAL_RELEVANCE_PROMPT`,
+`CONCISENESS_PROMPT`) unless overridden in the config.
+
+| Feedback key | Agent type | What it measures |
+|---|---|---|
+| `quality.correctness` | Event Assistant, Proactive Group Agent | Factual accuracy relative to context and general knowledge |
+| `quality.conciseness` | Event Assistant | Whether the response contains only what was asked, without padding |
+| `quality.helpfulness` | Proactive Group Agent | Whether the response actually helps the user accomplish their goal |
+| `quality.hallucination` | Proactive Group Agent only | Whether the response fabricates information not present in context |
+| `quality.groundedness` | Proactive Group Agent only | Whether claims are grounded in the retrieved context |
+| `quality.retrievalRelevance` | Proactive Group Agent only | Whether the retrieved context was relevant to the question |
+
+> **Note:** `hallucination`, `groundedness`, and `retrievalRelevance` are not applied to
+> Event Assistant traces. Event Assistant uses web search as a tool, and the search
+> results are not captured in the trace context — so these evaluators cannot accurately
+> judge whether a response is grounded in or consistent with what the search actually
+> returned.
+
+#### Personality evaluators (from `tests/utils/evaluators.ts`, used by Event Assistant suite)
+
+| Feedback key | What it measures |
+|---|---|
+| `personality.ceremony` | Whether the response skips unnecessary pleasantries and boilerplate |
+| `personality.leadWithAnswer` | Whether the first sentence gives a direct answer or clear stance |
+| `personality.antiSycophancy` | Whether the response avoids over-thanking, false agreement, and flattery |
+| `personality.pragmatic` | Whether the response gives concrete, actionable guidance rather than vague platitudes |
+| `personality.opinionatedBounded` | Whether the response makes clear recommendations while acknowledging alternatives |
+| `personality.confidentNotCocky` | Whether the response is assertive without being condescending |
+| `personality.witAndHumor` | Whether humor is dry, infrequent, and context-appropriate |
+| `personality.honestyAboutLimits` | Whether the response explicitly acknowledges uncertainty rather than bluffing |
+
+---
+
+## Dot-notation key convention
+
+Feedback keys use dot notation to group evaluators into categories on the report card:
+
+```
+compliance.tone          → category "compliance", name "Tone"
+qa.responseLengthCompliance → category "qa", name "Response Length Compliance"
+quality.correctness      → category "quality", name "Correctness"
+```
+
+Underscores and camelCase in the name segment are both rendered as title-cased words.
+Keys with no dot are rendered without a category separator.
+
+---
+
+## Report card anatomy
+
+Each Slack post contains:
+
+- **Header** — conversation name (redacted for private topics)
+- **Summary** — overall mean score and number of scored traces
+- **Score table** — per-evaluator traffic light (🟢 ≥ 0.7 / 🟡 ≥ 0.5 / 🔴 < 0.5),
+  mean score, score bar, and delta arrow vs. 30-day baseline (↑ / ↓ / →)
+- **Trending Down** _(if applicable)_ — evaluators where delta ≤ −0.10, sorted
+  worst-first
+- **Needs Review** _(if applicable)_ — up to 5 traces with any score below 0.5,
+  linked directly to LangSmith; shows total count if more than 5 exist
+- **Footer** — generation timestamp and baseline sample count
+
+---
+
+## Baseline and trend arrows
+
+Delta arrows compare today's per-evaluator mean against a 30-day rolling baseline
+computed from all other conversations' persisted `QualityReport` documents:
+
+- Requires **at least 5** reports in the window; suppressed when data is sparse
+- The current conversation is excluded from its own baseline
+- Arrow display threshold: **±0.02** (noise below this shows `→`)
+- Trending Down alert threshold: **−0.10**
+
+---
+
+## Smoke-testing the Slack output
+
+```bash
+NODE_ENV=development node --loader ts-node/esm scripts/checkScorekeeperSlack.ts \
+  --conversation=<scorekeeper-conversation-id> \
+  --target-conversation=<conversation-to-score> \
+  [--dry-run]
+```
+
+`--dry-run` fetches scores and renders the card without posting to Slack.
+
+---
+
+## Configuration
+
+Create a `scorekeeper` conversation type with the following properties:
+
+| Property | Required | Description |
+|---|---|---|
+| `slackChannel` | Yes | Slack channel ID (starts with `C` or `G`) |
+| `slackWorkspace` | Yes | Slack workspace ID (starts with `T`) |
+| `slackBotToken` | Yes | Bot User OAuth token (starts with `xoxb-`) |
+| `slackBotUserId` | No | Bot user ID for routing incoming messages |
+| `slackSigningSecret` | No | Signing secret; falls back to system-wide value |
+| `botName` | No | Display name in Slack (default: `Scorekeeper`) |
+
+LangSmith credentials are read from the application environment:
+
+| Env var | Description |
+|---|---|
+| `LANGSMITH_API_KEY` | LangSmith API key |
+| `LANGSMITH_PROJECT` | Project name that holds the traces |

--- a/src/agents/scorekeeper/agent.ts
+++ b/src/agents/scorekeeper/agent.ts
@@ -1,0 +1,173 @@
+import verify from '../helpers/verify.js'
+import { defaultLLMModel, defaultLLMPlatform } from '../helpers/getModelChat.js'
+import { AgentMessageActions } from '../../types/index.types.js'
+import type { QualityReportData } from '../../types/index.types.js'
+import logger from '../../config/logger.js'
+import Conversation from '../../models/conversation.model.js'
+import QualityReport from '../../models/qualityReport.model.js'
+import { fetchQualityScores } from './fetchQualityScores.js'
+
+function midnightUtc(): Date {
+  const d = new Date()
+  d.setUTCHours(0, 0, 0, 0)
+  return d
+}
+
+function twentyFourHoursAgo(): Date {
+  return new Date(Date.now() - 24 * 60 * 60 * 1000)
+}
+
+function thirtyDaysAgo(): Date {
+  return new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+}
+
+const BASELINE_MIN_SAMPLES = 5
+
+async function fetchBaseline(
+  excludeConversationId: string
+): Promise<{ deltas: Record<string, number>; sampleCount: number } | null> {
+  const reports = await QualityReport.find({
+    conversationId: { $ne: excludeConversationId },
+    reportDate: { $gte: thirtyDaysAgo() }
+  })
+    .select('evaluators')
+    .lean()
+
+  if (reports.length < BASELINE_MIN_SAMPLES) return null
+
+  const accumulated = new Map<string, { total: number; count: number }>()
+  for (const report of reports) {
+    for (const e of report.evaluators) {
+      const agg = accumulated.get(e.key) ?? { total: 0, count: 0 }
+      agg.total += e.mean
+      agg.count += 1
+      accumulated.set(e.key, agg)
+    }
+  }
+
+  const baseline: Record<string, number> = {}
+  for (const [key, { total, count }] of accumulated) {
+    baseline[key] = total / count
+  }
+
+  return { deltas: baseline, sampleCount: reports.length }
+}
+
+export default verify({
+  name: 'Scorekeeper',
+  description:
+    'Nightly sweep agent. Fetches LangSmith evaluator feedback scores for all conversations that ended today and returns a quality report card per conversation',
+  priority: 100,
+  maxTokens: undefined,
+  defaultTriggers: {
+    cron: { expression: '0 4 * * *' }
+  },
+  llmTemplateVars: undefined,
+  defaultLLMTemplates: undefined,
+  defaultLLMPlatform,
+  defaultLLMModel,
+  ragCollectionName: undefined,
+
+  async start() {
+    return true
+  },
+
+  async stop() {
+    return true
+  },
+
+  async introduce() {
+    return []
+  },
+
+  async evaluate(userMessage = null) {
+    return {
+      userMessage,
+      action: AgentMessageActions.CONTRIBUTE,
+      userContributionVisible: true,
+      suggestion: undefined
+    }
+  },
+
+  async respond() {
+    const reportDate = midnightUtc()
+
+    const conversations = await Conversation.find({
+      endTime: { $gte: twentyFourHoursAgo() },
+      $expr: { $gt: ['$endTime', '$startTime'] },
+      draft: false
+    })
+      .select('_id name topic')
+      .populate('topic', 'private')
+      .lean()
+
+    if (conversations.length === 0) {
+      logger.debug('scorekeeper: no conversations ended today')
+      return []
+    }
+
+    const responses: object[] = []
+
+    for (const conversation of conversations) {
+      const conversationId = conversation._id.toString()
+
+      const existing = await QualityReport.findOne({ conversationId: conversation._id, reportDate })
+      if (existing) {
+        logger.debug(`scorekeeper: report already exists for ${conversationId}`)
+        continue
+      }
+
+      const topic = conversation.topic as { private?: boolean } | undefined
+      const topicIsPrivate = topic?.private !== false
+      const displayName = topicIsPrivate ? 'a private conversation' : conversation.name
+
+      const scores = await fetchQualityScores(conversationId)
+      if (!scores) continue
+
+      const baseline = await fetchBaseline(conversationId)
+      const deltas: Record<string, number> | undefined = baseline
+        ? Object.fromEntries(
+            scores.evaluators
+              .filter((e) => baseline.deltas[e.key] !== undefined)
+              .map((e) => [e.key, e.mean - baseline.deltas[e.key]])
+          )
+        : undefined
+
+      await QualityReport.create({
+        conversationId: conversation._id,
+        conversationName: displayName,
+        reportDate,
+        evaluators: scores.evaluators,
+        overallMean: scores.overallMean,
+        tracesScored: scores.tracesScored,
+        totalLowScoreCount: scores.totalLowScoreCount
+      })
+
+      const renderData: QualityReportData = {
+        conversationName: displayName,
+        conversationId,
+        evaluators: scores.evaluators,
+        overallMean: scores.overallMean,
+        tracesScored: scores.tracesScored,
+        lowScoreTraces: scores.lowScoreTraces,
+        totalLowScoreCount: scores.totalLowScoreCount,
+        generatedAt: new Date().toISOString(),
+        deltas,
+        baselineSampleCount: baseline?.sampleCount
+      }
+
+      responses.push({
+        visible: true,
+        message: `Quality report for ${displayName}: overall ${scores.overallMean.toFixed(2)} across ${
+          scores.tracesScored
+        } traces`,
+        messageType: 'text' as const,
+        responseKind: 'qualityReport' as const,
+        renderData,
+        channels: this.conversation.channels
+      })
+    }
+
+    return responses
+  }
+})

--- a/src/agents/scorekeeper/fetchQualityScores.ts
+++ b/src/agents/scorekeeper/fetchQualityScores.ts
@@ -1,0 +1,128 @@
+import { Client } from 'langsmith'
+import config from '../../config/config.js'
+import logger from '../../config/logger.js'
+
+export interface EvaluatorScore {
+  key: string
+  mean: number
+  min: number
+  count: number
+  lowScoreCount: number
+}
+
+export interface LowScoreTrace {
+  runId: string
+  url: string | null
+  lowScores: Array<{ key: string; score: number }>
+}
+
+export interface QualityScores {
+  evaluators: EvaluatorScore[]
+  overallMean: number
+  tracesScored: number
+  lowScoreTraces: LowScoreTrace[]
+  totalLowScoreCount: number
+}
+
+const LOW_SCORE_THRESHOLD = 0.5
+const MAX_LOW_SCORE_TRACES = 5
+
+function conversationFilter(conversationId: string): string {
+  return `and(eq(metadata_key, "conversationId"), eq(metadata_value, "${conversationId}"))`
+}
+
+/**
+ * Fetches LangSmith feedback scores for all root traces tagged with the given
+ * conversationId. Aggregates per evaluator key and computes per-key and overall
+ * means. Also surfaces the worst-scoring traces where any evaluator scored below
+ * LOW_SCORE_THRESHOLD, with direct LangSmith links. Returns null if LangSmith is
+ * not configured or no scored traces exist.
+ */
+export async function fetchQualityScores(conversationId: string): Promise<QualityScores | null> {
+  if (!config.langsmith.key || !config.langsmith.project) {
+    logger.debug('scorekeeper: LangSmith key or project not configured; skipping')
+    return null
+  }
+
+  const client = new Client({ apiKey: config.langsmith.key })
+
+  try {
+    const runIds: string[] = []
+    for await (const run of client.listRuns({
+      projectName: config.langsmith.project,
+      isRoot: true,
+      filter: conversationFilter(conversationId)
+    })) {
+      runIds.push(String(run.id))
+    }
+
+    if (runIds.length === 0) {
+      logger.debug(`scorekeeper: no traces found for conversation ${conversationId}`)
+      return null
+    }
+
+    // accumulated[key] = { total, count, min, lowScoreCount } for aggregation
+    const accumulated = new Map<string, { total: number; count: number; min: number; lowScoreCount: number }>()
+    // perRun[runId][key] = score, for per-trace low-score detection
+    const perRun = new Map<string, Map<string, number>>()
+
+    for await (const feedback of client.listFeedback({ runIds })) {
+      if (feedback.score == null || !feedback.run_id) continue
+      const { key } = feedback
+      const score = Number(feedback.score)
+      const runId = String(feedback.run_id)
+
+      const agg = accumulated.get(key) ?? { total: 0, count: 0, min: Infinity, lowScoreCount: 0 }
+      agg.total += score
+      agg.count += 1
+      agg.min = Math.min(agg.min, score)
+      if (score < LOW_SCORE_THRESHOLD) agg.lowScoreCount += 1
+      accumulated.set(key, agg)
+
+      const runScores = perRun.get(runId) ?? new Map<string, number>()
+      runScores.set(key, score)
+      perRun.set(runId, runScores)
+    }
+
+    if (accumulated.size === 0) {
+      logger.debug(`scorekeeper: no feedback scores found for conversation ${conversationId}`)
+      return null
+    }
+
+    const evaluators: EvaluatorScore[] = [...accumulated.entries()]
+      .map(([key, { total, count, min, lowScoreCount }]) => ({ key, mean: total / count, min, count, lowScoreCount }))
+      .sort((a, b) => a.key.localeCompare(b.key))
+
+    const overallMean = evaluators.reduce((sum, e) => sum + e.mean, 0) / evaluators.length
+
+    // Find traces with any score below the threshold, sorted worst-first
+    const lowScoreEntries = [...perRun.entries()]
+      .map(([runId, scores]) => ({
+        runId,
+        lowScores: [...scores.entries()]
+          .filter(([, score]) => score < LOW_SCORE_THRESHOLD)
+          .map(([key, score]) => ({ key, score }))
+          .sort((a, b) => a.score - b.score)
+      }))
+      .filter((e) => e.lowScores.length > 0)
+      .sort((a, b) => a.lowScores[0].score - b.lowScores[0].score)
+
+    const totalLowScoreCount = lowScoreEntries.length
+    const lowScoreTraces: LowScoreTrace[] = await Promise.all(
+      lowScoreEntries.slice(0, MAX_LOW_SCORE_TRACES).map(async ({ runId, lowScores }) => {
+        let url: string | null = null
+        try {
+          url = await client.getRunUrl({ runId, projectOpts: { projectName: config.langsmith.project } })
+        } catch {
+          logger.debug(`scorekeeper: could not build URL for run ${runId}`)
+        }
+        return { runId, url, lowScores }
+      })
+    )
+
+    return { evaluators, overallMean, tracesScored: perRun.size, lowScoreTraces, totalLowScoreCount }
+  } catch (error) {
+    logger.error(`scorekeeper: LangSmith fetch failed for ${conversationId}`, error)
+    return null
+  }
+}

--- a/src/conversations/index.ts
+++ b/src/conversations/index.ts
@@ -6,6 +6,7 @@ import eventHistorian from './eventHistorian.js'
 import eventSetup from './eventSetup.js'
 import vibesAnalyst from './vibesAnalyst.js'
 import numberCruncher from './numberCruncher.js'
+import scorekeeper from './scorekeeper.js'
 
 // Internal conversation types are usable by the service but not exposed via the config API
 const internal: Record<string, ConversationType> = {
@@ -13,7 +14,8 @@ const internal: Record<string, ConversationType> = {
   eventHistorian,
   eventSetup,
   vibesAnalyst,
-  numberCruncher
+  numberCruncher,
+  scorekeeper
 }
 
 const defaultConversationTypes: Record<string, ConversationType> = {

--- a/src/conversations/numberCruncher.ts
+++ b/src/conversations/numberCruncher.ts
@@ -64,14 +64,6 @@ const numberCruncher: ConversationType = {
         'Array of budget configs. Each entry: { "label": "AWS Bedrock", "endpoint": "https://...", "apiKey": "...", "thresholdPercent": 80 }. Endpoints must return { "quota": { "limit": "250.0" }, "remaining_limit": "199.40" }.',
       required: true,
       type: 'array'
-    },
-    {
-      name: 'checkInterval',
-      label: 'Check Interval (seconds)',
-      description: 'How often to check budgets, in seconds. Defaults to 86400 (24 hours).',
-      required: false,
-      type: 'string',
-      default: '86400'
     }
   ],
   // internal
@@ -80,9 +72,7 @@ const numberCruncher: ConversationType = {
       name: 'numberCruncher',
       properties: [
         { $ref: 'botName', as: 'agentConfig.botName' },
-        { $ref: 'budgets', as: 'agentConfig.budgets' },
-        { $ref: 'checkInterval', as: 'triggers.periodic.timerPeriod' },
-        { name: 'proactive', as: 'triggers.periodic.proactive', type: 'boolean', required: false, default: true }
+        { $ref: 'budgets', as: 'agentConfig.budgets' }
       ]
     }
   ],

--- a/src/conversations/scorekeeper.ts
+++ b/src/conversations/scorekeeper.ts
@@ -1,0 +1,90 @@
+import { ConversationType, Direction } from '../types/index.types.js'
+
+const scorekeeper: ConversationType = {
+  name: 'scorekeeper',
+  label: 'Scorekeeper',
+  description:
+    'An admin bot that fetches nightly LangSmith evaluator feedback scores for all conversations and posts a quality report card per conversation to a Slack channel',
+  platforms: [{ name: 'slack', label: 'Slack' }],
+  properties: [
+    {
+      name: 'slackChannel',
+      label: 'Slack Channel ID',
+      description: 'The ID of the Slack channel the bot posts to (starts with C- or G-)',
+      required: true,
+      type: 'string'
+    },
+    {
+      name: 'slackWorkspace',
+      label: 'Slack Workspace ID',
+      description: 'The Slack workspace (team) ID (starts with T-)',
+      required: true,
+      type: 'string'
+    },
+    {
+      name: 'slackBotToken',
+      label: 'Slack Bot Token',
+      description: 'The Bot User OAuth token for the Slack app (starts with xoxb-)',
+      required: true,
+      type: 'string'
+    },
+    {
+      name: 'slackBotUserId',
+      label: 'Slack Bot User ID',
+      description: 'The user ID for the bot in Slack (starts with U-), used for routing incoming messages',
+      required: false,
+      type: 'string'
+    },
+    {
+      name: 'slackSigningSecret',
+      label: 'Slack App Signing Secret',
+      description: 'The signing secret for the Slack app. Defaults to the system-wide signing secret if not provided.',
+      required: false,
+      type: 'string'
+    },
+    {
+      name: 'slackAppKey',
+      label: 'Slack App Key in Webhook',
+      description: 'The app key for the Slack app, used as the last part of the webhook URL to route incoming messages.',
+      required: false,
+      type: 'string'
+    },
+    {
+      name: 'botName',
+      label: 'Bot Name',
+      description: 'The name the bot uses when posting messages.',
+      required: false,
+      type: 'string',
+      default: 'Scorekeeper'
+    }
+  ],
+  // internal
+  agents: [
+    {
+      name: 'scorekeeper',
+      properties: [{ $ref: 'botName', as: 'agentConfig.botName' }]
+    }
+  ],
+  channels: [{ name: 'scorekeeper' }],
+  adapters: {
+    slack: {
+      type: 'slack',
+      config: {
+        channel: '{{{properties.slackChannel}}}',
+        workspace: '{{{properties.slackWorkspace}}}',
+        botToken: '{{{properties.slackBotToken}}}',
+        botUserId: '{{{properties.slackBotUserId}}}',
+        signingSecret: '{{{properties.slackSigningSecret}}}',
+        appKey: '{{{properties.slackAppKey}}}'
+      },
+      chatChannels: [
+        {
+          name: 'scorekeeper',
+          direction: Direction.BOTH
+        }
+      ]
+    }
+  }
+}
+
+export default scorekeeper

--- a/src/jobs/define.ts
+++ b/src/jobs/define.ts
@@ -6,6 +6,10 @@ const defineJob = {
     await agenda.start()
     await agenda.define(`periodic - ${agentId}`, JobHandlers.periodicAgent)
   },
+  cronAgent: async (agentId) => {
+    await agenda.start()
+    await agenda.define(`cron - ${agentId}`, JobHandlers.periodicAgent)
+  },
   agentResponse: async (agentId) => {
     await agenda.start()
     await agenda.define(`response - ${agentId}`, JobHandlers.agentResponse)

--- a/src/jobs/schedule.ts
+++ b/src/jobs/schedule.ts
@@ -10,6 +10,12 @@ const schedule = {
   cancelPeriodicAgent: async (agentId) => {
     await agenda.cancel({ name: `periodic - ${agentId}` })
   },
+  cronAgent: async (expression: string, data) => {
+    await agenda.every(expression, `cron - ${data.agentId}`, data, { skipImmediate: true })
+  },
+  cancelCronAgent: async (agentId) => {
+    await agenda.cancel({ name: `cron - ${agentId}` })
+  },
   autoStartConversation: async (scheduledAt: Date, data) => {
     await agenda.schedule(scheduledAt, 'autoStart', data)
   },

--- a/src/models/qualityReport.model.ts
+++ b/src/models/qualityReport.model.ts
@@ -1,0 +1,38 @@
+import mongoose from 'mongoose'
+import { toJSON, paginate } from './plugins/index.js'
+
+const evaluatorScoreSchema = new mongoose.Schema(
+  {
+    key: { type: String, required: true },
+    mean: { type: Number, required: true },
+    min: { type: Number, required: true },
+    count: { type: Number, required: true },
+    lowScoreCount: { type: Number, required: true }
+  },
+  { _id: false }
+)
+
+const qualityReportSchema = new mongoose.Schema(
+  {
+    conversationId: {
+      type: mongoose.SchemaTypes.ObjectId,
+      ref: 'Conversation',
+      required: true,
+      index: true
+    },
+    conversationName: { type: String },
+    reportDate: { type: Date, required: true },
+    evaluators: { type: [evaluatorScoreSchema], default: [] },
+    overallMean: { type: Number, required: true },
+    tracesScored: { type: Number, required: true },
+    totalLowScoreCount: { type: Number, required: true }
+  },
+  { timestamps: true }
+)
+
+qualityReportSchema.index({ conversationId: 1, reportDate: 1 }, { unique: true })
+qualityReportSchema.plugin(toJSON)
+qualityReportSchema.plugin(paginate)
+
+const QualityReport = mongoose.model('QualityReport', qualityReportSchema)
+export default QualityReport

--- a/src/services/agent.service/index.ts
+++ b/src/services/agent.service/index.ts
@@ -16,6 +16,13 @@ async function schedulePeriodicAgent(agent) {
   await schedule.periodicAgent(`${agent.triggers.periodic.timerPeriod} seconds`, { agentId: agent._id })
   logger.debug(`Set timer for ${agent.agentType} ${agent._id} ${agent.triggers.periodic.timerPeriod} seconds`)
 }
+
+async function scheduleCronAgent(agent) {
+  await schedule.cancelCronAgent(agent._id)
+  await defineJob.cronAgent(agent._id)
+  await schedule.cronAgent(agent.triggers.cron.expression, { agentId: agent._id })
+  logger.debug(`Set cron for ${agent.agentType} ${agent._id} "${agent.triggers.cron.expression}"`)
+}
 async function initialize(agent) {
   try {
     if (!agent.triggers || agent.triggers?.perMessage) {
@@ -24,6 +31,9 @@ async function initialize(agent) {
     }
     if (agent.active && agent.triggers?.periodic) {
       await schedulePeriodicAgent(agent)
+    }
+    if (agent.active && agent.triggers?.cron) {
+      await scheduleCronAgent(agent)
     }
   } catch (err) {
     logger.error(err)
@@ -67,14 +77,18 @@ async function patchAgent(agent, agentProps) {
   if (agent.active && agent.triggers?.periodic) {
     await schedulePeriodicAgent(agent)
   }
+  if (agent.active && agent.triggers?.cron) {
+    await scheduleCronAgent(agent)
+  }
 }
 
 async function startAgent(agent) {
   logger.debug(`Agent service start: ${agent._id}`)
   await agent.start()
   if (agent.triggers?.periodic) {
-    // periodic activation
     await schedulePeriodicAgent(agent)
+  } else if (agent.triggers?.cron) {
+    await scheduleCronAgent(agent)
   } else if (!agent.triggers) {
     // activate manual agent
     await schedule.agentResponse({ agentId: agent._id })
@@ -86,6 +100,9 @@ async function stopAgent(agent) {
   await agent.stop()
   if (agent.triggers?.periodic) {
     await schedule.cancelPeriodicAgent(agent._id)
+  }
+  if (agent.triggers?.cron) {
+    await schedule.cancelCronAgent(agent._id)
   }
 }
 

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -1159,6 +1159,7 @@ export interface Triggers {
     allowMessagesFromAgents?: boolean
   }
   periodic?: { timerPeriod: number; proactive?: boolean; conversationHistorySettings?: ConversationHistorySettings }
+  cron?: { expression: string }
 }
 
 export interface GenericAgentAnswer {

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -1054,6 +1054,35 @@ export interface BudgetAlertData {
   checkedAt: string
 }
 
+export interface QualityReportEvaluatorScore {
+  key: string
+  mean: number
+  min: number
+  count: number
+  lowScoreCount: number
+}
+
+export interface QualityReportLowScoreTrace {
+  runId: string
+  url: string | null
+  lowScores: Array<{ key: string; score: number }>
+}
+
+export interface QualityReportData {
+  conversationName: string
+  conversationId: string
+  evaluators: QualityReportEvaluatorScore[]
+  overallMean: number
+  tracesScored: number
+  lowScoreTraces: QualityReportLowScoreTrace[]
+  totalLowScoreCount: number
+  generatedAt: string
+  /** Per-evaluator delta vs. 30-day cross-conversation baseline. Omitted when baseline has < 5 samples. */
+  deltas?: Record<string, number>
+  /** Number of reports used to compute the baseline. */
+  baselineSampleCount?: number
+}
+
 /* Per-model aggregation of a conversation's llm-type LangSmith runs. Costs come from
    LangSmith's own pricing table, not the provider invoice, so every figure is an
    estimate — user-facing copy must say so.

--- a/tests/agents/scorekeeper/scorekeeper.agent.test.ts
+++ b/tests/agents/scorekeeper/scorekeeper.agent.test.ts
@@ -1,0 +1,318 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { jest } from '@jest/globals'
+import mongoose from 'mongoose'
+
+import setupIntTest from '../../utils/setupIntTest.js'
+
+// Mock fetchQualityScores so the agent never hits LangSmith
+const mockFetchQualityScores = jest.fn<(...args: any[]) => Promise<any>>()
+
+jest.unstable_mockModule('../src/agents/scorekeeper/fetchQualityScores.js', () => ({
+  fetchQualityScores: mockFetchQualityScores
+}))
+
+const { default: scorekeeperAgentType } = await import('../../../src/agents/scorekeeper/agent.js')
+const { default: Conversation } = await import('../../../src/models/conversation.model.js')
+const { default: QualityReport } = await import('../../../src/models/qualityReport.model.js')
+const { AgentMessageActions } = await import('../../../src/types/index.types.js')
+
+jest.setTimeout(15000)
+setupIntTest()
+
+const CONV_ID = new mongoose.Types.ObjectId()
+const CONV_NAME = 'AI in Education'
+
+function makeScores(overrides = {}) {
+  return {
+    evaluators: [{ key: 'compliance.tone', mean: 0.82, min: 0.5, count: 10, lowScoreCount: 1 }],
+    overallMean: 0.82,
+    tracesScored: 10,
+    lowScoreTraces: [],
+    totalLowScoreCount: 0,
+    ...overrides
+  }
+}
+
+// Bind respond() to a minimal agent context
+function callRespond(channels: any[] = [{ name: 'scorekeeper' }]) {
+  return scorekeeperAgentType.respond.call({ conversation: { channels } })
+}
+
+// Mock Conversation.find to return the given lean array
+function mockConversations(convs: any[]) {
+  jest.spyOn(Conversation, 'find').mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      populate: jest.fn().mockReturnValue({
+        lean: jest.fn<() => Promise<any>>().mockResolvedValue(convs)
+      })
+    })
+  } as any)
+}
+
+describe('scorekeeper agent respond()', () => {
+  beforeAll(async () => {
+    await QualityReport.syncIndexes()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('returns empty when no conversations started in the last 24 hours', async () => {
+    mockConversations([])
+    const responses = await callRespond()
+    expect(responses).toHaveLength(0)
+  })
+
+  it('queries for conversations that ended today where endTime > startTime', async () => {
+    const findSpy = jest.spyOn(Conversation, 'find').mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        populate: jest.fn().mockReturnValue({
+          lean: jest.fn<() => Promise<any>>().mockResolvedValue([])
+        })
+      })
+    } as any)
+
+    await callRespond()
+
+    const query = (findSpy.mock.calls as any[][])[0][0]
+    expect(query.endTime.$gte).toBeInstanceOf(Date)
+    // endTime.$gte should be approximately 24 hours ago
+    const expectedCutoff = Date.now() - 24 * 60 * 60 * 1000
+    expect(query.endTime.$gte.getTime()).toBeCloseTo(expectedCutoff, -3)
+    expect(query.$expr).toEqual({ $gt: ['$endTime', '$startTime'] })
+    expect(query.startTime).toBeUndefined()
+  })
+
+  it('posts a quality report for a conversation with scores', async () => {
+    const channels = [{ name: 'scorekeeper' }]
+    mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: false } }])
+    mockFetchQualityScores.mockResolvedValue(makeScores())
+
+    const responses = await callRespond(channels)
+
+    expect(responses).toHaveLength(1)
+    expect(responses[0]).toMatchObject({
+      visible: true,
+      responseKind: 'qualityReport',
+      channels
+    })
+  })
+
+  it('includes conversation name, overallMean, and tracesScored in the fallback message', async () => {
+    mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: false } }])
+    mockFetchQualityScores.mockResolvedValue(makeScores({ overallMean: 0.75, tracesScored: 12 }))
+
+    const responses = await callRespond()
+
+    expect(responses[0].message).toContain(CONV_NAME)
+    expect(responses[0].message).toContain('0.75')
+    expect(responses[0].message).toContain('12')
+  })
+
+  it('passes evaluators, overallMean, tracesScored, lowScoreTraces, and totalLowScoreCount to renderData', async () => {
+    const scores = makeScores({
+      overallMean: 0.9,
+      tracesScored: 7,
+      lowScoreTraces: [
+        { runId: 'r1', url: 'https://smith.langchain.com/r1', lowScores: [{ key: 'compliance.tone', score: 0.3 }] }
+      ],
+      totalLowScoreCount: 3
+    })
+    mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: false } }])
+    mockFetchQualityScores.mockResolvedValue(scores)
+
+    const responses = await callRespond()
+    const { renderData } = responses[0] as any
+
+    expect(renderData.conversationName).toBe(CONV_NAME)
+    expect(renderData.overallMean).toBeCloseTo(0.9)
+    expect(renderData.tracesScored).toBe(7)
+    expect(renderData.evaluators).toHaveLength(1)
+    expect(renderData.lowScoreTraces).toHaveLength(1)
+    expect(renderData.totalLowScoreCount).toBe(3)
+    expect(renderData.generatedAt).toBeTruthy()
+  })
+
+  it('skips a conversation when fetchQualityScores returns null', async () => {
+    mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: false } }])
+    mockFetchQualityScores.mockResolvedValue(null)
+
+    const responses = await callRespond()
+    expect(responses).toHaveLength(0)
+  })
+
+  it('posts one report per conversation, skipping those with no scores', async () => {
+    const convB = { _id: new mongoose.Types.ObjectId(), name: 'Climate Policy', topic: { private: false } }
+    mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: false } }, convB])
+    mockFetchQualityScores
+      .mockResolvedValueOnce(null) // CONV_ID — no scores
+      .mockResolvedValueOnce(makeScores()) // convB — has scores
+
+    const responses = await callRespond()
+    expect(responses).toHaveLength(1)
+    expect(responses[0].message).toContain('Climate Policy')
+  })
+
+  it('persists the quality report to MongoDB', async () => {
+    mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: false } }])
+    mockFetchQualityScores.mockResolvedValue(makeScores())
+
+    await callRespond()
+
+    const saved = await QualityReport.findOne({ conversationId: CONV_ID })
+    expect(saved).not.toBeNull()
+    expect(saved!.conversationName).toBe(CONV_NAME)
+    expect(saved!.overallMean).toBeCloseTo(0.82)
+    expect(saved!.evaluators).toHaveLength(1)
+    expect(saved!.evaluators[0].key).toBe('compliance.tone')
+  })
+
+  describe('private topic redaction', () => {
+    it('uses the real name when topic.private is false', async () => {
+      mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: false } }])
+      mockFetchQualityScores.mockResolvedValue(makeScores())
+
+      const responses = await callRespond()
+      expect(responses[0].renderData.conversationName).toBe(CONV_NAME)
+      expect(responses[0].message).toContain(CONV_NAME)
+    })
+
+    it('redacts the name when topic.private is true', async () => {
+      mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: true } }])
+      mockFetchQualityScores.mockResolvedValue(makeScores())
+
+      const responses = await callRespond()
+      expect(responses[0].renderData.conversationName).toBe('a private conversation')
+      expect(responses[0].message).not.toContain(CONV_NAME)
+    })
+
+    it('redacts the name when topic is missing (fail-closed)', async () => {
+      mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: undefined }])
+      mockFetchQualityScores.mockResolvedValue(makeScores())
+
+      const responses = await callRespond()
+      expect(responses[0].renderData.conversationName).toBe('a private conversation')
+    })
+
+    it('persists the redacted name to MongoDB for private conversations', async () => {
+      mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: true } }])
+      mockFetchQualityScores.mockResolvedValue(makeScores())
+
+      await callRespond()
+
+      const saved = await QualityReport.findOne({ conversationId: CONV_ID })
+      expect(saved!.conversationName).toBe('a private conversation')
+    })
+  })
+
+  describe('baseline deltas', () => {
+    async function seedBaselineReports(count: number, mean = 0.70) {
+      const yesterday = new Date()
+      yesterday.setUTCDate(yesterday.getUTCDate() - 1)
+      yesterday.setUTCHours(0, 0, 0, 0)
+      await QualityReport.insertMany(
+        Array.from({ length: count }, (_, i) => ({
+          conversationId: new mongoose.Types.ObjectId(),
+          conversationName: `Baseline Conv ${i}`,
+          reportDate: yesterday,
+          evaluators: [{ key: 'compliance.tone', mean, min: 0.5, count: 10, lowScoreCount: 0 }],
+          overallMean: mean,
+          tracesScored: 10,
+          totalLowScoreCount: 0
+        }))
+      )
+    }
+
+    it('omits deltas when fewer than 5 baseline reports exist', async () => {
+      await seedBaselineReports(4)
+      mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: false } }])
+      mockFetchQualityScores.mockResolvedValue(makeScores())
+
+      const responses = await callRespond()
+      const { renderData } = responses[0] as any
+      expect(renderData.deltas).toBeUndefined()
+      expect(renderData.baselineSampleCount).toBeUndefined()
+    })
+
+    it('includes deltas and baselineSampleCount when 5+ baseline reports exist', async () => {
+      await seedBaselineReports(5, 0.70)
+      mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: false } }])
+      mockFetchQualityScores.mockResolvedValue(
+        makeScores({
+          overallMean: 0.82,
+          evaluators: [{ key: 'compliance.tone', mean: 0.82, min: 0.5, count: 10, lowScoreCount: 1 }]
+        })
+      )
+
+      const responses = await callRespond()
+      const { renderData } = responses[0] as any
+      expect(renderData.baselineSampleCount).toBe(5)
+      expect(renderData.deltas?.['compliance.tone']).toBeCloseTo(0.12) // 0.82 - 0.70
+    })
+
+    it('excludes the current conversation from the baseline calculation', async () => {
+      await seedBaselineReports(5, 0.70)
+      // Also seed a report for CONV_ID with a very different mean — should not skew baseline
+      const yesterday = new Date()
+      yesterday.setUTCDate(yesterday.getUTCDate() - 1)
+      yesterday.setUTCHours(0, 0, 0, 0)
+      await QualityReport.create({
+        conversationId: CONV_ID,
+        conversationName: CONV_NAME,
+        reportDate: yesterday,
+        evaluators: [{ key: 'compliance.tone', mean: 0.10, min: 0.0, count: 10, lowScoreCount: 8 }],
+        overallMean: 0.10,
+        tracesScored: 10,
+        totalLowScoreCount: 8
+      })
+
+      mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: false } }])
+      mockFetchQualityScores.mockResolvedValue(
+        makeScores({
+          overallMean: 0.82,
+          evaluators: [{ key: 'compliance.tone', mean: 0.82, min: 0.5, count: 10, lowScoreCount: 1 }]
+        })
+      )
+
+      const responses = await callRespond()
+      const { renderData } = responses[0] as any
+      // sampleCount should be 5, not 6 — CONV_ID report excluded
+      expect(renderData.baselineSampleCount).toBe(5)
+      // delta should be against 0.70 baseline, not the skewed 0.10
+      expect(renderData.deltas?.['compliance.tone']).toBeCloseTo(0.12)
+    })
+  })
+
+  it('skips a conversation that already has a report for today', async () => {
+    // Pre-insert a report for today
+    const midnight = new Date()
+    midnight.setUTCHours(0, 0, 0, 0)
+    await QualityReport.create({
+      conversationId: CONV_ID,
+      conversationName: CONV_NAME,
+      reportDate: midnight,
+      evaluators: [{ key: 'compliance.tone', mean: 0.7, min: 0.5, count: 5, lowScoreCount: 0 }],
+      overallMean: 0.7,
+      tracesScored: 5,
+      totalLowScoreCount: 0
+    })
+
+    mockConversations([{ _id: CONV_ID, name: CONV_NAME, topic: { private: false } }])
+
+    const responses = await callRespond()
+    expect(responses).toHaveLength(0)
+    expect(mockFetchQualityScores).not.toHaveBeenCalled()
+  })
+})
+
+describe('scorekeeper agent evaluate()', () => {
+  it('always returns CONTRIBUTE', async () => {
+    const evaluation = await scorekeeperAgentType.evaluate.call({})
+    expect(evaluation.action).toBe(AgentMessageActions.CONTRIBUTE)
+  })
+})

--- a/tests/unit/agents/scorekeeper/fetchQualityScores.test.ts
+++ b/tests/unit/agents/scorekeeper/fetchQualityScores.test.ts
@@ -1,0 +1,230 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { jest } from '@jest/globals'
+
+// Async generator helper — mimics what LangSmith SDK returns for list* methods
+async function* asyncItems<T>(items: T[]) {
+  for (const item of items) yield item
+}
+
+const mockListRuns = jest.fn<(...args: any[]) => any>()
+const mockListFeedback = jest.fn<(...args: any[]) => any>()
+const mockGetRunUrl = jest.fn<(...args: any[]) => Promise<any>>()
+
+jest.unstable_mockModule('langsmith', () => ({
+  Client: jest.fn().mockImplementation(() => ({
+    listRuns: mockListRuns,
+    listFeedback: mockListFeedback,
+    getRunUrl: mockGetRunUrl
+  }))
+}))
+
+// Import config before fetchQualityScores so we can control langsmith settings
+const config = ((await import('../../../../src/config/config.js')).default) as any
+const { fetchQualityScores } = await import('../../../../src/agents/scorekeeper/fetchQualityScores.js')
+
+const RUN_1 = 'aaaaaaaa-0000-0000-0000-000000000001'
+const RUN_2 = 'aaaaaaaa-0000-0000-0000-000000000002'
+const RUN_3 = 'aaaaaaaa-0000-0000-0000-000000000003'
+
+function makeFeedback(runId: string, key: string, score: number) {
+  return { run_id: runId, key, score }
+}
+
+describe('fetchQualityScores()', () => {
+  const originalLangsmith = { key: config.langsmith?.key, project: config.langsmith?.project }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    config.langsmith.key = 'test-key'
+    config.langsmith.project = 'test-project'
+    mockGetRunUrl.mockResolvedValue('https://smith.langchain.com/runs/test')
+  })
+
+  afterEach(() => {
+    config.langsmith.key = originalLangsmith.key
+    config.langsmith.project = originalLangsmith.project
+  })
+
+  it('returns null when LangSmith key is not configured', async () => {
+    config.langsmith.key = ''
+    const result = await fetchQualityScores('conv-1')
+    expect(result).toBeNull()
+  })
+
+  it('returns null when LangSmith project is not configured', async () => {
+    config.langsmith.project = ''
+    const result = await fetchQualityScores('conv-1')
+    expect(result).toBeNull()
+  })
+
+  it('returns null when no traces exist for the conversation', async () => {
+    mockListRuns.mockReturnValue(asyncItems([]))
+    const result = await fetchQualityScores('conv-1')
+    expect(result).toBeNull()
+  })
+
+  it('returns null when traces exist but none have feedback', async () => {
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }]))
+    mockListFeedback.mockReturnValue(asyncItems([]))
+    const result = await fetchQualityScores('conv-1')
+    expect(result).toBeNull()
+  })
+
+  it('computes per-evaluator mean correctly', async () => {
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }, { id: RUN_2 }]))
+    mockListFeedback.mockReturnValue(asyncItems([
+      makeFeedback(RUN_1, 'quality.correctness', 0.8),
+      makeFeedback(RUN_2, 'quality.correctness', 0.6)
+    ]))
+
+    const result = await fetchQualityScores('conv-1')
+    const evaluator = result!.evaluators.find((e) => e.key === 'quality.correctness')!
+
+    expect(evaluator.mean).toBeCloseTo(0.7)
+    expect(evaluator.count).toBe(2)
+  })
+
+  it('computes per-evaluator min correctly', async () => {
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }, { id: RUN_2 }, { id: RUN_3 }]))
+    mockListFeedback.mockReturnValue(asyncItems([
+      makeFeedback(RUN_1, 'compliance.tone', 0.9),
+      makeFeedback(RUN_2, 'compliance.tone', 0.3),
+      makeFeedback(RUN_3, 'compliance.tone', 0.7)
+    ]))
+
+    const result = await fetchQualityScores('conv-1')
+    expect(result!.evaluators[0].min).toBeCloseTo(0.3)
+  })
+
+  it('counts per-evaluator lowScoreCount for scores below 0.5', async () => {
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }, { id: RUN_2 }, { id: RUN_3 }]))
+    mockListFeedback.mockReturnValue(asyncItems([
+      makeFeedback(RUN_1, 'compliance.tone', 0.8),
+      makeFeedback(RUN_2, 'compliance.tone', 0.4),
+      makeFeedback(RUN_3, 'compliance.tone', 0.2)
+    ]))
+
+    const result = await fetchQualityScores('conv-1')
+    expect(result!.evaluators[0].lowScoreCount).toBe(2)
+  })
+
+  it('computes overall mean as mean of per-key means', async () => {
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }]))
+    mockListFeedback.mockReturnValue(asyncItems([
+      makeFeedback(RUN_1, 'quality.correctness', 0.8),
+      makeFeedback(RUN_1, 'compliance.tone', 0.6)
+    ]))
+
+    const result = await fetchQualityScores('conv-1')
+    expect(result!.overallMean).toBeCloseTo(0.7)
+  })
+
+  it('sets tracesScored to number of runs that received feedback, not total traces listed', async () => {
+    // 3 runs listed, but only 2 get feedback
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }, { id: RUN_2 }, { id: RUN_3 }]))
+    mockListFeedback.mockReturnValue(asyncItems([
+      makeFeedback(RUN_1, 'quality.correctness', 0.8),
+      makeFeedback(RUN_2, 'quality.correctness', 0.6)
+    ]))
+
+    const result = await fetchQualityScores('conv-1')
+    expect(result!.tracesScored).toBe(2)
+  })
+
+  it('identifies a trace as low-score when any evaluator score is below 0.5', async () => {
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }]))
+    mockListFeedback.mockReturnValue(asyncItems([
+      makeFeedback(RUN_1, 'quality.correctness', 0.9),
+      makeFeedback(RUN_1, 'compliance.tone', 0.3)
+    ]))
+
+    const result = await fetchQualityScores('conv-1')
+    expect(result!.totalLowScoreCount).toBe(1)
+    expect(result!.lowScoreTraces).toHaveLength(1)
+    expect(result!.lowScoreTraces[0].runId).toBe(RUN_1)
+    expect(result!.lowScoreTraces[0].lowScores).toEqual([{ key: 'compliance.tone', score: 0.3 }])
+  })
+
+  it('does not flag a trace when all scores are at or above 0.5', async () => {
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }]))
+    mockListFeedback.mockReturnValue(asyncItems([
+      makeFeedback(RUN_1, 'quality.correctness', 0.5),
+      makeFeedback(RUN_1, 'compliance.tone', 0.8)
+    ]))
+
+    const result = await fetchQualityScores('conv-1')
+    expect(result!.totalLowScoreCount).toBe(0)
+    expect(result!.lowScoreTraces).toHaveLength(0)
+  })
+
+  it('sorts low-score traces worst-first', async () => {
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }, { id: RUN_2 }]))
+    mockListFeedback.mockReturnValue(asyncItems([
+      makeFeedback(RUN_1, 'compliance.tone', 0.4),
+      makeFeedback(RUN_2, 'compliance.tone', 0.1)
+    ]))
+
+    const result = await fetchQualityScores('conv-1')
+    expect(result!.lowScoreTraces[0].runId).toBe(RUN_2)
+    expect(result!.lowScoreTraces[1].runId).toBe(RUN_1)
+  })
+
+  it('caps lowScoreTraces at 5 but reports the true total in totalLowScoreCount', async () => {
+    const runs = Array.from({ length: 8 }, (_, i) => ({ id: `run-${i}` }))
+    mockListRuns.mockReturnValue(asyncItems(runs))
+    mockListFeedback.mockReturnValue(asyncItems(
+      runs.map((r) => makeFeedback(r.id, 'compliance.tone', 0.1))
+    ))
+
+    const result = await fetchQualityScores('conv-1')
+    expect(result!.lowScoreTraces).toHaveLength(5)
+    expect(result!.totalLowScoreCount).toBe(8)
+  })
+
+  it('attaches a LangSmith URL to each low-score trace', async () => {
+    const url = 'https://smith.langchain.com/runs/abc'
+    mockGetRunUrl.mockResolvedValue(url)
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }]))
+    mockListFeedback.mockReturnValue(asyncItems([makeFeedback(RUN_1, 'compliance.tone', 0.2)]))
+
+    const result = await fetchQualityScores('conv-1')
+    expect(result!.lowScoreTraces[0].url).toBe(url)
+  })
+
+  it('sets url to null when getRunUrl throws', async () => {
+    mockGetRunUrl.mockRejectedValue(new Error('not found'))
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }]))
+    mockListFeedback.mockReturnValue(asyncItems([makeFeedback(RUN_1, 'compliance.tone', 0.2)]))
+
+    const result = await fetchQualityScores('conv-1')
+    expect(result!.lowScoreTraces[0].url).toBeNull()
+  })
+
+  it('skips feedback entries with null score', async () => {
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }]))
+    mockListFeedback.mockReturnValue(asyncItems([
+      { run_id: RUN_1, key: 'quality.correctness', score: null },
+      makeFeedback(RUN_1, 'compliance.tone', 0.8)
+    ]))
+
+    const result = await fetchQualityScores('conv-1')
+    expect(result!.evaluators).toHaveLength(1)
+    expect(result!.evaluators[0].key).toBe('compliance.tone')
+  })
+
+  it('sorts evaluators alphabetically by key', async () => {
+    mockListRuns.mockReturnValue(asyncItems([{ id: RUN_1 }]))
+    mockListFeedback.mockReturnValue(asyncItems([
+      makeFeedback(RUN_1, 'quality.correctness', 0.8),
+      makeFeedback(RUN_1, 'compliance.tone', 0.7),
+      makeFeedback(RUN_1, 'accuracy.factual', 0.9)
+    ]))
+
+    const result = await fetchQualityScores('conv-1')
+    expect(result!.evaluators.map((e) => e.key)).toEqual([
+      'accuracy.factual',
+      'compliance.tone',
+      'quality.correctness'
+    ])
+  })
+})

--- a/tests/unit/agents/scorekeeper/qualityReportCard.test.ts
+++ b/tests/unit/agents/scorekeeper/qualityReportCard.test.ts
@@ -1,0 +1,299 @@
+import type { KnownBlock, SectionBlock, HeaderBlock, ContextBlock } from '@slack/types'
+import renderQualityReportCard from '../../../../src/adapters/slack/blocks/scorekeeper/qualityReportCard.js'
+import type { QualityReportData } from '../../../../src/types/index.types.js'
+
+function makeData(overrides: Partial<QualityReportData> = {}): QualityReportData {
+  return {
+    conversationName: 'AI in Education',
+    conversationId: 'conv-1',
+    evaluators: [
+      { key: 'quality.correctness', mean: 0.85, min: 0.6, count: 10, lowScoreCount: 0 }
+    ],
+    overallMean: 0.85,
+    tracesScored: 10,
+    lowScoreTraces: [],
+    totalLowScoreCount: 0,
+    generatedAt: '2026-08-13T03:00:00.000Z',
+    ...overrides
+  }
+}
+
+function asSection(b: KnownBlock): SectionBlock {
+  if (b.type !== 'section') throw new Error(`Expected section, got ${b.type}`)
+  return b
+}
+
+function asHeader(b: KnownBlock): HeaderBlock {
+  if (b.type !== 'header') throw new Error(`Expected header, got ${b.type}`)
+  return b
+}
+
+function asContext(b: KnownBlock): ContextBlock {
+  if (b.type !== 'context') throw new Error(`Expected context, got ${b.type}`)
+  return b
+}
+
+function findSection(blocks: KnownBlock[], match: (text: string) => boolean): SectionBlock {
+  const block = blocks.find((b) => b.type === 'section' && match((b as SectionBlock).text?.text ?? ''))
+  if (!block) throw new Error('Section not found')
+  return block as SectionBlock
+}
+
+describe('renderQualityReportCard()', () => {
+  describe('header', () => {
+    it('includes the conversation name in the header', () => {
+      const blocks = renderQualityReportCard(makeData())
+      const header = asHeader(blocks[0])
+      expect(header.text.text).toContain('AI in Education')
+    })
+  })
+
+  describe('summary section', () => {
+    it('shows the overall mean and trace count', () => {
+      const blocks = renderQualityReportCard(makeData({ overallMean: 0.76, tracesScored: 12 }))
+      const summary = asSection(blocks[1])
+      expect(summary.text?.text).toContain('0.76')
+      expect(summary.text?.text).toContain('12 traces scored')
+    })
+  })
+
+  describe('score table', () => {
+    it('renders evaluator name formatted from dot-notation key', () => {
+      const blocks = renderQualityReportCard(makeData())
+      const table = findSection(blocks, (t) => t.includes('```'))
+      expect(table.text?.text).toContain('Correctness')
+    })
+
+    it('formats underscore-separated names as title case', () => {
+      const blocks = renderQualityReportCard(makeData({
+        evaluators: [{ key: 'compliance.intervention_appropriateness', mean: 0.7, min: 0.5, count: 5, lowScoreCount: 0 }]
+      }))
+      const table = findSection(blocks, (t) => t.includes('```'))
+      expect(table.text?.text).toContain('Intervention Appropriateness')
+    })
+
+    it('renders a category separator for dot-notation keys', () => {
+      const blocks = renderQualityReportCard(makeData())
+      const table = findSection(blocks, (t) => t.includes('```'))
+      expect(table.text?.text).toContain('quality')
+    })
+
+    it('renders 🟢 for mean >= 0.7', () => {
+      const blocks = renderQualityReportCard(makeData({
+        evaluators: [{ key: 'quality.correctness', mean: 0.7, min: 0.7, count: 1, lowScoreCount: 0 }]
+      }))
+      const table = findSection(blocks, (t) => t.includes('```'))
+      expect(table.text?.text).toContain('🟢')
+    })
+
+    it('renders 🟡 for mean >= 0.5 and < 0.7', () => {
+      const blocks = renderQualityReportCard(makeData({
+        evaluators: [{ key: 'quality.correctness', mean: 0.65, min: 0.5, count: 1, lowScoreCount: 0 }]
+      }))
+      const table = findSection(blocks, (t) => t.includes('```'))
+      expect(table.text?.text).toContain('🟡')
+    })
+
+    it('renders 🔴 for mean < 0.5', () => {
+      const blocks = renderQualityReportCard(makeData({
+        evaluators: [{ key: 'quality.correctness', mean: 0.3, min: 0.1, count: 1, lowScoreCount: 1 }]
+      }))
+      const table = findSection(blocks, (t) => t.includes('```'))
+      expect(table.text?.text).toContain('🔴')
+    })
+
+    it('groups multiple evaluators under their shared category', () => {
+      const blocks = renderQualityReportCard(makeData({
+        evaluators: [
+          { key: 'quality.correctness', mean: 0.8, min: 0.6, count: 5, lowScoreCount: 0 },
+          { key: 'quality.relevance', mean: 0.7, min: 0.5, count: 5, lowScoreCount: 0 }
+        ]
+      }))
+      const text = findSection(blocks, (t) => t.includes('```')).text?.text ?? ''
+      expect(text).toContain('quality')
+      expect(text).toContain('Correctness')
+      expect(text).toContain('Relevance')
+    })
+
+    it('renders evaluators with no category (no dot) without a category separator', () => {
+      const blocks = renderQualityReportCard(makeData({
+        evaluators: [{ key: 'interventionAppropriateness', mean: 0.9, min: 0.7, count: 5, lowScoreCount: 0 }]
+      }))
+      const text = findSection(blocks, (t) => t.includes('```')).text?.text ?? ''
+      expect(text).toContain('Intervention Appropriateness')
+      expect(text).not.toContain('──')
+    })
+
+    it('renders delta arrows when deltas are provided', () => {
+      const blocks = renderQualityReportCard(makeData({
+        deltas: { 'quality.correctness': 0.12 }
+      }))
+      const text = findSection(blocks, (t) => t.includes('```')).text?.text ?? ''
+      expect(text).toContain('↑ +0.12')
+    })
+
+    it('renders ↓ arrow for negative delta', () => {
+      const blocks = renderQualityReportCard(makeData({
+        deltas: { 'quality.correctness': -0.15 }
+      }))
+      const text = findSection(blocks, (t) => t.includes('```')).text?.text ?? ''
+      expect(text).toContain('↓ -0.15')
+    })
+
+    it('renders → when delta is below the display threshold', () => {
+      const blocks = renderQualityReportCard(makeData({
+        deltas: { 'quality.correctness': 0.01 }
+      }))
+      const text = findSection(blocks, (t) => t.includes('```')).text?.text ?? ''
+      expect(text).toContain('→')
+    })
+
+    it('omits arrows when deltas are not provided', () => {
+      const blocks = renderQualityReportCard(makeData())
+      const text = findSection(blocks, (t) => t.includes('```')).text?.text ?? ''
+      expect(text).not.toContain('↑')
+      expect(text).not.toContain('↓')
+      expect(text).not.toContain('→')
+    })
+  })
+
+  describe('Trending Down section', () => {
+    it('is not rendered when deltas are absent', () => {
+      const blocks = renderQualityReportCard(makeData())
+      expect(blocks.some((b) => b.type === 'section' && (b as SectionBlock).text?.text?.includes('Trending Down'))).toBe(false)
+    })
+
+    it('is not rendered when no evaluator is below the threshold', () => {
+      const blocks = renderQualityReportCard(makeData({
+        deltas: { 'quality.correctness': -0.05 }
+      }))
+      expect(blocks.some((b) => b.type === 'section' && (b as SectionBlock).text?.text?.includes('Trending Down'))).toBe(false)
+    })
+
+    it('appears when an evaluator delta is at or below -0.10', () => {
+      const blocks = renderQualityReportCard(makeData({
+        deltas: { 'quality.correctness': -0.10 }
+      }))
+      const section = findSection(blocks, (t) => t.includes('Trending Down'))
+      expect(section.text?.text).toContain('Correctness')
+      expect(section.text?.text).toContain('-0.10')
+    })
+
+    it('lists trending-down evaluators worst-first', () => {
+      const blocks = renderQualityReportCard(makeData({
+        evaluators: [
+          { key: 'quality.correctness', mean: 0.6, min: 0.4, count: 5, lowScoreCount: 1 },
+          { key: 'quality.relevance', mean: 0.5, min: 0.3, count: 5, lowScoreCount: 2 }
+        ],
+        deltas: { 'quality.correctness': -0.11, 'quality.relevance': -0.20 }
+      }))
+      const text = findSection(blocks, (t) => t.includes('Trending Down')).text?.text ?? ''
+      expect(text.indexOf('Relevance')).toBeLessThan(text.indexOf('Correctness'))
+    })
+  })
+
+  describe('Needs Review section', () => {
+    it('is not rendered when there are no low-score traces', () => {
+      const blocks = renderQualityReportCard(makeData({ lowScoreTraces: [], totalLowScoreCount: 0 }))
+      expect(blocks.some((b) => b.type === 'section' && (b as SectionBlock).text?.text?.includes('Needs Review'))).toBe(false)
+    })
+
+    it('appears when there are low-score traces', () => {
+      const blocks = renderQualityReportCard(makeData({
+        lowScoreTraces: [{ runId: 'r1', url: 'https://smith.langchain.com/r1', lowScores: [{ key: 'compliance.tone', score: 0.2 }] }],
+        totalLowScoreCount: 1
+      }))
+      expect(findSection(blocks, (t) => t.includes('Needs Review'))).toBeDefined()
+    })
+
+    it('shows the total count and a link when url is available', () => {
+      const blocks = renderQualityReportCard(makeData({
+        lowScoreTraces: [{ runId: 'run-abc123', url: 'https://smith.langchain.com/run-abc123', lowScores: [{ key: 'compliance.tone', score: 0.2 }] }],
+        totalLowScoreCount: 1
+      }))
+      const text = findSection(blocks, (t) => t.includes('Needs Review')).text?.text ?? ''
+      expect(text).toContain('1 trace')
+      expect(text).toContain('https://smith.langchain.com/run-abc123')
+      expect(text).toContain('Tone')
+      expect(text).toContain('0.20')
+    })
+
+    it('falls back to a truncated run ID when url is null', () => {
+      const blocks = renderQualityReportCard(makeData({
+        lowScoreTraces: [{ runId: 'abcdefgh-1234', url: null, lowScores: [{ key: 'compliance.tone', score: 0.3 }] }],
+        totalLowScoreCount: 1
+      }))
+      const text = findSection(blocks, (t) => t.includes('Needs Review')).text?.text ?? ''
+      expect(text).toContain('abcdefgh')
+    })
+
+    it('shows "showing worst N of M" when totalLowScoreCount exceeds the number shown', () => {
+      const traces = Array.from({ length: 5 }, (_, i) => ({
+        runId: `run-${i}`,
+        url: null,
+        lowScores: [{ key: 'compliance.tone', score: 0.1 }]
+      }))
+      const text = findSection(
+        renderQualityReportCard(makeData({ lowScoreTraces: traces, totalLowScoreCount: 23 })),
+        (t) => t.includes('Needs Review')
+      ).text?.text ?? ''
+      expect(text).toContain('showing worst 5 of 23')
+    })
+
+    it('does not show the "showing worst" suffix when all low-score traces fit', () => {
+      const text = findSection(
+        renderQualityReportCard(makeData({
+          lowScoreTraces: [{ runId: 'r1', url: null, lowScores: [{ key: 'compliance.tone', score: 0.3 }] }],
+          totalLowScoreCount: 1
+        })),
+        (t) => t.includes('Needs Review')
+      ).text?.text ?? ''
+      expect(text).not.toContain('showing worst')
+    })
+  })
+
+  describe('footer', () => {
+    it('renders a context block with the generatedAt timestamp', () => {
+      const blocks = renderQualityReportCard(makeData({ generatedAt: '2026-08-13T03:00:00.000Z' }))
+      const context = asContext(blocks[blocks.length - 1])
+      const element = context.elements[0]
+      expect('text' in element && element.text).toContain('Generated at')
+    })
+
+    it('includes baseline sample count in footer when deltas are present', () => {
+      const blocks = renderQualityReportCard(makeData({ deltas: {}, baselineSampleCount: 18 }))
+      const context = asContext(blocks[blocks.length - 1])
+      const element = context.elements[0]
+      expect('text' in element && element.text).toContain('18 reports')
+    })
+
+    it('omits baseline note when deltas are absent', () => {
+      const blocks = renderQualityReportCard(makeData())
+      const context = asContext(blocks[blocks.length - 1])
+      const element = context.elements[0]
+      expect('text' in element && element.text).not.toContain('reports')
+    })
+  })
+
+  describe('block structure', () => {
+    it('renders header, summary, divider, table, divider, and footer with no extras', () => {
+      const blocks = renderQualityReportCard(makeData())
+      expect(blocks.map((b) => b.type)).toEqual(['header', 'section', 'divider', 'section', 'divider', 'context'])
+    })
+
+    it('inserts Trending Down section when a delta is below threshold', () => {
+      const blocks = renderQualityReportCard(makeData({
+        deltas: { 'quality.correctness': -0.15 }
+      }))
+      expect(blocks.map((b) => b.type)).toEqual(['header', 'section', 'divider', 'section', 'divider', 'section', 'divider', 'context'])
+    })
+
+    it('inserts Needs Review section when low-score traces exist', () => {
+      const blocks = renderQualityReportCard(makeData({
+        lowScoreTraces: [{ runId: 'r1', url: null, lowScores: [{ key: 'k', score: 0.1 }] }],
+        totalLowScoreCount: 1
+      }))
+      expect(blocks.map((b) => b.type)).toEqual(['header', 'section', 'divider', 'section', 'divider', 'section', 'divider', 'context'])
+    })
+  })
+})


### PR DESCRIPTION
## What is in this PR?

<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->

  This PR adds a Scorekeeper agent that runs nightly and posts automated quality report cards to Slack based
   on LangSmith online evaluator scores, closing the feedback loop on agent quality in production. It also  
  includes the groundwork that makes this possible: a cron trigger type for schedule-based agents, and trace
   restructuring so LangSmith online evaluators have the policy context they need to score compliance.

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

Cron trigger (src/jobs/define.ts, src/jobs/schedule.ts, src/types/index.types.ts)                        
  - New cron default trigger type for agents that should run on a schedule rather than in response to
  messages, restart-safe via agenda

  Agent trace restructuring (src/agents/eventAssistant/, src/agents/proactiveGroupAgent/)
  - Agent traces now include behavior policy, goals, and conversation context in LangSmith metadata so
  online evaluators have the policy data they need to judge compliance

  Scorekeeper agent (src/agents/scorekeeper/)
  - Nightly cron at 04:00 UTC; queries conversations with endTime in the last 24 hours
  - fetchQualityScores: reads root LangSmith traces by conversationId metadata tag, aggregates per-evaluator
   mean/min/count/lowScoreCount, surfaces up to 5 worst traces with direct LangSmith links                  
  - 30-day cross-conversation baseline with delta trend arrows (±0.02 display threshold, −0.10 alert
  threshold); suppressed when fewer than 5 reports exist                                                    
  - Private conversation names redacted fail-closed (topic.private !== false)
  - Idempotent: one QualityReport document per conversation per UTC day (unique index on conversationId +   
  reportDate)                                                                                              
                                                                                                            
  Slack Block Kit report card (src/adapters/slack/blocks/scorekeeper/qualityReportCard.ts)
  - Header, summary, score table with traffic lights (🟢🟡🔴) and score bars                                
  - Evaluator keys use dot-notation category grouping (compliance.tone → category "compliance")            
  - Optional Trending Down section for evaluators with delta ≤ −0.10                           
  - Optional Needs Review section for traces with any score below 0.5                                       
  - Footer with generation timestamp and baseline sample count
                                                                                                            
  numberCruncher (src/conversations/numberCruncher.ts)                                                     
  - Switched from message-triggered to cron trigger at 03:00 UTC using the same restart-safe mechanism as   
  scorekeeper

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [x] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

(Best just to review shared screenshots, but here are the steps I used):
- [ ] Create a convo of type 'scorekeeper' (see Hoppscotch) and hook it to a Slack channel. Invite the bot Scorekeeper to the channel
- [ ] Run scripts/checkScoreKeeperSlack.ts with the ID of your Slack convo and the ID of an ended conversation that had Langsmith evaluators applied to traces (I used the 'jen' Langsmith project)
- [ ] Review the Scorekeeper output to the Slack channel

## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
