### PR TITLE
Retry a structured LLM call once when the model returns a malformed response

### DIFF
--- a/src/agents/helpers/llmChain.ts
+++ b/src/agents/helpers/llmChain.ts
@@ -11,6 +11,11 @@ import rag from './rag.js'
 
 const RESPONSE_PLACEHOLDER = '(user sent an empty message)'
 
+/* The model answered, but not in the shape the schema demands: a hollow or misshapen tool
+   call, or prose where JSON belonged. Distinct from transport errors so callers can
+   resample the model once instead of failing outright. */
+class MalformedStructuredResponseError extends Error {}
+
 // Helper to determine if we should use structured output for a given LLM
 function shouldUseStructuredOutput(llm): boolean {
   // Skip structured output for Claude models to avoid tool calling issues
@@ -302,7 +307,7 @@ function getStructuredResponseChain(llm, prompt, responseFormatSchema) {
       if (rewrapped.success) return rewrapped.data
     }
 
-    throw new Error(`Structured response did not match schema: ${direct.error.message}`)
+    throw new MalformedStructuredResponseError(`Structured response did not match schema: ${direct.error.message}`)
   }
 
   // Convert Zod schema to JSON Schema and ensure it has type: 'object' for Bedrock compatibility
@@ -354,7 +359,7 @@ function getStructuredResponseChain(llm, prompt, responseFormatSchema) {
     }
 
     if (!text) {
-      throw new Error('No tool calls found in the response and no text content to parse.')
+      throw new MalformedStructuredResponseError('No tool calls found in the response and no text content to parse.')
     }
 
     let parsed: unknown
@@ -365,7 +370,9 @@ function getStructuredResponseChain(llm, prompt, responseFormatSchema) {
         .trim()
       parsed = JSON.parse(stripped)
     } catch {
-      throw new Error('No tool calls found in the response and content was not parseable as JSON.')
+      throw new MalformedStructuredResponseError(
+        'No tool calls found in the response and content was not parseable as JSON.'
+      )
     }
 
     logger.debug('llmChain: no tool call found — parsed content as JSON fallback')
@@ -449,7 +456,19 @@ async function getChatPromptResponse(
 
   const invokeParams = { ...inputParams }
 
-  return chain.invoke(invokeParams)
+  if (!structuredOutputSchema) return chain.invoke(invokeParams)
+
+  /* A structured call can fail because the model shaped its answer wrong (hollow tool
+     call, prose instead of JSON) even though the request itself was fine. One fresh
+     sample usually fixes that, so resample once before giving up. Transport errors are
+     not retried here; the model client handles those. */
+  try {
+    return await chain.invoke(invokeParams)
+  } catch (error: unknown) {
+    if (!(error instanceof MalformedStructuredResponseError)) throw error
+    logger.warn(`llmChain: structured response was malformed, retrying once: ${error.message}`)
+    return chain.invoke(invokeParams)
+  }
   // You can do this if you want detailed logging:
   // return chain.invoke(invokeParams, { callbacks: [new ConsoleCallbackHandler()] })
 }

--- a/tests/unit/agents/getChatPromptResponse.retry.test.ts
+++ b/tests/unit/agents/getChatPromptResponse.retry.test.ts
@@ -1,0 +1,64 @@
+import { RunnableLambda } from '@langchain/core/runnables'
+import { z } from 'zod'
+import { getChatPromptResponse } from '../../../src/agents/helpers/llmChain.js'
+
+const responseSchema = z.object({
+  header: z.string(),
+  standouts: z.array(z.object({ text: z.string() }))
+})
+
+/* Stands in for a Claude-family model: the anthropic model name routes llmChain down the
+   bindTools path (the one Bedrock uses), and bindTools returns a runnable that replays the
+   canned messages in order, one per call, so a retry sees a fresh response. An Error in
+   the list is thrown instead, imitating the model client failing. Records how many calls
+   the model received. */
+function fakeClaudeModelSequence(messages: unknown[]) {
+  let calls = 0
+  return {
+    model: 'us.anthropic.claude-sonnet-4-6',
+    bindTools: () =>
+      RunnableLambda.from(async () => {
+        const message = messages[calls]
+        calls += 1
+        if (message instanceof Error) throw message
+        return message
+      }),
+    callCount: () => calls
+  }
+}
+
+function toolCallMessage(args: unknown) {
+  return { tool_calls: [{ name: 'structured_response', args, id: 'call_1' }] }
+}
+
+function invokeWithSchema(model: ReturnType<typeof fakeClaudeModelSequence>) {
+  return getChatPromptResponse(model, 'You are a summarizer', 'summarize the event', {}, undefined, responseSchema)
+}
+
+describe('getChatPromptResponse structured-output retry', () => {
+  const goodPayload = { header: 'Quiet room', standouts: [{ text: 'Turnout ran low' }, { text: 'Chat stayed public' }] }
+
+  it('retries once when the first structured response is malformed', async () => {
+    const model = fakeClaudeModelSequence([toolCallMessage({}), toolCallMessage(goodPayload)])
+
+    await expect(invokeWithSchema(model)).resolves.toEqual(goodPayload)
+    expect(model.callCount()).toBe(2)
+  })
+
+  it('gives up after a second malformed response', async () => {
+    const model = fakeClaudeModelSequence([
+      toolCallMessage({}),
+      toolCallMessage({ header: 'Quiet room', standouts: 'still not an array' })
+    ])
+
+    await expect(invokeWithSchema(model)).rejects.toThrow(/did not match schema/)
+    expect(model.callCount()).toBe(2)
+  })
+
+  it('does not retry when the model call itself fails', async () => {
+    const model = fakeClaudeModelSequence([new Error('connection reset'), toolCallMessage(goodPayload)])
+
+    await expect(invokeWithSchema(model)).rejects.toThrow('connection reset')
+    expect(model.callCount()).toBe(1)
+  })
+})


### PR DESCRIPTION
## What is in this PR?

The Vibes Analyst stopped posting its recap card in production: when an event ended, the fact-check step sometimes got a hollow tool call back from the model (no `verdicts` field), the schema check threw, and the whole job died. Any structured-output call through `getChatPromptResponse` now retries once with a fresh sample when the model's response doesn't match the expected shape. A second failure still throws, and transport errors are untouched (the Bedrock gateway already retries those, #244).

## Changes in the codebase

- Malformed structured responses (schema mismatch, missing tool call, unparseable text) now throw a dedicated `MalformedStructuredResponseError` instead of a generic `Error`.
- `getChatPromptResponse` catches that error type on structured calls, logs a warning, and re-invokes the model once before giving up.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages? (no breaking changes)
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers? (not needed)
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables? (none)

## Testing this PR

- [ ] Run `yarn test --testPathPattern=getChatPromptResponse.retry`. It covers the three cases: a malformed response is retried once and succeeds, a second malformed response still throws, and a transport error is not retried.

This is hard to trigger manually since it depends on the model misbehaving. After deploy, the `structured response was malformed, retrying once` warning followed by a posted recap card confirms the retry is working in production.

## Additional information

Root-caused from production logs: the critic model returned a tool call with empty arguments on a long event (large input, tiny structured output), which is a known intermittent model failure mode, so a single resample is the fix. The whole-job crash meant one bad sample killed the recap card entirely.