### PR TITLE
feat: replace scheduled auto-stop with idle-based detector

### DIFF
--- a/src/jobs/define.ts
+++ b/src/jobs/define.ts
@@ -18,9 +18,9 @@ const defineJob = {
     await agenda.start()
     await agenda.define('autoStart', JobHandlers.autoStartConversation)
   },
-  autoStopConversation: async () => {
+  autoStopConversation: async (conversationId) => {
     await agenda.start()
-    await agenda.define('autoStop', JobHandlers.autoStopConversation)
+    await agenda.define(`autoStop - ${conversationId}`, JobHandlers.autoStopConversation)
   },
   batchTranscript: async (conversationId) => {
     await agenda.start()

--- a/src/jobs/handlers/conversation.ts
+++ b/src/jobs/handlers/conversation.ts
@@ -1,11 +1,12 @@
 import logger from '../../config/logger.js'
-import { Conversation } from '../../models/index.js'
+import { Conversation, Message } from '../../models/index.js'
 import {
   doConversationEndingSoon,
   doStartConversation,
   doStopConversation
 } from '../../services/conversation.service/lifecycle.js'
-import websocketGateway from '../../websockets/websocketGateway.js'
+
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000
 
 const autoStartConversation = async (job) => {
   const { conversationId } = job.attrs.data
@@ -26,25 +27,6 @@ const autoStartConversation = async (job) => {
   }
 }
 
-const autoStopConversation = async (job) => {
-  const { conversationId } = job.attrs.data
-  try {
-    const conversation = await Conversation.findOne({ _id: conversationId })
-    if (!conversation) {
-      logger.warn(`Auto-stop: conversation ${conversationId} not found`)
-      return
-    }
-    if (!conversation.active) {
-      logger.debug(`Auto-stop: conversation ${conversationId} already inactive, skipping`)
-      return
-    }
-    await conversation.populate(['topic', 'agents', 'adapters'])
-    await doStopConversation(conversation)
-  } catch (err) {
-    logger.error(`Auto-stop failed for conversation ${conversationId}`, err)
-  }
-}
-
 const conversationEndingSoon = async (job) => {
   const { conversationId } = job.attrs.data
   try {
@@ -60,6 +42,40 @@ const conversationEndingSoon = async (job) => {
     await doConversationEndingSoon(conversation)
   } catch (err) {
     logger.error(`Conversation ending soon failed for conversation ${conversationId}`, err)
+  }
+}
+
+const autoStopConversation = async (job) => {
+  const { conversationId } = job.attrs.data
+  try {
+    const conversation = await Conversation.findOne({ _id: conversationId })
+    if (!conversation) {
+      logger.warn(`autoStop: conversation ${conversationId} not found`)
+      return
+    }
+
+    const now = Date.now()
+    const lastTranscriptMessage = await Message.findOne({
+      conversation: conversationId,
+      channels: { $in: ['transcript'] }
+    })
+      .sort({ createdAt: -1 })
+      .select('createdAt')
+      .lean()
+
+    const shouldStop = !lastTranscriptMessage || now - (lastTranscriptMessage.createdAt?.getTime() ?? 0) >= IDLE_TIMEOUT_MS
+
+    if (shouldStop) {
+      logger.info(
+        `autoStop: stopping conversation ${conversationId} — ${
+          lastTranscriptMessage ? `idle for ${IDLE_TIMEOUT_MS / 60000} minutes` : 'no transcript activity in grace period'
+        }`
+      )
+      await conversation.populate(['topic', 'agents', 'adapters'])
+      await doStopConversation(conversation)
+    }
+  } catch (err) {
+    logger.error(`Auto stop check failed for conversation ${conversationId}`, err)
   }
 }
 

--- a/src/jobs/schedule.ts
+++ b/src/jobs/schedule.ts
@@ -22,11 +22,14 @@ const schedule = {
   cancelAutoStartConversation: async (conversationId) => {
     await agenda.cancel({ name: 'autoStart', 'data.conversationId': conversationId })
   },
-  autoStopConversation: async (scheduledAt: Date, data) => {
-    await agenda.schedule(scheduledAt, 'autoStop', data)
+  autoStopConversation: async (timerPeriod, data, firstRunAt: Date) => {
+    const job = agenda.create(`autoStop - ${data.conversationId}`, data)
+    job.repeatEvery(timerPeriod)
+    job.schedule(firstRunAt)
+    await job.save()
   },
   cancelAutoStopConversation: async (conversationId) => {
-    await agenda.cancel({ name: 'autoStop', 'data.conversationId': conversationId })
+    await agenda.cancel({ name: `autoStop - ${conversationId}` })
   },
   batchTranscript: async (timerPeriod, data) => {
     await agenda.every(timerPeriod, `batchTranscript - ${data.conversationId}`, data, { skipImmediate: true })

--- a/src/jobs/startup.ts
+++ b/src/jobs/startup.ts
@@ -11,7 +11,6 @@ export async function startJobs() {
     await defineJob.cleanUpTranscripts()
     await schedule.cleanUpTranscripts()
     await defineJob.autoStartConversation()
-    await defineJob.autoStopConversation()
     await defineJob.conversationEndingSoon()
     await defineJob.summarizePdf()
     await defineJob.conversationEvent()

--- a/src/services/conversation.service/index.ts
+++ b/src/services/conversation.service/index.ts
@@ -37,7 +37,6 @@ const returnFields =
 const draftEditLockoutMs = 6 * 60 * 1000 // 6 minutes
 export const maxScheduledInterval = 10 * 60 * 1000 // 10 minutes in milliseconds
 export const { autoStartLeadTimeMs } = config.conversation
-export const { autoStopDelayMs } = config.conversation
 
 /**
  * Removed messages array property and replaces with messageCount
@@ -125,13 +124,6 @@ async function scheduleConversationAutoStart(conversation) {
   const scheduledAt = new Date(conversation.scheduledTime.getTime() - autoStartLeadTimeMs)
   await schedule.autoStartConversation(scheduledAt, { conversationId: conversation._id })
   logger.debug(`Scheduled auto-start for conversation ${conversation._id} at ${scheduledAt}`)
-}
-
-async function scheduleConversationAutoStop(conversation) {
-  await schedule.cancelAutoStopConversation(conversation._id)
-  const scheduledAt = new Date(conversation.scheduledEndTime.getTime() + autoStopDelayMs)
-  await schedule.autoStopConversation(scheduledAt, { conversationId: conversation._id })
-  logger.debug(`Scheduled auto-stop for conversation ${conversation._id} at ${scheduledAt}`)
 }
 
 async function scheduleConversationEndingSoon(conversation) {
@@ -262,7 +254,6 @@ const createConversation = async (conversationBody, user, { allowDraft = false }
   if (conversation.scheduledTime) {
     await scheduleConversationAutoStart(conversation)
     if (conversation.scheduledEndTime) {
-      await scheduleConversationAutoStop(conversation)
       await scheduleConversationEndingSoon(conversation)
     }
   } else {
@@ -612,7 +603,6 @@ const updateConversation = async (conversationBody, user) => {
     await scheduleConversationAutoStart(conversationDoc!)
   }
   if (restBody.scheduledEndTime !== undefined && conversationDoc!.scheduledEndTime) {
-    await scheduleConversationAutoStop(conversationDoc!)
     await scheduleConversationEndingSoon(conversationDoc!)
   }
 

--- a/src/services/conversation.service/lifecycle.ts
+++ b/src/services/conversation.service/lifecycle.ts
@@ -11,7 +11,7 @@ import logger from '../../config/logger.js'
 import adapterService from '../adapter.service.js'
 import { getChatPromptResponse } from '../../agents/helpers/llmChain.js'
 import { coreLLMModel, coreLLMPlatform, getModelChat } from '../../agents/helpers/getModelChat.js'
-import { Conversation, User } from '../../models/index.js'
+import { Channel, Conversation, User } from '../../models/index.js'
 import { formatTranscript, formatMultiUserConversationHistory } from '../../agents/helpers/llmInputFormatters.js'
 import getConversationHistory from '../../agents/helpers/getConversationHistory.js'
 import Poll from '../../models/poll.model/poll.js'
@@ -19,6 +19,8 @@ import { getConversationType } from '../../conversations/index.js'
 import { isValidPropertyFormat } from '../../conversations/propertyFormats.js'
 
 const transcriptBatchInterval = 30
+const autoStopCheckInterval = 5 * 60
+const autoStopGracePeriod = 15 * 60
 const SUMMARIZATION_PROMPT = `
   Please summarize what happened during this conversation. Where possible, also draw conclusions about outcomes of the discussion.
   When available, use as reference the listed speaker(s), moderator(s) and their bios, and event description.
@@ -57,6 +59,15 @@ async function scheduleTranscriptBatching(conversation) {
   await schedule.cancelBatchTranscript(conversation._id)
   await defineJob.batchTranscript(conversation._id)
   await schedule.batchTranscript(`${transcriptBatchInterval} seconds`, { conversationId: conversation._id })
+}
+
+async function scheduleAutoStop(conversation) {
+  const hasTranscriptChannel = await Channel.exists({ _id: { $in: conversation.channels }, name: 'transcript' })
+  if (!hasTranscriptChannel) return
+  await schedule.cancelAutoStopConversation(conversation._id)
+  await defineJob.autoStopConversation(conversation._id)
+  const firstCheckAt = new Date(Date.now() + autoStopGracePeriod * 1000)
+  await schedule.autoStopConversation(`${autoStopCheckInterval} seconds`, { conversationId: conversation._id }, firstCheckAt)
 }
 
 /**
@@ -125,6 +136,7 @@ export async function doStartConversation(conversation) {
     await agentService.startAgent(agent)
   }
   await scheduleTranscriptBatching(doc)
+  await scheduleAutoStop(doc)
   for (const adapter of doc.adapters) {
     adapter.conversation = doc
     await adapterService.start(adapter)
@@ -144,6 +156,7 @@ export async function doStopConversation(conversation) {
     await agentService.stopAgent(agent)
   }
   await schedule.cancelBatchTranscript(doc._id)
+  await schedule.cancelAutoStopConversation(doc._id)
   const activePolls = await Poll.find({ conversation: doc._id, expirationDate: { $gt: new Date() } }, '_id')
   await Promise.all(activePolls.map((poll) => schedule.cancelPollExpired(poll._id.toString())))
   for (const adapter of doc.adapters) {

--- a/tests/jobs/handlers/conversation.handlers.test.ts
+++ b/tests/jobs/handlers/conversation.handlers.test.ts
@@ -1,4 +1,5 @@
-import { Conversation } from '../../../src/models/index.js'
+import mongoose from 'mongoose'
+import { Conversation, Message } from '../../../src/models/index.js'
 import { publicTopic, conversationOne } from '../../fixtures/conversation.fixture.js'
 import { insertTopics } from '../../fixtures/topic.fixture.js'
 import { insertUsers, userOne } from '../../fixtures/user.fixture.js'
@@ -63,11 +64,13 @@ describe('conversation handler tests', () => {
   })
 
   describe('autoStopConversation', () => {
+    const startedLongAgo = new Date(Date.now() - 20 * 60 * 1000) // 20 min ago, past NEVER_STARTED_TIMEOUT_MS
+
     beforeEach(async () => {
-      await Conversation.findByIdAndUpdate(conversation._id, { active: true, startTime: new Date() })
+      await Conversation.findByIdAndUpdate(conversation._id, { active: true, startTime: startedLongAgo })
     })
 
-    test('should stop an active conversation', async () => {
+    test('stops when no transcript messages exist (never-started case)', async () => {
       await JobHandlers.autoStopConversation({ attrs: { data: { conversationId: conversation._id } } })
 
       const updated = await Conversation.findById(conversation._id)
@@ -75,16 +78,41 @@ describe('conversation handler tests', () => {
       expect(updated!.endTime).toBeDefined()
     })
 
-    test('should skip if conversation is already inactive', async () => {
-      await Conversation.findByIdAndUpdate(conversation._id, { active: false })
+    test('stops when last transcript message is older than IDLE_TIMEOUT_MS', async () => {
+      await Message.create({
+        conversation: conversation._id,
+        channels: ['transcript'],
+        body: 'hello',
+        pseudonym: 'Speaker',
+        pseudonymId: new mongoose.Types.ObjectId(),
+        createdAt: new Date(Date.now() - 6 * 60 * 1000) // 6 min ago
+      })
 
       await JobHandlers.autoStopConversation({ attrs: { data: { conversationId: conversation._id } } })
 
       const updated = await Conversation.findById(conversation._id)
+      expect(updated!.active).toBe(false)
+      expect(updated!.endTime).toBeDefined()
+    })
+
+    test('does not stop when a recent transcript message exists', async () => {
+      await Message.create({
+        conversation: conversation._id,
+        channels: ['transcript'],
+        body: 'hello',
+        pseudonym: 'Speaker',
+        pseudonymId: new mongoose.Types.ObjectId(),
+        createdAt: new Date(Date.now() - 60 * 1000) // 1 min ago
+      })
+
+      await JobHandlers.autoStopConversation({ attrs: { data: { conversationId: conversation._id } } })
+
+      const updated = await Conversation.findById(conversation._id)
+      expect(updated!.active).toBe(true)
       expect(updated!.endTime).toBeUndefined()
     })
 
-    test('should not throw if conversation not found', async () => {
+    test('does not throw if conversation not found', async () => {
       const fakeId = '000000000000000000000000'
       await expect(JobHandlers.autoStopConversation({ attrs: { data: { conversationId: fakeId } } })).resolves.not.toThrow()
     })

--- a/tests/services/conversation.service.test.ts
+++ b/tests/services/conversation.service.test.ts
@@ -5,7 +5,7 @@ import { insertUsers, registeredUser } from '../fixtures/user.fixture.js'
 import { insertTopics, newPublicTopic, newPrivateTopic } from '../fixtures/topic.fixture.js'
 import conversationService from '../../src/services/conversation.service/index.js'
 import { Feature } from '../../src/types/index.types.js'
-import { Agent, Adapter, Conversation, Topic } from '../../src/models/index.js'
+import { Agent, Adapter, Conversation, Topic, Channel } from '../../src/models/index.js'
 import { setConversationTypes, resetConversationTypes, getAllConversationTypes } from '../../src/conversations/index.js'
 import ApiError from '../../src/utils/ApiError.js'
 import websocketGateway from '../../src/websockets/websocketGateway.js'
@@ -1369,6 +1369,60 @@ describe('Conversation service methods', () => {
     })
   })
 
+  describe('startConversation() auto-stop scheduling', () => {
+    beforeEach(async () => {
+      await insertUsers([registeredUser])
+      await insertTopics([topicOne])
+    })
+
+    test('schedules auto-stop when conversation has a transcript channel', async () => {
+      const defineJobSpy = jest.spyOn(defineJob, 'autoStopConversation').mockResolvedValue(undefined)
+      const scheduleSpy = jest.spyOn(schedule, 'autoStopConversation').mockResolvedValue(undefined)
+
+      const conversation = new Conversation({
+        name: 'Event With Transcript',
+        owner: registeredUser._id,
+        topic: topicOne._id,
+        draft: false,
+        agents: [],
+        adapters: [],
+        messages: []
+      })
+      await conversation.save()
+
+      const channel = await Channel.create({ name: 'transcript', conversation: conversation._id })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      conversation.channels.push(channel._id as any)
+      await conversation.save()
+
+      await conversationService.startConversation(conversation._id.toString(), registeredUser)
+
+      expect(defineJobSpy).toHaveBeenCalledWith(conversation._id)
+      expect(scheduleSpy).toHaveBeenCalled()
+    })
+
+    test('does not schedule auto-stop when conversation has no transcript channel', async () => {
+      const defineJobSpy = jest.spyOn(defineJob, 'autoStopConversation').mockResolvedValue(undefined)
+      const scheduleSpy = jest.spyOn(schedule, 'autoStopConversation').mockResolvedValue(undefined)
+
+      const conversation = new Conversation({
+        name: 'Chat Only Event',
+        owner: registeredUser._id,
+        topic: topicOne._id,
+        draft: false,
+        agents: [],
+        adapters: [],
+        messages: []
+      })
+      await conversation.save()
+
+      await conversationService.startConversation(conversation._id.toString(), registeredUser)
+
+      expect(defineJobSpy).not.toHaveBeenCalled()
+      expect(scheduleSpy).not.toHaveBeenCalled()
+    })
+  })
+
   describe('startConversation() draft gating', () => {
     beforeEach(async () => {
       await insertUsers([registeredUser])
@@ -1682,20 +1736,6 @@ describe('Conversation service methods', () => {
       const newStart = new Date(Date.now() + 7200000)
       await conversationService.updateConversation(
         { id: conversation._id.toString(), scheduledTime: newStart },
-        registeredUser
-      )
-
-      expect(cancelSpy).toHaveBeenCalledWith(conversation._id)
-      expect(scheduleSpy).toHaveBeenCalled()
-    })
-
-    test('should reschedule the auto-stop job when scheduledEndTime changes', async () => {
-      const cancelSpy = jest.spyOn(schedule, 'cancelAutoStopConversation').mockResolvedValue(undefined)
-      const scheduleSpy = jest.spyOn(schedule, 'autoStopConversation').mockResolvedValue(undefined)
-
-      const newEnd = new Date(Date.now() + 10800000)
-      await conversationService.updateConversation(
-        { id: conversation._id.toString(), scheduledEndTime: newEnd },
         registeredUser
       )
 


### PR DESCRIPTION
stop convos that have transcript channel and no msgs for 5+ mins, after pad of first 15 mins

## What is in this PR?

<!-- What is the goal of this PR? What steps are involved in achieving that goal? -->

  Replaces the fixed-offset auto-stop mechanism with an idle-based detector. Instead of stopping a          
  conversation at a hard offset from scheduledEndTime, the system now monitors actual transcript activity   
  and stops when the conversation has gone idle (assuming the conversation has a transcript channel). This helps ensure that both scheduled and quick start convos do not run longer than needed and incur periodic LLM expenses or report end times that are 30 minutes past the actual event ending.

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- Removes scheduleConversationAutoStop (which fired at scheduledEndTime + autoStopDelayMs) from the create
   and update conversation paths                                                                            
  - scheduleAutoStop in lifecycle.ts runs on conversation start, skipped entirely for conversations with no
  transcript channel (chat-only)
  - A recurring check runs every 5 minutes with a 15-minute grace period before the first firing; the
  handler stops the conversation if no transcript message has arrived within the last 5 minutes, or if there
   was no transcript activity at all during the grace period
  - Per-conversation job name (autoStop - <id>) prevents agenda from collapsing all conversations to a
  single job slot
  - Uses job.repeatEvery + job.schedule in sequence rather than agenda.every({ startDate }) — agenda ignores
   startDate for human-interval strings (only honored for cron expressions), so the initial delay must be
  set by overriding nextRunAt directly after repeatEvery computes it
  - doStopConversation already cancels the agenda job, so no explicit cancel is needed in the handler

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x] Create a quick start convo (no scheduled start time) and keep it running with no transcript. Ensure it stops after approx 15 minutes
- [x] Create a scheduled convo, and, once started, run it for longer than 15 minutes with transcript. Cut off transcript and ensure conversation stops approx 5 mins later (might be a bit longer depending on where you are in the 5 min check interval)
- [x] Restart a stopped convo and keep it running with no transcript. Ensure it stops after approx 15 minutes.



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
